### PR TITLE
Refactor gameinfo

### DIFF
--- a/src/de/gurkenlabs/litiengine/Game.java
+++ b/src/de/gurkenlabs/litiengine/Game.java
@@ -32,6 +32,7 @@ import de.gurkenlabs.litiengine.physics.PhysicsEngine;
 import de.gurkenlabs.litiengine.sound.ISoundEngine;
 import de.gurkenlabs.litiengine.sound.SoundEngine;
 import de.gurkenlabs.litiengine.util.ArrayUtilities;
+import de.gurkenlabs.litiengine.util.io.XmlUtilities;
 
 public final class Game {
   public static final String COMMADLINE_ARG_RELEASE = "-release";
@@ -50,7 +51,7 @@ public final class Game {
   private static final GameConfiguration configuration;
   private static final EntityControllerManager entityControllerManager;
   private static final IRenderEngine graphicsEngine;
-  private static final GameInfo info;
+
   private static final List<IMap> maps;
   private static final List<ITileset> tilesets;
   private static final GameMetrics metrics;
@@ -58,6 +59,7 @@ public final class Game {
   private static final ISoundEngine soundEngine;
   private static final GameTime gameTime;
 
+  private static GameInfo gameInfo;
   private static IEnvironment environment;
   private static ICamera camera;
   private static IGameLoop gameLoop;
@@ -76,7 +78,7 @@ public final class Game {
     soundEngine = new SoundEngine();
     metrics = new GameMetrics();
     entityControllerManager = new EntityControllerManager();
-    info = new GameInfo();
+    gameInfo = new GameInfo();
     maps = new CopyOnWriteArrayList<>();
     tilesets = new CopyOnWriteArrayList<>();
     gameTime = new GameTime();
@@ -163,7 +165,7 @@ public final class Game {
   }
 
   public static GameInfo getInfo() {
-    return info;
+    return gameInfo;
   }
 
   public static IGameLoop getLoop() {
@@ -239,7 +241,7 @@ public final class Game {
     gameLoop = updateLoop;
     getLoop().attach(getPhysicsEngine());
 
-    final ScreenManager scrMgr = new ScreenManager(getInfo().toString());
+    final ScreenManager scrMgr = new ScreenManager(getInfo().getTitle());
 
     // setup default exception handling for render and update loop
     renderLoop = new RenderLoop(scrMgr.getRenderComponent());
@@ -414,6 +416,19 @@ public final class Game {
       Game.getLoop().attach(cam);
       getCamera().updateFocus();
     }
+  }
+
+  public static void setInfo(final GameInfo info) {
+    gameInfo = info;
+  }
+
+  public static void setInfo(final String gameInfoFile) {
+    GameInfo info = XmlUtilities.readFromFile(GameInfo.class, gameInfoFile);
+    if (info == null) {
+      log.log(Level.WARNING, "Could not read game info from {0}", new Object[] { gameInfoFile });
+    }
+    
+    setInfo(info);
   }
 
   private static void handleCommandLineArguments(String[] args) {

--- a/src/de/gurkenlabs/litiengine/GameInfo.java
+++ b/src/de/gurkenlabs/litiengine/GameInfo.java
@@ -4,43 +4,41 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
-@XmlRootElement(name = "info")
+@XmlRootElement(name = "gameinfo")
 public class GameInfo {
   @XmlElement
-  private String cooperation;
+  private String name;
+
+  @XmlElement
+  private String subTitle;
 
   @XmlElement
   private String description;
 
-  private String[] developers;
-  private String icon;
-
-  private String logo;
-  @XmlElement
-  private String name;
-  private float renderScale;
-
-  @XmlElement
-  private String subTitle;
   @XmlElement
   private String version;
 
+  @XmlElement
+  private String company;
+
+  @XmlElement
+  private String publisher;
+
+  @XmlElement(name = "developer")
+  private String[] developers;
+
   public GameInfo() {
-    this.cooperation = "gurkenlabs";
+    this.company = "gurkenlabs";
     this.name = "LITIengine Game";
     this.subTitle = "The pure 2D java game engine";
     this.description = "A game, created with the allmighty LITIengine.";
     this.developers = new String[] { "Steffen Wilke", "Matthias Wilke" };
-    this.icon = "";
-    this.logo = "";
     this.version = "v1.0";
-
-    this.renderScale = 3.0f;
   }
 
   @XmlTransient
-  public String getCooperation() {
-    return this.cooperation;
+  public String getCompany() {
+    return this.company;
   }
 
   @XmlTransient
@@ -54,23 +52,13 @@ public class GameInfo {
   }
 
   @XmlTransient
-  public String getIcon() {
-    return this.icon;
-  }
-
-  @XmlTransient
-  public String getLogo() {
-    return this.logo;
-  }
-
-  @XmlTransient
   public String getName() {
     return this.name;
   }
 
   @XmlTransient
-  public float getDefaultRenderScale() {
-    return this.renderScale;
+  public String getPublisher() {
+    return this.publisher;
   }
 
   @XmlTransient
@@ -83,8 +71,8 @@ public class GameInfo {
     return this.version;
   }
 
-  public void setCooperation(final String cooperation) {
-    this.cooperation = cooperation;
+  public void setCompany(final String company) {
+    this.company = company;
   }
 
   public void setDescription(final String description) {
@@ -95,20 +83,8 @@ public class GameInfo {
     this.developers = developers;
   }
 
-  public void setIcon(final String icon) {
-    this.icon = icon;
-  }
-
-  public void setLogo(final String logo) {
-    this.logo = logo;
-  }
-
   public void setName(final String name) {
     this.name = name;
-  }
-
-  public void setDefaultRenderScale(final float renderScale) {
-    this.renderScale = renderScale;
   }
 
   public void setSubTitle(final String subTitle) {

--- a/src/de/gurkenlabs/litiengine/GameInfo.java
+++ b/src/de/gurkenlabs/litiengine/GameInfo.java
@@ -1,11 +1,21 @@
 package de.gurkenlabs.litiengine;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
+import de.gurkenlabs.litiengine.environment.tilemap.xml.CustomPropertyProvider;
+
 @XmlRootElement(name = "gameinfo")
-public class GameInfo {
+public class GameInfo extends CustomPropertyProvider {
+  private static final Logger log = Logger.getLogger(GameInfo.class.getName());
+  private static final long serialVersionUID = 3340166298303962177L;
+
   @XmlElement
   private String name;
 
@@ -14,6 +24,9 @@ public class GameInfo {
 
   @XmlElement
   private String description;
+
+  @XmlElement
+  private String website;
 
   @XmlElement
   private String version;
@@ -34,6 +47,7 @@ public class GameInfo {
     this.description = "A game, created with the allmighty LITIengine.";
     this.developers = new String[] { "Steffen Wilke", "Matthias Wilke" };
     this.version = "v1.0";
+    this.website = "https://litiengine.com";
   }
 
   @XmlTransient
@@ -44,6 +58,25 @@ public class GameInfo {
   @XmlTransient
   public String getDescription() {
     return this.description;
+  }
+
+  @XmlTransient
+  public String getWebsite() {
+    return this.website;
+  }
+
+  @XmlTransient
+  public URL getWebsiteURL() {
+    if (this.getWebsite() == null || this.getWebsite().isEmpty()) {
+      return null;
+    }
+
+    try {
+      return new URL(this.getWebsite());
+    } catch (MalformedURLException e) {
+      log.log(Level.WARNING, this.getWebsite() + ": " + e.getMessage(), e);
+      return null;
+    }
   }
 
   @XmlTransient
@@ -95,8 +128,11 @@ public class GameInfo {
     this.version = version;
   }
 
-  @Override
-  public String toString() {
+  public void setWebsite(final String website) {
+    this.website = website;
+  }
+
+  public String getTitle() {
     return this.getSubTitle() != null && !this.getSubTitle().isEmpty() ? this.getName() + " " + this.getVersion() + " - " + this.getSubTitle() : this.getName() + " " + this.getVersion();
   }
 }

--- a/src/de/gurkenlabs/litiengine/annotation/Tag.java
+++ b/src/de/gurkenlabs/litiengine/annotation/Tag.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import de.gurkenlabs.litiengine.entities.IEntity;
 
 /**

--- a/src/de/gurkenlabs/litiengine/configuration/GraphicConfiguration.java
+++ b/src/de/gurkenlabs/litiengine/configuration/GraphicConfiguration.java
@@ -116,7 +116,7 @@ public class GraphicConfiguration extends ConfigurationGroup {
     this.resolutionWidth = resolutionWidth;
   }
 
-  public boolean enableResolutionScale() {
+  public boolean enableResolutionScaling() {
     return this.enableResolutionScale;
   }
 

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProvider.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProvider.java
@@ -17,7 +17,6 @@ import de.gurkenlabs.litiengine.environment.tilemap.ICustomPropertyProvider;
 public class CustomPropertyProvider implements ICustomPropertyProvider, Serializable {
   private static final long serialVersionUID = 7418225969292279565L;
 
-  /** The properties. */
   @XmlElementWrapper(name = "properties")
   @XmlElement(name = "property")
   private List<Property> properties = new CopyOnWriteArrayList<>();

--- a/src/de/gurkenlabs/litiengine/graphics/Camera.java
+++ b/src/de/gurkenlabs/litiengine/graphics/Camera.java
@@ -119,7 +119,7 @@ public class Camera implements ICamera {
 
   @Override
   public float getRenderScale() {
-    return Game.getInfo().getDefaultRenderScale() * this.getZoom();
+    return Game.getRenderEngine().getBaseRenderScale() * this.getZoom();
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/graphics/IRenderEngine.java
+++ b/src/de/gurkenlabs/litiengine/graphics/IRenderEngine.java
@@ -19,6 +19,13 @@ public interface IRenderEngine {
 
   public void entityRenderingCondition(Predicate<IEntity> predicate);
 
+  /**
+   * Gets the base render scale of the game.
+   * 
+   * @return The base render scale.
+   */
+  public float getBaseRenderScale();
+
   public IMapRenderer getMapRenderer(MapOrientation orientation);
 
   public void onEntityRendered(Consumer<RenderEvent<IEntity>> entity);
@@ -46,14 +53,24 @@ public interface IRenderEngine {
   public void renderLayers(Graphics2D g, final IMap map, RenderType type);
 
   public void renderMap(Graphics2D g, final IMap map);
-  
+
   public void renderShape(final Graphics2D g, final Shape shape);
-  
+
   public void renderOutline(Graphics2D g, final Shape shape);
-  
+
   public void renderOutline(Graphics2D g, final Shape shape, Stroke stroke);
 
   public void renderText(final Graphics2D g, final String text, final double x, final double y);
 
   public void renderText(final Graphics2D g, final String text, final Point2D location);
+
+  /**
+   * Sets the global base scale that is used to calculate the actual render scale of the game.
+   * 
+   * @param scale
+   *          The base render scale for the game.
+   * 
+   * @see ICamera#getRenderScale()
+   */
+  public void setBaseRenderScale(float scale);
 }

--- a/src/de/gurkenlabs/litiengine/graphics/RenderEngine.java
+++ b/src/de/gurkenlabs/litiengine/graphics/RenderEngine.java
@@ -30,12 +30,16 @@ import de.gurkenlabs.litiengine.graphics.animation.IAnimationController;
 import de.gurkenlabs.litiengine.graphics.animation.IEntityAnimationController;
 
 public final class RenderEngine implements IRenderEngine {
+  private static final float DEFAULT_RENDERSCALE = 3.0f;
+
   private final EntityYComparator entityComparator;
   private final List<Consumer<RenderEvent<IEntity>>> entityRenderedConsumer;
   private final List<Predicate<IEntity>> entityRenderingConditions;
   private final List<Consumer<RenderEvent<IEntity>>> entityRenderingConsumer;
   private final List<Consumer<RenderEvent<IMap>>> mapRenderedConsumer;
   private final EnumMap<MapOrientation, IMapRenderer> mapRenderer;
+
+  private float baseRenderScale;
 
   public RenderEngine() {
     this.entityRenderedConsumer = new CopyOnWriteArrayList<>();
@@ -46,6 +50,8 @@ public final class RenderEngine implements IRenderEngine {
     this.entityComparator = new EntityYComparator();
 
     this.mapRenderer.put(MapOrientation.ORTHOGONAL, new OrthogonalMapRenderer());
+
+    this.baseRenderScale = DEFAULT_RENDERSCALE;
   }
 
   /**
@@ -271,7 +277,7 @@ public final class RenderEngine implements IRenderEngine {
 
     g.drawImage(image, transform, null);
   }
-  
+
   @Override
   public boolean canRender(final IEntity entity) {
     if (!this.entityRenderingConditions.isEmpty()) {
@@ -290,6 +296,11 @@ public final class RenderEngine implements IRenderEngine {
     if (!this.entityRenderingConditions.contains(predicate)) {
       this.entityRenderingConditions.add(predicate);
     }
+  }
+
+  @Override
+  public float getBaseRenderScale() {
+    return this.baseRenderScale;
   }
 
   @Override
@@ -467,5 +478,10 @@ public final class RenderEngine implements IRenderEngine {
     for (final Consumer<RenderEvent<IMap>> consumer : this.mapRenderedConsumer) {
       consumer.accept(new RenderEvent<>(g, map));
     }
+  }
+
+  @Override
+  public void setBaseRenderScale(float scale) {
+    this.baseRenderScale = scale;
   }
 }

--- a/src/de/gurkenlabs/litiengine/gui/screens/ScreenManager.java
+++ b/src/de/gurkenlabs/litiengine/gui/screens/ScreenManager.java
@@ -249,9 +249,9 @@ public class ScreenManager extends JFrame implements IScreenManager, WindowState
   private void setResolution(Dimension dim) {
     Dimension insetAwareDimension = new Dimension(dim.width + this.getInsets().left + this.getInsets().right, dim.height + this.getInsets().top + this.getInsets().bottom);
 
-    if (Game.getConfiguration().graphics().enableResolutionScale()) {
+    if (Game.getConfiguration().graphics().enableResolutionScaling()) {
       this.resolutionScale = (float) (dim.getWidth() / Resolution.Ratio16x9.RES_1920x1080.getWidth());
-      Game.getInfo().setDefaultRenderScale(Game.getInfo().getDefaultRenderScale() * this.resolutionScale);
+      Game.getRenderEngine().setBaseRenderScale(Game.getRenderEngine().getBaseRenderScale() * this.resolutionScale);
     }
 
     this.setSize(insetAwareDimension);

--- a/src/de/gurkenlabs/litiengine/util/UriUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/UriUtilities.java
@@ -1,0 +1,37 @@
+package de.gurkenlabs.litiengine.util;
+
+import java.awt.Desktop;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class UriUtilities {
+  private static final Logger log = Logger.getLogger(UriUtilities.class.getName());
+
+  private UriUtilities() {
+  }
+
+  public static boolean openWebpage(URI uri) {
+    Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
+    if (desktop != null && desktop.isSupported(Desktop.Action.BROWSE)) {
+      try {
+        desktop.browse(uri);
+        return true;
+      } catch (Exception e) {
+        log.log(Level.SEVERE, e.getMessage(), e);
+      }
+    }
+    return false;
+  }
+
+  public static boolean openWebpage(URL url) {
+    try {
+      return openWebpage(url.toURI());
+    } catch (URISyntaxException e) {
+      log.log(Level.SEVERE, e.getMessage(), e);
+    }
+    return false;
+  }
+}

--- a/src/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
@@ -92,7 +92,6 @@ public final class XmlUtilities {
 
       final Unmarshaller um = jaxbContext.createUnmarshaller();
 
-      
       InputStream stream = FileUtilities.getGameResource(path);
       if (stream == null) {
         stream = new FileInputStream(path);
@@ -106,17 +105,12 @@ public final class XmlUtilities {
     return null;
   }
 
-  public static <T> String save(T object, String fileName, String extension) {
+  public static <T> String save(T object, String fileName) {
     if (fileName == null || fileName.isEmpty()) {
       return null;
     }
 
-    String fileNameWithExtension = fileName;
-    if (!fileNameWithExtension.endsWith("." + extension)) {
-      fileNameWithExtension += "." + extension;
-    }
-
-    File newFile = new File(fileNameWithExtension);
+    File newFile = new File(fileName);
 
     try (FileOutputStream fileOut = new FileOutputStream(newFile)) {
       JAXBContext jaxbContext = getContext(object.getClass());
@@ -145,4 +139,12 @@ public final class XmlUtilities {
     return newFile.toString();
   }
 
+  public static <T> String save(T object, String fileName, String extension) {
+    String fileNameWithExtension = fileName;
+    if (!fileNameWithExtension.endsWith("." + extension)) {
+      fileNameWithExtension += "." + extension;
+    }
+
+    return save(object, fileNameWithExtension);
+  }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -118,7 +118,7 @@ public class Program {
 
     Game.getConfiguration().getConfigurationGroups().add(new UserPreferenceConfiguration());
     Game.init(args);
-    Game.getInfo().setDefaultRenderScale(1.0f);
+    Game.getRenderEngine().setBaseRenderScale(1.0f);
     JOptionPane.setDefaultLocale(Locale.getDefault());
 
     userPreferences = Game.getConfiguration().getConfigurationGroup("user_");
@@ -238,11 +238,11 @@ public class Program {
 
   private static void setupInterface() {
     JFrame window = initWindow();
-    
+
     Canvas canvas = Game.getScreenManager().getRenderComponent();
     canvas.setFocusable(true);
     canvas.setSize((int) (window.getSize().width * 0.75), window.getSize().height);
-    
+
     // remove canvas because we want to add a wrapping panel
     window.remove(canvas);
 
@@ -933,7 +933,7 @@ public class Program {
       exitItem.addActionListener(a -> Game.terminate());
       menu.add(exitItem);
 
-      trayIcon = new TrayIcon(Resources.getImage("pixel-icon-utility.png"), Game.getInfo().toString(), menu);
+      trayIcon = new TrayIcon(Resources.getImage("litiengine-icon.png"), Game.getInfo().toString(), menu);
       trayIcon.setImageAutoSize(true);
       try {
         tray.add(trayIcon);

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/FileDrop.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/FileDrop.java
@@ -23,6 +23,8 @@ import java.util.TooManyListenersException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import de.gurkenlabs.utiliti.swing.FileDrop.TransferableObject;
+
 /**
  * This class makes it easy to drag and drop files from the operating system to
  * a Java program. Any <tt>java.awt.Component</tt> can be dropped onto, but only


### PR DESCRIPTION
This change takes care of the inconsistencies of the `GameInfo` class.
It not only provided information about the game but also the `defaultRenderScale` and even some unused fields.

We've also extended the `GameInfo` with more detailed information about the game (e.g. publisher or website) and additionally provided the possibility to add custom properties for even more project specific information.