### PR TITLE
Fix the Travis CI Build

### DIFF
--- a/src/de/gurkenlabs/litiengine/entities/Entity.java
+++ b/src/de/gurkenlabs/litiengine/entities/Entity.java
@@ -323,15 +323,17 @@ public abstract class Entity implements IEntity {
     if (!this.getTags().contains(tag)) {
       this.getTags().add(tag);
     }
-    if (Game.getEnvironment() == null) {
-      return;
+    if (Game.getEnvironment() != null) {
+      Game.getEnvironment().getEntitiesByTag().computeIfAbsent(tag, t -> new CopyOnWriteArrayList<>()).add(this);
     }
+    /*
     if (Game.getEnvironment().getEntitiesByTag().containsKey(tag)) {
       Game.getEnvironment().getEntitiesByTag().get(tag).add(this);
       return;
     }
     Game.getEnvironment().getEntitiesByTag().put(tag, new CopyOnWriteArrayList<>());
     Game.getEnvironment().getEntitiesByTag().get(tag).add(this);
+    */
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/ICustomPropertyProvider.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/ICustomPropertyProvider.java
@@ -320,22 +320,19 @@ public interface ICustomPropertyProvider {
   public <T extends Enum<T>> void setProperty(String name, T value);
 
   /**
-   * Sets the value for the custom property with the given name to the given string value.
+   * Enumerates the custom properties for this object.
    *
-   * @param name
-   *          the name of the custom property
-   * @param value
-   *          the new value
+   * @return a complete list of custom properties for this {@code ICustomPropertyProvider}
    */
   public List<Property> getCustomProperties();
 
   /**
-   * Sets the value for the custom property with the given name to the given string value.
+   * Sets all of the custom properties on this object to the provided values. Properties are added
+   * when they only exist in the provided properties, and deleted when they only exist in the current
+   * properties.
    *
-   * @param name
-   *          the name of the custom property
-   * @param value
-   *          the new value
+   * @param props
+   *          the new list of properties
    */
   public void setCustomProperties(List<Property> props);
 }


### PR DESCRIPTION
The problem with the build was a lack of atomicity in the map of entities by tag. Using the `computeIfAbsent` method adds the required atomicity. I also fixed some bad javadoc in the `ICustomPropertyProvider` interface.

This resolves #181.