### PR TITLE
utiliti window will now be centered on screen

### DIFF
--- a/utiliti/src/de/gurkenlabs/utiliti/EditorScreen.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/EditorScreen.java
@@ -17,8 +17,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import javax.swing.JFileChooser;
-import javax.swing.JOptionPane;
+import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
@@ -207,7 +206,7 @@ public class EditorScreen extends Screen {
       chooser = new JFileChooser(new File(".").getCanonicalPath());
       chooser.setDialogTitle(Resources.get("input_select_project_folder"));
       chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-      if (chooser.showOpenDialog(Game.getScreenManager().getRenderComponent()) != JFileChooser.APPROVE_OPTION) {
+      if (chooser.showOpenDialog((JFrame) Game.getScreenManager()) != JFileChooser.APPROVE_OPTION) {
         return;
       }
 
@@ -498,7 +497,7 @@ public class EditorScreen extends Screen {
         chooser.addChoosableFileFilter(filter);
         chooser.setSelectedFile(new File(DEFAULT_GAME_NAME + "." + GameData.FILE_EXTENSION));
 
-        int result = chooser.showSaveDialog(Game.getScreenManager().getRenderComponent());
+        int result = chooser.showSaveDialog((JFrame) Game.getScreenManager());
         if (result == JFileChooser.APPROVE_OPTION) {
           String newFile = this.saveGameFile(chooser.getSelectedFile().toString());
           this.currentResourceFile = newFile;

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -318,6 +318,7 @@ public class Program {
       window.setExtendedState(userPreferences.getFrameState());
     }
 
+    window.setLocationRelativeTo(null);
     return window;
   }
 

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/EditorFileChooser.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/EditorFileChooser.java
@@ -2,7 +2,7 @@ package de.gurkenlabs.utiliti.swing;
 
 import java.io.File;
 
-import javax.swing.JFileChooser;
+import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
@@ -26,7 +26,7 @@ public final class EditorFileChooser extends JFileChooser {
     instance().setFileSelectionMode(JFileChooser.FILES_ONLY);
     instance().setMultiSelectionEnabled(multiselect);
     instance().setDialogTitle(title);
-    return instance().showOpenDialog(Game.getScreenManager().getRenderComponent());
+    return instance().showOpenDialog((JFrame) Game.getScreenManager());
   }
 
   public static int showFileDialog(String description, boolean multiselect, String... extensions) {


### PR DESCRIPTION
Hello! :) 

I noticed this while experimenting with utiliti.
The utiliti window itself is was not centered on the monitor on startup. Also, all the filechooser dialogs
used for importing game files used the render component to position themselfes. However that was not the center of the utiliti window, but slighty above.
Now they will be centered wherever the utiliti window is located. I think that looks/feels a bit better.

All in all, very small change. What do you think?