### PR TITLE
Floatingpoint mapobject

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/IMapObject.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/IMapObject.java
@@ -1,7 +1,6 @@
 package de.gurkenlabs.litiengine.environment.tilemap;
 
-import java.awt.Dimension;
-import java.awt.Point;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
 /**
@@ -10,13 +9,6 @@ import java.awt.geom.Rectangle2D;
  * special regions on the map.
  */
 public interface IMapObject extends ICustomPropertyProvider, Comparable<IMapObject> {
-
-  /**
-   * Gets the dimension.
-   *
-   * @return the dimension
-   */
-  public Dimension getDimension();
 
   /**
    * Gets the grid id.
@@ -44,7 +36,7 @@ public interface IMapObject extends ICustomPropertyProvider, Comparable<IMapObje
    *
    * @return the location
    */
-  public Point getLocation();
+  public Point2D getLocation();
 
   /**
    * Gets the name.
@@ -65,20 +57,19 @@ public interface IMapObject extends ICustomPropertyProvider, Comparable<IMapObje
 
   public void setType(String type);
 
-  public void setX(int x);
+  public void setX(float x);
 
-  public void setY(int y);
+  public void setY(float y);
 
-  public void setWidth(int width);
+  public void setWidth(float width);
 
-  public void setHeight(int height);
+  public void setHeight(float height);
 
-  public int getX();
+  public float getX();
 
-  public int getY();
+  public float getY();
 
-  public int getWidth();
+  public float getWidth();
 
-  public int getHeight();
-
+  public float getHeight();
 }

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Blueprint.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Blueprint.java
@@ -1,7 +1,7 @@
 package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
-import java.awt.Rectangle;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,14 +37,14 @@ public class Blueprint extends MapObject {
     this.setType(MapObjectType.AREA.toString());
     this.setName(name);
     
-    final Rectangle bounds = MapObject.getBounds(items);
-    this.setWidth(bounds.width);
-    this.setHeight(bounds.height);
+    final Rectangle2D bounds = MapObject.getBounds(items);
+    this.setWidth((float)bounds.getWidth());
+    this.setHeight((float)bounds.getHeight());
 
     for (MapObject item : items) {
       MapObject newItem = new MapObject(item);
-      newItem.setX(item.getX() - bounds.x);
-      newItem.setY(item.getY() - bounds.y);
+      newItem.setX((float)(item.getX() - bounds.getX()));
+      newItem.setY((float)(item.getY() - bounds.getY()));
       if (keepIds) {
         newItem.setId(item.getId());
       }
@@ -73,7 +73,7 @@ public class Blueprint extends MapObject {
     return this.build(Math.round((float) location.getX()), Math.round((float) location.getY()));
   }
 
-  public List<MapObject> build(int x, int y) {
+  public List<MapObject> build(float x, float y) {
     List<MapObject> builtObjects = new ArrayList<>();
 
     for (MapObject item : this.getItems()) {

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/DecimalFloatAdapter.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/DecimalFloatAdapter.java
@@ -1,0 +1,24 @@
+package de.gurkenlabs.litiengine.environment.tilemap.xml;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * This adapter implementation ensures that the float value is serialized
+ * like an integer when it has no digits behind the decimal point.
+ */
+public class DecimalFloatAdapter extends XmlAdapter<String, Float> {
+
+  @Override
+  public Float unmarshal(String v) throws Exception {
+    return Float.parseFloat(v);
+  }
+
+  @Override
+  public String marshal(Float v) throws Exception {
+    if (v.floatValue() % 1 == 0) {
+      return Integer.toString(v.intValue());
+    }
+
+    return v.toString();
+  }
+}

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
@@ -1,8 +1,6 @@
 package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
-import java.awt.Dimension;
-import java.awt.Point;
-import java.awt.Rectangle;
+import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 
@@ -11,6 +9,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.IPolyline;
@@ -32,16 +31,20 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   private String type;
 
   @XmlAttribute
-  private int x;
+  @XmlJavaTypeAdapter(value = DecimalFloatAdapter.class)
+  private Float x;
 
   @XmlAttribute
-  private int y;
+  @XmlJavaTypeAdapter(value = DecimalFloatAdapter.class)
+  private Float y;
 
   @XmlAttribute
-  private int width;
+  @XmlJavaTypeAdapter(value = DecimalFloatAdapter.class)
+  private Float width;
 
   @XmlAttribute
-  private int height;
+  @XmlJavaTypeAdapter(value = DecimalFloatAdapter.class)
+  private Float height;
 
   @XmlAttribute
   private Integer gid;
@@ -50,9 +53,14 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   private Polyline polyline;
 
   public MapObject() {
+    this.x = 0f;
+    this.y = 0f;
+    this.width = 0f;
+    this.height = 0f;
   }
 
   public MapObject(MapObject mapObject) {
+    super();
     this.gid = mapObject.gid;
     this.height = mapObject.height;
     this.width = mapObject.width;
@@ -72,15 +80,15 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
     return getBounds(objects);
   }
 
-  public static Rectangle getBounds(MapObject... objects) {
+  public static Rectangle2D getBounds(MapObject... objects) {
     return getBounds(Arrays.asList(objects));
   }
 
-  public static Rectangle getBounds(Iterable<MapObject> objects) {
-    int minX = -1;
-    int minY = -1;
-    int maxX = -1;
-    int maxY = -1;
+  public static Rectangle2D getBounds(Iterable<MapObject> objects) {
+    float minX = -1;
+    float minY = -1;
+    float maxX = -1;
+    float maxY = -1;
     for (MapObject item : objects) {
       if (minX == -1 || item.getX() < minX) {
         minX = item.getX();
@@ -99,7 +107,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
       }
     }
 
-    return new Rectangle(minX, minY, maxX - minX, maxY - minY);
+    return new Rectangle2D.Float(minX, minY, maxX - minX, maxY - minY);
   }
 
   @Override
@@ -117,11 +125,6 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
     }
 
     return this.getName().compareTo(obj.getName());
-  }
-
-  @Override
-  public Dimension getDimension() {
-    return new Dimension(this.width, this.height);
   }
 
   @Override
@@ -144,8 +147,8 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   }
 
   @Override
