### PR TITLE
Fix some things about the ICamera implementation

### DIFF
--- a/src/de/gurkenlabs/litiengine/graphics/Camera.java
+++ b/src/de/gurkenlabs/litiengine/graphics/Camera.java
@@ -271,7 +271,7 @@ public class Camera implements ICamera {
   // TODO: write a unit test for this
   protected Point2D clampToMap(Point2D focus) {
     if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null || !this.isClampToMap()) {
-      return focus;
+      return new Point2D.Double(focus.getX(), focus.getY());
     }
 
     final Dimension mapSize = Game.getEnvironment().getMap().getSizeInPixels();

--- a/src/de/gurkenlabs/litiengine/graphics/Camera.java
+++ b/src/de/gurkenlabs/litiengine/graphics/Camera.java
@@ -6,6 +6,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.function.DoubleConsumer;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.entities.IEntity;
@@ -13,8 +14,8 @@ import de.gurkenlabs.litiengine.graphics.animation.IAnimationController;
 import de.gurkenlabs.litiengine.util.MathUtilities;
 
 public class Camera implements ICamera {
-  private final List<Consumer<Float>> zoomChangedConsumer;
-  private final List<Consumer<Point2D>> focusChangedConsumer;
+  private final List<DoubleConsumer> zoomChangedConsumer = new CopyOnWriteArrayList<>();
+  private final List<Consumer<Point2D>> focusChangedConsumer = new CopyOnWriteArrayList<>();
   /**
    * Provides the center location for the viewport.
    */
@@ -50,10 +51,8 @@ public class Camera implements ICamera {
    * Instantiates a new camera.
    */
   public Camera() {
-    this.zoomChangedConsumer = new CopyOnWriteArrayList<>();
-    this.focusChangedConsumer = new CopyOnWriteArrayList<>();
-    this.focus = new Point2D.Double(0, 0);
-    this.viewPort = new Rectangle2D.Double(0, 0, 0, 0);
+    this.focus = new Point2D.Double();
+    this.viewPort = new Rectangle2D.Double();
     this.zoom = 1;
   }
 
@@ -127,7 +126,7 @@ public class Camera implements ICamera {
   }
 
   @Override
-  public void onZoomChanged(final Consumer<Float> zoomCons) {
+  public void onZoomChanged(final DoubleConsumer zoomCons) {
     this.zoomChangedConsumer.add(zoomCons);
   }
 
@@ -167,7 +166,7 @@ public class Camera implements ICamera {
   @Override
   public void setZoom(final float targetZoom, final int delay) {
     if (delay == 0) {
-      for (final Consumer<Float> cons : this.zoomChangedConsumer) {
+      for (final DoubleConsumer cons : this.zoomChangedConsumer) {
         cons.accept(targetZoom);
       }
 
@@ -204,7 +203,7 @@ public class Camera implements ICamera {
 
     if (this.targetZoom > 0) {
       if (Game.loop().getDeltaTime(this.zoomTick) >= this.zoomDelay) {
-        for (final Consumer<Float> cons : this.zoomChangedConsumer) {
+        for (final DoubleConsumer cons : this.zoomChangedConsumer) {
           cons.accept(this.zoom);
         }
 
@@ -216,7 +215,7 @@ public class Camera implements ICamera {
       } else {
 
         this.zoom += this.zoomStep;
-        for (final Consumer<Float> cons : this.zoomChangedConsumer) {
+        for (final DoubleConsumer cons : this.zoomChangedConsumer) {
           cons.accept(this.zoom);
         }
       }

--- a/src/de/gurkenlabs/litiengine/graphics/ICamera.java
+++ b/src/de/gurkenlabs/litiengine/graphics/ICamera.java
@@ -3,6 +3,7 @@ package de.gurkenlabs.litiengine.graphics;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.function.Consumer;
+import java.util.function.DoubleConsumer;
 
 import de.gurkenlabs.litiengine.IUpdateable;
 import de.gurkenlabs.litiengine.entities.IEntity;
@@ -86,7 +87,7 @@ public interface ICamera extends IUpdateable {
 
   public float getZoom();
 
-  public void onZoomChanged(Consumer<Float> zoomCons);
+  public void onZoomChanged(DoubleConsumer zoomCons);
 
   public void onFocusChanged(Consumer<Point2D> focusCons);
 

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -136,7 +136,7 @@ public class Program {
     JOptionPane.setDefaultLocale(Locale.getDefault());
 
     userPreferences = Game.config().getConfigurationGroup("user_", UserPreferenceConfiguration.class);
-    Game.getCamera().onZoomChanged(zoom -> userPreferences.setZoom(zoom));
+    Game.getCamera().onZoomChanged(zoom -> userPreferences.setZoom((float)zoom));
 
     Game.screens().display(EditorScreen.instance());
 


### PR DESCRIPTION
The main reason this is a pull request is because it may cause errors in existing projects.

There isn't a `FloatConsumer` class, but a `DoubleConsumer` is still faster than a `Consumer<Float>` because it avoids boxing and unboxing the primitive `float`s.