### PR TITLE
Improve accessibility of CustomMapObjectLoader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     token:
       secure: G0KkiaIo+eBOrLgnvH5R6OLxhp7KWXEhP4VYuIo+yF0to4ZI3xLpmWL8ILQy9y//1QY6srbvTD6plpir3j7pToquko0GSpJwrcbQYjs+8WisH8f3WHFNGZoi3Y0BGwk3ozlcAwsxjpFvx/b1LPx5uPQpKNPaV35ag+IajholPXSwRi86/LvL12IxI5UgNfpEXwLiEquUJp9IGLGWFNT4Nb6TsZdD5EBerjkRJGyVV3MZvASiTLZLnV8CswFucbz5+SUBRmqNfSHzzryXnTwgFS7CNp3TRyNHWh5xBE2bbAvkgy3G/xSECQ3qUglxNleZ/AYqYyAbQfCX2q9WEwYD3OvZOZ3qyjzxdJ3NBa50KnKduiSF6GQDmmrUS6n6pu6R77NVz1fzkD4oz0Uny5BeiB5fkhn4rEVk9QmCOnfAFOj6MjSgFVTMGV3nmh6bHJlKhbHXPiYJAp7dwPWczOj2jevnJ4WO5yoNaAxHQWUMqkaukDjPkQGqF9/GPBElriOBM4CdQ/CGClpa82HexYuiGL+TCChZgcEWgBNLzt5BqMuckdVzmRB6AYXIJQZ0ZdTbDVIAioU6l08oDXM5Y3wd0yDTqKieIyof6lWqGc+hPdyN9wlY6BNGCR2g9wpUTBNPHXULVEixfnaeEUotd87hx26HC0wryuh+ZzY4GTCufQs=
 script: 
-- ./gradlew fullbuild --stacktrace --scan
+- ./gradlew fullbuild --debug
 - if [ $TRAVIS_PULL_REQUEST = 'false' ]; then 
     sonar-scanner; 
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     token:
       secure: G0KkiaIo+eBOrLgnvH5R6OLxhp7KWXEhP4VYuIo+yF0to4ZI3xLpmWL8ILQy9y//1QY6srbvTD6plpir3j7pToquko0GSpJwrcbQYjs+8WisH8f3WHFNGZoi3Y0BGwk3ozlcAwsxjpFvx/b1LPx5uPQpKNPaV35ag+IajholPXSwRi86/LvL12IxI5UgNfpEXwLiEquUJp9IGLGWFNT4Nb6TsZdD5EBerjkRJGyVV3MZvASiTLZLnV8CswFucbz5+SUBRmqNfSHzzryXnTwgFS7CNp3TRyNHWh5xBE2bbAvkgy3G/xSECQ3qUglxNleZ/AYqYyAbQfCX2q9WEwYD3OvZOZ3qyjzxdJ3NBa50KnKduiSF6GQDmmrUS6n6pu6R77NVz1fzkD4oz0Uny5BeiB5fkhn4rEVk9QmCOnfAFOj6MjSgFVTMGV3nmh6bHJlKhbHXPiYJAp7dwPWczOj2jevnJ4WO5yoNaAxHQWUMqkaukDjPkQGqF9/GPBElriOBM4CdQ/CGClpa82HexYuiGL+TCChZgcEWgBNLzt5BqMuckdVzmRB6AYXIJQZ0ZdTbDVIAioU6l08oDXM5Y3wd0yDTqKieIyof6lWqGc+hPdyN9wlY6BNGCR2g9wpUTBNPHXULVEixfnaeEUotd87hx26HC0wryuh+ZzY4GTCufQs=
 script: 
-- ./gradlew fullbuild
+- ./gradlew fullbuild --stacktrace --scan
 - if [ $TRAVIS_PULL_REQUEST = 'false' ]; then 
     sonar-scanner; 
   fi

--- a/src/de/gurkenlabs/litiengine/entities/Entity.java
+++ b/src/de/gurkenlabs/litiengine/entities/Entity.java
@@ -11,6 +11,7 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.annotation.EntityInfo;
 import de.gurkenlabs.litiengine.annotation.Tag;
 import de.gurkenlabs.litiengine.entities.ai.IBehaviorController;
+import de.gurkenlabs.litiengine.environment.IEnvironment;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.TmxProperty;
 import de.gurkenlabs.litiengine.graphics.RenderType;
@@ -321,7 +322,10 @@ public abstract class Entity implements IEntity {
       return;
     }
     Game.getEnvironment().getEntitiesByTag().put(tag, new CopyOnWriteArrayList<>());
-    Game.getEnvironment().getEntitiesByTag().get(tag).add(this);
+    IEnvironment env = Game.getEnvironment();
+    Map<String, List<IEntity>> byTag = env.getEntitiesByTag();
+    List<IEntity> forTag = byTag.get(tag);
+    forTag.add(this);
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/environment/CustomMapObjectLoader.java
+++ b/src/de/gurkenlabs/litiengine/environment/CustomMapObjectLoader.java
@@ -9,21 +9,21 @@ import de.gurkenlabs.litiengine.entities.ICollisionEntity;
 import de.gurkenlabs.litiengine.entities.IEntity;
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 
-public final class CustomMapObjectLoader extends MapObjectLoader {
+public class CustomMapObjectLoader extends MapObjectLoader {
   private final ConstructorInvocation invoke;
 
   @FunctionalInterface
-  private interface ConstructorInvocation {
+  protected interface ConstructorInvocation {
     IEntity invoke(IEnvironment environment, IMapObject mapObject) throws InvocationTargetException, IllegalAccessException, InstantiationException;
   }
 
-  protected CustomMapObjectLoader(String mapObjectType, Class<? extends IEntity> entityType) {
+  public CustomMapObjectLoader(String mapObjectType, Class<? extends IEntity> entityType) {
     super(mapObjectType);
     if (entityType.isInterface())
       throw new IllegalArgumentException("Cannot create loader for interface or abstract class");
     ConstructorInvocation invoke;
     try {
-      final Constructor<? extends IEntity> constructor = entityType.getConstructor(IEnvironment.class, IEnvironment.class);
+      final Constructor<? extends IEntity> constructor = entityType.getConstructor(IEnvironment.class, IMapObject.class);
       invoke = (e, o) -> constructor.newInstance(e, o);
     } catch (NoSuchMethodException e1) {
       try {


### PR DESCRIPTION
First, there’s no reason for this class to be final.
Second, the constructor should be public, so that it can be instantiated by other parts of the application, e.g. to place a wrapper around it.
Third, make ConstructorInvocation protected rather than private so that subclasses can define their own invocations.