-  public Point getLocation() {
-    return new Point(this.x, this.y);
+  public Point2D getLocation() {
+    return new Point2D.Double(this.x, this.y);
   }
 
   @Override
@@ -176,7 +179,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
 
   @Override
   @XmlTransient
-  public void setHeight(int height) {
+  public void setHeight(float height) {
     this.height = height;
   }
 
@@ -200,29 +203,29 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
 
   @Override
   @XmlTransient
-  public void setWidth(int width) {
+  public void setWidth(float width) {
     this.width = width;
   }
 
   @Override
   @XmlTransient
-  public void setX(int x) {
+  public void setX(float x) {
     this.x = x;
   }
 
   @Override
   @XmlTransient
-  public void setY(int y) {
+  public void setY(float y) {
     this.y = y;
   }
 
   @Override
-  public int getX() {
+  public float getX() {
     return this.x;
   }
 
   @Override
-  public int getY() {
+  public float getY() {
     return this.y;
   }
 
@@ -232,12 +235,12 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   }
 
   @Override
-  public int getWidth() {
+  public float getWidth() {
     return this.width;
   }
 
   @Override
-  public int getHeight() {
+  public float getHeight() {
     return this.height;
   }
 

--- a/src/de/gurkenlabs/litiengine/graphics/particles/xml/EmitterData.java
+++ b/src/de/gurkenlabs/litiengine/graphics/particles/xml/EmitterData.java
@@ -51,7 +51,7 @@ public class EmitterData implements Serializable, Comparable<EmitterData> {
   private ParticleParameter gravityY;
 
   @XmlAttribute
-  private int height;
+  private float height;
 
   @XmlAttribute
   private int maxParticles;
@@ -87,7 +87,7 @@ public class EmitterData implements Serializable, Comparable<EmitterData> {
   private int updateRate;
 
   @XmlAttribute
-  private int width;
+  private float width;
 
   @XmlElement
   private float colorDeviation;
@@ -246,7 +246,7 @@ public class EmitterData implements Serializable, Comparable<EmitterData> {
   }
 
   @XmlTransient
-  public int getHeight() {
+  public float getHeight() {
     return this.height;
   }
 
@@ -351,7 +351,7 @@ public class EmitterData implements Serializable, Comparable<EmitterData> {
   }
 
   @XmlTransient
-  public int getWidth() {
+  public float getWidth() {
     return this.width;
   }
 
@@ -418,7 +418,7 @@ public class EmitterData implements Serializable, Comparable<EmitterData> {
     this.gravityY = gravityY;
   }
 
-  public void setHeight(final int height) {
+  public void setHeight(final float height) {
     this.height = height;
   }
 
@@ -482,7 +482,7 @@ public class EmitterData implements Serializable, Comparable<EmitterData> {
     this.updateRate = updateRate;
   }
 
-  public void setWidth(final int width) {
+  public void setWidth(final float width) {
     this.width = width;
   }
 

--- a/src/de/gurkenlabs/litiengine/util/MathUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/MathUtilities.java
@@ -11,13 +11,7 @@ public class MathUtilities {
   }
 
   public static float round(float value, int places) {
-    if (places < 0) {
-      throw new IllegalArgumentException();
-    }
-
-    BigDecimal bd = BigDecimal.valueOf(value);
-    bd = bd.setScale(places, RoundingMode.HALF_UP);
-    return bd.floatValue();
+    return (float) round((double) value, places);
   }
 
   public static double round(double value, int places) {

--- a/src/de/gurkenlabs/litiengine/util/MathUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/MathUtilities.java
@@ -1,11 +1,33 @@
 package de.gurkenlabs.litiengine.util;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Random;
 
 public class MathUtilities {
   private static Random random = new Random();
 
   private MathUtilities() {
+  }
+
+  public static float round(float value, int places) {
+    if (places < 0) {
+      throw new IllegalArgumentException();
+    }
+
+    BigDecimal bd = BigDecimal.valueOf(value);
+    bd = bd.setScale(places, RoundingMode.HALF_UP);
+    return bd.floatValue();
+  }
+
+  public static double round(double value, int places) {
+    if (places < 0) {
+      throw new IllegalArgumentException();
+    }
+
+    BigDecimal bd = BigDecimal.valueOf(value);
+    bd = bd.setScale(places, RoundingMode.HALF_UP);
+    return bd.doubleValue();
   }
 
   public static double clamp(final double value, final double min, final double max) {

--- a/tests/de/gurkenlabs/litiengine/environment/MapObjectLoaderTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/MapObjectLoaderTests.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.awt.Color;
-import java.awt.Dimension;
 import java.awt.Point;
 import java.util.Collection;
 import java.util.Optional;
@@ -40,7 +39,7 @@ public class MapObjectLoaderTests {
     when(mapObject.getId()).thenReturn(111);
     when(mapObject.getName()).thenReturn("testProp");
     when(mapObject.getLocation()).thenReturn(new Point(100, 100));
-    when(mapObject.getDimension()).thenReturn(new Dimension(200, 200));
+
 
     when(mapObject.getCustomProperty(MapObjectProperty.PROP_MATERIAL)).thenReturn(Material.PLASTIC.name());
     when(mapObject.getCustomPropertyBool(MapObjectProperty.PROP_INDESTRUCTIBLE)).thenReturn(true);
@@ -88,9 +87,8 @@ public class MapObjectLoaderTests {
     when(mapObject.getId()).thenReturn(111);
     when(mapObject.getName()).thenReturn("testCollider");
     when(mapObject.getLocation()).thenReturn(new Point(100, 100));
-    when(mapObject.getDimension()).thenReturn(new Dimension(200, 200));
-    when(mapObject.getWidth()).thenReturn(200);
-    when(mapObject.getHeight()).thenReturn(200);
+    when(mapObject.getWidth()).thenReturn(200f);
+    when(mapObject.getHeight()).thenReturn(200f);
 
     Collection<IEntity> entities = loader.load(environment, mapObject);
     Optional<IEntity> opt = entities.stream().findFirst();
@@ -119,9 +117,8 @@ public class MapObjectLoaderTests {
     when(mapObject.getId()).thenReturn(111);
     when(mapObject.getName()).thenReturn("testTrigger");
     when(mapObject.getLocation()).thenReturn(new Point(100, 100));
-    when(mapObject.getWidth()).thenReturn(200);
-    when(mapObject.getHeight()).thenReturn(200);
-    when(mapObject.getDimension()).thenReturn(new Dimension(200, 200));
+    when(mapObject.getWidth()).thenReturn(200f);
+    when(mapObject.getHeight()).thenReturn(200f);
 
     when(mapObject.getCustomProperty(MapObjectProperty.TRIGGER_MESSAGE)).thenReturn("message");
     when(mapObject.getCustomProperty(MapObjectProperty.TRIGGER_ACTIVATION)).thenReturn(TriggerActivation.INTERACT.name());
@@ -160,7 +157,6 @@ public class MapObjectLoaderTests {
     when(mapObject.getId()).thenReturn(111);
     when(mapObject.getName()).thenReturn("testEmitter");
     when(mapObject.getLocation()).thenReturn(new Point(100, 100));
-    when(mapObject.getDimension()).thenReturn(new Dimension(200, 200));
 
     Collection<IEntity> entities = loader.load(environment, mapObject);
     Optional<IEntity> opt = entities.stream().findFirst();
@@ -184,7 +180,6 @@ public class MapObjectLoaderTests {
     when(mapObject.getId()).thenReturn(111);
     when(mapObject.getName()).thenReturn("testLight");
     when(mapObject.getLocation()).thenReturn(new Point(100, 100));
-    when(mapObject.getDimension()).thenReturn(new Dimension(200, 200));
 
     when(mapObject.getCustomPropertyInt(MapObjectProperty.LIGHT_ALPHA)).thenReturn(100);
     when(mapObject.getCustomPropertyInt(MapObjectProperty.LIGHT_INTENSITY, 100)).thenReturn(100);

--- a/utiliti/resources/localization/strings.properties
+++ b/utiliti/resources/localization/strings.properties
@@ -7,6 +7,7 @@ menu_exit=Exit
 menu_recentFiles=Recent files...
 
 menu_view=View
+menu_snapPixels=Snap to pixels
 menu_snapGrid=Snap to grid
 menu_renderGrid=Render grid
 menu_renderCollisionBoxes=Render collision boxes

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -252,7 +252,7 @@ public class Program {
         return terminate;
       }
     });
-    
+
     window.setResizable(true);
 
     window.setMenuBar(menuBar);
@@ -416,31 +416,27 @@ public class Program {
   private static Menu initViewMenu() {
     Menu mnView = new Menu(Resources.get("menu_view"));
 
+    CheckboxMenuItem snapToPixels = new CheckboxMenuItem(Resources.get("menu_snapPixels"));
+    snapToPixels.setState(userPreferences.isSnapPixels());
+    snapToPixels.addItemListener(e -> {
+      userPreferences.setSnapPixels(snapToPixels.getState());
+      EditorScreen.instance().getMapObjectPanel().updateSpinnerModels();
+      EditorScreen.instance().getMapObjectPanel().bind(EditorScreen.instance().getMapComponent().getFocusedMapObject());
+    });
+
     CheckboxMenuItem snapToGrid = new CheckboxMenuItem(Resources.get("menu_snapGrid"));
     snapToGrid.setState(userPreferences.isSnapGrid());
-    EditorScreen.instance().getMapComponent().setSnapToGrid(snapToGrid.getState());
-    snapToGrid.addItemListener(e -> {
-      EditorScreen.instance().getMapComponent().setSnapToGrid(snapToGrid.getState());
-      userPreferences.setSnapGrid(snapToGrid.getState());
-    });
+    snapToGrid.addItemListener(e -> userPreferences.setSnapGrid(snapToGrid.getState()));
 
     CheckboxMenuItem renderGrid = new CheckboxMenuItem(Resources.get("menu_renderGrid"));
     renderGrid.setState(userPreferences.isShowGrid());
-    EditorScreen.instance().getMapComponent().setRenderGrid(renderGrid.getState());
     renderGrid.setShortcut(new MenuShortcut(KeyEvent.VK_G));
-    renderGrid.addItemListener(e -> {
-      EditorScreen.instance().getMapComponent().setRenderGrid(renderGrid.getState());
-      userPreferences.setShowGrid(renderGrid.getState());
-    });
+    renderGrid.addItemListener(e -> userPreferences.setShowGrid(renderGrid.getState()));
 
     CheckboxMenuItem renderCollision = new CheckboxMenuItem(Resources.get("menu_renderCollisionBoxes"));
     renderCollision.setState(userPreferences.isRenderBoundingBoxes());
-    EditorScreen.instance().getMapComponent().setRenderCollisionBoxes(renderCollision.getState());
     renderCollision.setShortcut(new MenuShortcut(KeyEvent.VK_H));
-    renderCollision.addItemListener(e -> {
-      EditorScreen.instance().getMapComponent().setRenderCollisionBoxes(renderCollision.getState());
-      userPreferences.setRenderBoundingBoxes(renderCollision.getState());
-    });
+    renderCollision.addItemListener(e -> userPreferences.setRenderBoundingBoxes(renderCollision.getState()));
 
     MenuItem setGrid = new MenuItem(Resources.get("menu_gridSize"));
     setGrid.addActionListener(a -> {
@@ -459,6 +455,7 @@ public class Program {
     zoomOut.setShortcut(new MenuShortcut(KeyEvent.VK_MINUS));
     zoomOut.addActionListener(a -> EditorScreen.instance().getMapComponent().zoomOut());
 
+    mnView.add(snapToPixels);
     mnView.add(snapToGrid);
     mnView.add(renderGrid);
     mnView.add(renderCollision);

--- a/utiliti/src/de/gurkenlabs/utiliti/UserPreferenceConfiguration.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/UserPreferenceConfiguration.java
@@ -11,6 +11,7 @@ import de.gurkenlabs.litiengine.configuration.ConfigurationGroupInfo;
 public class UserPreferenceConfiguration extends ConfigurationGroup {
   private float zoom;
   private boolean showGrid;
+  private boolean snapPixels;
   private boolean snapGrid;
   private boolean renderBoundingBoxes;
   private boolean compressFile;
@@ -31,6 +32,7 @@ public class UserPreferenceConfiguration extends ConfigurationGroup {
   public UserPreferenceConfiguration() {
     this.zoom = 1.0f;
     this.showGrid = true;
+    this.snapPixels = true;
     this.snapGrid = true;
     this.renderBoundingBoxes = true;
     this.lastOpenedFiles = new String[10];
@@ -205,5 +207,13 @@ public class UserPreferenceConfiguration extends ConfigurationGroup {
 
   public void setFrameState(int frameState) {
     this.frameState = frameState;
+  }
+
+  public boolean isSnapPixels() {
+    return snapPixels;
+  }
+
+  public void setSnapPixels(boolean snapPixels) {
+    this.snapPixels = snapPixels;
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/MapObjectPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/MapObjectPanel.java
@@ -5,6 +5,8 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.GroupLayout;
@@ -131,15 +133,9 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
 
   public void updateSpinnerModels() {
     if (Program.getUserPreferences().isSnapPixels()) {
-      this.spinnerX.setModel(getIntegerModel());
-      this.spinnerY.setModel(getIntegerModel());
-      this.spinnerWidth.setModel(getIntegerModel());
-      this.spinnerHeight.setModel(getIntegerModel());
+      this.updateSpinnerModels(MapObjectPanel::getIntegerModel);
     } else {
-      this.spinnerX.setModel(getFloatModel());
-      this.spinnerY.setModel(getFloatModel());
-      this.spinnerWidth.setModel(getFloatModel());
-      this.spinnerHeight.setModel(getFloatModel());
+      this.updateSpinnerModels(MapObjectPanel::getFloatModel);
     }
   }
 
@@ -295,5 +291,12 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
 
   private static SpinnerNumberModel getIntegerModel() {
     return new SpinnerNumberModel(0, 0, 10000, 1);
+  }
+
+  private void updateSpinnerModels(Supplier<SpinnerNumberModel> supp) {
+    this.spinnerX.setModel(supp.get());
+    this.spinnerY.setModel(supp.get());
+    this.spinnerWidth.setModel(supp.get());
+    this.spinnerHeight.setModel(supp.get());
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/MapObjectPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/MapObjectPanel.java
@@ -15,12 +15,14 @@ import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
+import javax.swing.SpinnerNumberModel;
 
 import de.gurkenlabs.litiengine.Resources;
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectType;
 import de.gurkenlabs.utiliti.EditorScreen;
+import de.gurkenlabs.utiliti.Program;
 import de.gurkenlabs.utiliti.swing.TagPanel;
 
 @SuppressWarnings("serial")
@@ -40,7 +42,7 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
   private final JLabel labelEntityID;
   private TagPanel tagPanel;
   private JLabel lblTags;
-  
+
   public MapObjectPanel() {
     this.panels = new ConcurrentHashMap<>();
     this.panels.put(MapObjectType.PROP, new PropPanel());
@@ -57,13 +59,9 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
     setMinimumSize(new Dimension(250, 500));
 
     JLabel lblX = new JLabel(Resources.get("panel_x"));
-
     JLabel lblYcoordinate = new JLabel(Resources.get("panel_y"));
-
     JLabel lblWidth = new JLabel(Resources.get("panel_width"));
-
     JLabel lblHeight = new JLabel(Resources.get("panel_height"));
-
     JLabel lblName = new JLabel(Resources.get("panel_name"));
 
     this.textFieldName = new JTextField();
@@ -77,6 +75,8 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
     this.spinnerY = new JSpinner();
     this.spinnerWidth = new JSpinner();
     this.spinnerHeight = new JSpinner();
+
+    this.updateSpinnerModels();
 
     JLabel lblNewLabel = new JLabel("ID");
     lblNewLabel.setFont(lblNewLabel.getFont().deriveFont(Font.BOLD).deriveFont(12f));
@@ -127,6 +127,20 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
 
     this.setupChangedListeners();
     this.comboBoxType.setSelectedItem(MapObjectType.AREA);
+  }
+
+  public void updateSpinnerModels() {
+    if (Program.getUserPreferences().isSnapPixels()) {
+      this.spinnerX.setModel(getIntegerModel());
+      this.spinnerY.setModel(getIntegerModel());
+      this.spinnerWidth.setModel(getIntegerModel());
+      this.spinnerHeight.setModel(getIntegerModel());
+    } else {
+      this.spinnerX.setModel(getFloatModel());
+      this.spinnerY.setModel(getFloatModel());
+      this.spinnerWidth.setModel(getFloatModel());
+      this.spinnerHeight.setModel(getFloatModel());
+    }
   }
 
   public MapObjectType getObjectType() {
@@ -241,26 +255,45 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
 
     this.textFieldName.addActionListener(new MapObjectPropertyActionListener(m -> m.setName(textFieldName.getText())));
 
+    // TODO: wrap the value changing with the spin controls into one undo
+    // operation.
     this.spinnerX.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setX((float)spinnerX.getValue());
+
+      m.setX(getSpinnerValue(spinnerX));
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.spinnerY.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setY((float) spinnerY.getValue());
+      m.setY(getSpinnerValue(spinnerY));
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.spinnerWidth.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setWidth((float) spinnerWidth.getValue());
+      m.setWidth(getSpinnerValue(spinnerWidth));
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.spinnerHeight.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setHeight((float) spinnerHeight.getValue());
+      m.setHeight(getSpinnerValue(spinnerHeight));
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.tagPanel.addActionListener(new MapObjectPropertyActionListener(m -> m.setCustomProperty(MapObjectProperty.TAGS, this.tagPanel.getTagsString())));
+  }
+
+  private static float getSpinnerValue(JSpinner spinner) {
+    if (spinner.getValue() instanceof Integer) {
+      return (int) spinner.getValue();
+    } else {
+      return (float) (double) spinner.getValue();
+    }
+  }
+
+  private static SpinnerNumberModel getFloatModel() {
+    return new SpinnerNumberModel(0f, 0f, 10000f, 0.01f);
+  }
+
+  private static SpinnerNumberModel getIntegerModel() {
+    return new SpinnerNumberModel(0, 0, 10000, 1);
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/MapObjectPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/MapObjectPanel.java
@@ -212,10 +212,10 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
 
   @Override
   protected void setControlValues(IMapObject mapObject) {
-    this.spinnerX.setValue((int) mapObject.getLocation().getX());
-    this.spinnerY.setValue((int) mapObject.getLocation().getY());
-    this.spinnerWidth.setValue((int) mapObject.getDimension().getWidth());
-    this.spinnerHeight.setValue((int) mapObject.getDimension().getHeight());
+    this.spinnerX.setValue(mapObject.getLocation().getX());
+    this.spinnerY.setValue(mapObject.getLocation().getY());
+    this.spinnerWidth.setValue(mapObject.getWidth());
+    this.spinnerHeight.setValue(mapObject.getHeight());
 
     MapObjectType type = MapObjectType.get(mapObject.getType());
     this.comboBoxType.setSelectedItem(type);
@@ -242,22 +242,22 @@ public class MapObjectPanel extends PropertyPanel<IMapObject> {
     this.textFieldName.addActionListener(new MapObjectPropertyActionListener(m -> m.setName(textFieldName.getText())));
 
     this.spinnerX.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setX((int) spinnerX.getValue());
+      m.setX((float)spinnerX.getValue());
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.spinnerY.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setY((int) spinnerY.getValue());
+      m.setY((float) spinnerY.getValue());
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.spinnerWidth.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setWidth((int) spinnerWidth.getValue());
+      m.setWidth((float) spinnerWidth.getValue());
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 
     this.spinnerHeight.addChangeListener(new MapObjectPropertyChangeListener(m -> {
-      m.setHeight((int) spinnerHeight.getValue());
+      m.setHeight((float) spinnerHeight.getValue());
       EditorScreen.instance().getMapComponent().updateTransformControls();
     }));
 


### PR DESCRIPTION
With this change, the `MapObject` position and size does now support float values.
The TiledEditor seems to support float values although [the documentation of the tmx file format](http://docs.mapeditor.org/en/latest/reference/tmx-map-format/) states that x/y/width and height are saved in pixels.
Previously it cut off the decimal digits and therefore it was not possible to use floating point numbers for the position/size of a `MapObject`.

With this change, there is now a new option for the editor that allows to enable/disable pixel precise snapping.