### PR TITLE
Implement the "Environment manager"

### DIFF
--- a/src/de/gurkenlabs/litiengine/Game.java
+++ b/src/de/gurkenlabs/litiengine/Game.java
@@ -89,7 +89,7 @@ public final class Game {
   private static final RenderEngine graphicsEngine;
   private static final SoundEngine soundEngine;
   private static final IPhysicsEngine physicsEngine;
-  
+
   private static final GameConfiguration configuration;
   private static final GameMetrics metrics;
   private static final GameTime gameTime;
@@ -559,6 +559,8 @@ public final class Game {
     gameLoop.terminate();
 
     soundEngine.terminate();
+
+    world().clear();
     if (!isInNoGUIMode()) {
       renderLoop.terminate();
     }

--- a/src/de/gurkenlabs/litiengine/Game.java
+++ b/src/de/gurkenlabs/litiengine/Game.java
@@ -400,7 +400,8 @@ public final class Game {
    * @return The game's screen manager.
    * 
    * @see Screen
-   * @see Game#environment()
+   * @see GameWorld#environment()
+   * @see Game#world()
    */
   public static IScreenManager screens() {
     return screenManager;

--- a/src/de/gurkenlabs/litiengine/Game.java
+++ b/src/de/gurkenlabs/litiengine/Game.java
@@ -448,6 +448,7 @@ public final class Game {
     gameLoop = new GameLoop("Main Update Loop", config().client().getUpdaterate());
     gameLoop.attach(physics());
     gameLoop.attach(metrics());
+    gameLoop.attach(world());
 
     final ScreenManager scrMgr = new ScreenManager(info().getTitle());
 

--- a/src/de/gurkenlabs/litiengine/Game.java
+++ b/src/de/gurkenlabs/litiengine/Game.java
@@ -86,11 +86,11 @@ public final class Game {
   private static final List<GameListener> gameListeners;
   private static final List<GameTerminatedListener> gameTerminatedListeners;
 
-  private static final GameConfiguration configuration;
   private static final RenderEngine graphicsEngine;
   private static final SoundEngine soundEngine;
   private static final IPhysicsEngine physicsEngine;
-
+  
+  private static final GameConfiguration configuration;
   private static final GameMetrics metrics;
   private static final GameTime gameTime;
   private static GameInfo gameInfo;

--- a/src/de/gurkenlabs/litiengine/Game.java
+++ b/src/de/gurkenlabs/litiengine/Game.java
@@ -407,6 +407,28 @@ public final class Game {
     return screenManager;
   }
 
+  /**
+   * Gets the game's world which is a global environment manager that contains all <code>Environments</code>
+   * and provides the currently active <code>Environment</code> and
+   * <code>Camera</code>.<br>
+   * <p>
+   * The <code>GameWorld</code> returns the same instance for a particular map/mapName until the
+   * <code>GameWorld.reset(String)</code> method is called.
+   * </p>
+   * 
+   * Moreover, it provides the possibility to attach game logic via <code>EnvironmentListeners</code> to different events of the
+   * <code>Envrionment's</code> life cycle (e.g. loaded, initialized, ...).<br>
+   * <i>This is typically used to provide some per-level logic or to trigger
+   * general loading behavior.</i>
+   * 
+   * @return The game's environment manager.
+   * 
+   * @see GameWorld
+   * @see Environment
+   * @see Camera
+   * @see GameWorld#environment()
+   * @see GameWorld#camera()
+   */
   public static GameWorld world() {
     return world;
   }

--- a/src/de/gurkenlabs/litiengine/GameTime.java
+++ b/src/de/gurkenlabs/litiengine/GameTime.java
@@ -1,6 +1,10 @@
 package de.gurkenlabs.litiengine;
 
-public class GameTime {
+import de.gurkenlabs.litiengine.environment.EnvironmentLoadedListener;
+import de.gurkenlabs.litiengine.environment.IEnvironment;
+
+public final class GameTime implements EnvironmentLoadedListener {
+  private long environmentLoaded;
 
   protected GameTime() {
   }
@@ -10,6 +14,11 @@ public class GameTime {
   }
 
   public long sinceEnvironmentLoad() {
-    return Game.loop().convertToMs(Game.loop().getTicks() - Game.environmentLoadTick);
+    return Game.loop().convertToMs(Game.loop().getTicks() - this.environmentLoaded);
+  }
+
+  @Override
+  public void environmentLoaded(IEnvironment environment) {
+    environmentLoaded = Game.loop().getTicks();
   }
 }

--- a/src/de/gurkenlabs/litiengine/GameTime.java
+++ b/src/de/gurkenlabs/litiengine/GameTime.java
@@ -18,7 +18,7 @@ public final class GameTime implements EnvironmentLoadedListener {
   }
 
   @Override
-  public void environmentLoaded(IEnvironment environment) {
+  public void loaded(IEnvironment environment) {
     environmentLoaded = Game.loop().getTicks();
   }
 }

--- a/src/de/gurkenlabs/litiengine/RenderLoop.java
+++ b/src/de/gurkenlabs/litiengine/RenderLoop.java
@@ -17,7 +17,7 @@ public class RenderLoop extends UpdateLoop {
       final long fpsWait = (long) (1000.0 / this.maxFps);
       final long renderStart = System.nanoTime();
       try {
-        Game.getCamera().updateFocus();
+        Game.world().camera().updateFocus();
         this.update();
 
         Game.window().getRenderComponent().render();

--- a/src/de/gurkenlabs/litiengine/abilities/effects/Effect.java
+++ b/src/de/gurkenlabs/litiengine/abilities/effects/Effect.java
@@ -201,7 +201,7 @@ public abstract class Effect implements IEffect {
   }
 
   protected Collection<ICombatEntity> getEntitiesInImpactArea(final Shape impactArea) {
-    return Game.getEnvironment().findCombatEntities(impactArea);
+    return Game.world().environment().findCombatEntities(impactArea);
   }
 
   protected long getTotalDuration() {

--- a/src/de/gurkenlabs/litiengine/entities/Entity.java
+++ b/src/de/gurkenlabs/litiengine/entities/Entity.java
@@ -323,20 +323,20 @@ public abstract class Entity implements IEntity {
     if (!this.getTags().contains(tag)) {
       this.getTags().add(tag);
     }
-    if (Game.getEnvironment() != null) {
-      Game.getEnvironment().getEntitiesByTag().computeIfAbsent(tag, t -> new CopyOnWriteArrayList<>()).add(this);
+    if (Game.world().environment() != null) {
+      Game.world().environment().getEntitiesByTag().computeIfAbsent(tag, t -> new CopyOnWriteArrayList<>()).add(this);
     }
   }
 
   @Override
   public void removeTag(String tag) {
     this.getTags().remove(tag);
-    if (Game.getEnvironment() == null) {
+    if (Game.world().environment() == null) {
       return;
     }
-    Game.getEnvironment().getEntitiesByTag().get(tag).remove(this);
-    if (Game.getEnvironment().getEntitiesByTag().get(tag).isEmpty()) {
-      Game.getEnvironment().getEntitiesByTag().remove(tag);
+    Game.world().environment().getEntitiesByTag().get(tag).remove(this);
+    if (Game.world().environment().getEntitiesByTag().get(tag).isEmpty()) {
+      Game.world().environment().getEntitiesByTag().remove(tag);
     }
   }
 

--- a/src/de/gurkenlabs/litiengine/entities/Entity.java
+++ b/src/de/gurkenlabs/litiengine/entities/Entity.java
@@ -11,6 +11,7 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.annotation.EntityInfo;
 import de.gurkenlabs.litiengine.annotation.Tag;
 import de.gurkenlabs.litiengine.entities.ai.IBehaviorController;
+import de.gurkenlabs.litiengine.environment.IEnvironment;
 import de.gurkenlabs.litiengine.environment.tilemap.ICustomPropertyProvider;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.TmxProperty;
@@ -32,6 +33,8 @@ public abstract class Entity implements IEntity {
   private final EntityControllers controllers;
 
   private ICustomPropertyProvider properties;
+
+  private IEnvironment environment;
 
   private float angle;
 
@@ -359,17 +362,27 @@ public abstract class Entity implements IEntity {
   }
 
   @Override
-  public void loaded() {
+  public IEnvironment getEnvironment() {
+    return this.environment;
+  }
+
+  @Override
+  public void loaded(IEnvironment environment) {
+    this.environment = environment;
+    
     for (EntityListener listener : this.listeners) {
-      listener.loaded(this);
+      listener.loaded(this, this.getEnvironment());
     }
   }
 
   @Override
-  public void removed() {
+  public void removed(IEnvironment environment) {
     for (EntityListener listener : this.listeners) {
-      listener.removed(this);
+      listener.removed(this, this.getEnvironment());
     }
+
+    // set to null after informing the listeners so they can still access the environment instance
+    this.environment = null;
   }
 
   protected EntityControllers getControllers() {

--- a/src/de/gurkenlabs/litiengine/entities/EntityAdapter.java
+++ b/src/de/gurkenlabs/litiengine/entities/EntityAdapter.java
@@ -1,5 +1,7 @@
 package de.gurkenlabs.litiengine.entities;
 
+import de.gurkenlabs.litiengine.environment.IEnvironment;
+
 /**
  * An abstract implementation of a <code>EntityListener</code> that allows to only overwrite
  * individual callbacks in anonymous implementations.
@@ -9,10 +11,10 @@ package de.gurkenlabs.litiengine.entities;
 public abstract class EntityAdapter implements EntityListener {
 
   @Override
-  public void loaded(IEntity entity) {
+  public void loaded(IEntity entity, IEnvironment environment) {
   }
 
   @Override
-  public void removed(IEntity entity) {
+  public void removed(IEntity entity, IEnvironment environment) {
   }
 }

--- a/src/de/gurkenlabs/litiengine/entities/EntityListener.java
+++ b/src/de/gurkenlabs/litiengine/entities/EntityListener.java
@@ -2,9 +2,11 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
+import de.gurkenlabs.litiengine.environment.IEnvironment;
+
 public interface EntityListener extends EventListener {
 
-  public void loaded(IEntity entity);
+  public void loaded(IEntity entity, IEnvironment environment);
 
-  public void removed(IEntity entity);
+  public void removed(IEntity entity, IEnvironment environment);
 }

--- a/src/de/gurkenlabs/litiengine/entities/IEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/IEntity.java
@@ -5,6 +5,7 @@ import java.awt.geom.Rectangle2D;
 import java.util.List;
 
 import de.gurkenlabs.litiengine.entities.ai.IBehaviorController;
+import de.gurkenlabs.litiengine.environment.IEnvironment;
 import de.gurkenlabs.litiengine.environment.tilemap.ICustomPropertyProvider;
 import de.gurkenlabs.litiengine.graphics.RenderType;
 import de.gurkenlabs.litiengine.graphics.animation.IEntityAnimationController;
@@ -111,16 +112,23 @@ public interface IEntity {
   public ICustomPropertyProvider getProperties();
 
   /**
+   * Gets the environment the entity was loaded to or null if it is not loaded.
+   * 
+   * @return The entity's environment.
+   */
+  public IEnvironment getEnvironment();
+
+  /**
    * This method provides the possibility to implement behavior whenever this entity was added to the environment.
    * 
    * @see IEntity#addListener(EntityListener)
    */
-  public void loaded();
+  public void loaded(IEnvironment environment);
 
   /**
    * This method provides the possibility to implement behavior whenever this entity was removed from the environment.
    * 
    * @see IEntity#addListener(EntityListener)
    */
-  public void removed();
+  public void removed(IEnvironment environment);
 }

--- a/src/de/gurkenlabs/litiengine/entities/LightSource.java
+++ b/src/de/gurkenlabs/litiengine/entities/LightSource.java
@@ -228,7 +228,7 @@ public class LightSource extends Entity implements IRenderable {
     final float ry = (float) bounds.getHeight() / 2f;
 
     // get relative center of entity
-    final Point2D relativeCenter = Game.getCamera().getViewportLocation(new Point((int) (bounds.getX() + r), (int) (bounds.getY() + ry)));
+    final Point2D relativeCenter = Game.world().camera().getViewportLocation(new Point((int) (bounds.getX() + r), (int) (bounds.getY() + ry)));
     final double cx = relativeCenter.getX();
     final double cy = relativeCenter.getY();
 
@@ -267,7 +267,7 @@ public class LightSource extends Entity implements IRenderable {
     shadowPolygon.addPoint((int) pointD.getX(), (int) pointD.getY());
     shadowPolygon.addPoint((int) pointC.getX(), (int) pointC.getY());
 
-    final Point2D shadowRenderLocation = Game.getCamera().getViewportLocation(new Point2D.Double(shadowEllipse.getX(), shadowEllipse.getY()));
+    final Point2D shadowRenderLocation = Game.world().camera().getViewportLocation(new Point2D.Double(shadowEllipse.getX(), shadowEllipse.getY()));
     final Ellipse2D relativeEllipse = new Ellipse2D.Double(shadowRenderLocation.getX(), shadowRenderLocation.getY(), shadowEllipse.getWidth(), shadowEllipse.getHeight());
 
     final Area ellipseArea = new Area(relativeEllipse);
@@ -305,24 +305,24 @@ public class LightSource extends Entity implements IRenderable {
    *          the center
    */
   private void renderShadows(final Graphics2D g) {
-    if (!Game.getEnvironment().getCombatEntities().stream().anyMatch(isInRange(this.getCenter(), SHADOW_GRADIENT_SIZE))) {
+    if (!Game.world().environment().getCombatEntities().stream().anyMatch(isInRange(this.getCenter(), SHADOW_GRADIENT_SIZE))) {
       return;
     }
 
     // we'll use a radial gradient
-    final Paint gradientPaint = new RadialGradientPaint(Game.getCamera().getViewportDimensionCenter(this), SHADOW_GRADIENT_SIZE, SHADOW_GRADIENT_FRACTIONS, SHADOW_GRADIENT_COLORS);
+    final Paint gradientPaint = new RadialGradientPaint(Game.world().camera().getViewportDimensionCenter(this), SHADOW_GRADIENT_SIZE, SHADOW_GRADIENT_FRACTIONS, SHADOW_GRADIENT_COLORS);
 
     // old Paint object for resetting it later
     final Paint oldPaint = g.getPaint();
     g.setPaint(gradientPaint);
 
     // for each entity
-    for (final ICombatEntity mob : Game.getEnvironment().getCombatEntities()) {
+    for (final ICombatEntity mob : Game.world().environment().getCombatEntities()) {
       if (mob.isDead() || !isInRange(this.getCenter(), SHADOW_GRADIENT_SIZE).test(mob)) {
         continue;
       }
 
-      final Shape obstructedVision = this.getObstructedVisionArea(mob, Game.getCamera().getViewportDimensionCenter(this));
+      final Shape obstructedVision = this.getObstructedVisionArea(mob, Game.world().camera().getViewportDimensionCenter(this));
       // fill the polygon with the gradient paint
 
       ShapeRenderer.render(g, obstructedVision);
@@ -337,12 +337,12 @@ public class LightSource extends Entity implements IRenderable {
   }
 
   private void updateAmbientLayers() {
-    if (Game.getEnvironment() != null && Game.getEnvironment().getAmbientLight() != null) {
-      Game.getEnvironment().getAmbientLight().updateSection(this.getBoundingBox());
+    if (Game.world().environment() != null && Game.world().environment().getAmbientLight() != null) {
+      Game.world().environment().getAmbientLight().updateSection(this.getBoundingBox());
     }
 
-    if (Game.getEnvironment() != null && Game.getEnvironment().getStaticShadowLayer() != null) {
-      Game.getEnvironment().getStaticShadowLayer().updateSection(this.getBoundingBox());
+    if (Game.world().environment() != null && Game.world().environment().getStaticShadowLayer() != null) {
+      Game.world().environment().getStaticShadowLayer().updateSection(this.getBoundingBox());
     }
   }
 

--- a/src/de/gurkenlabs/litiengine/entities/Prop.java
+++ b/src/de/gurkenlabs/litiengine/entities/Prop.java
@@ -167,7 +167,7 @@ public class Prop extends CombatEntity {
   private void updateAnimationController() {
     PropAnimationController<Prop> controller = new PropAnimationController<>(this);
     this.getControllers().addController(controller);
-    if (Game.getEnvironment() != null && Game.getEnvironment().isLoaded()) {
+    if (Game.world().environment() != null && Game.world().environment().isLoaded()) {
       Game.loop().attach(controller);
     }
   }

--- a/src/de/gurkenlabs/litiengine/entities/Trigger.java
+++ b/src/de/gurkenlabs/litiengine/entities/Trigger.java
@@ -222,7 +222,7 @@ public class Trigger extends CollisionEntity implements IUpdateable {
 
   @Override
   public void update() {
-    if (Game.getEnvironment() == null || this.activationType != TriggerActivation.COLLISION) {
+    if (Game.world().environment() == null || this.activationType != TriggerActivation.COLLISION) {
       return;
     }
 
@@ -276,7 +276,7 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     // if we actually have a trigger target, we send the message to the target
     if (!triggerTargets.isEmpty()) {
       for (final int target : triggerTargets) {
-        final IEntity entity = Game.getEnvironment().get(target);
+        final IEntity entity = Game.world().environment().get(target);
         if (entity == null) {
           log.log(Level.WARNING, "trigger [{0}] was activated, but the trigger target [{1}] could not be found on the environment", new Object[] { this.getName(), target });
           continue;
@@ -293,7 +293,7 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     }
 
     if (this.isOneTimeTrigger && this.isActivated) {
-      Game.getEnvironment().remove(this);
+      Game.world().environment().remove(this);
     }
 
     this.lastActivation = Game.loop().getTicks();

--- a/src/de/gurkenlabs/litiengine/environment/EntitySpawner.java
+++ b/src/de/gurkenlabs/litiengine/environment/EntitySpawner.java
@@ -36,12 +36,12 @@ public abstract class EntitySpawner<T extends IEntity> implements IEntitySpawner
    */
   public EntitySpawner(final IEnvironment environment, final IGameLoop loop, final List<Spawnpoint> spawnpoints, final int interval, final int amount) {
     this.environment = environment;
-    Game.addEnvironmentUnloadedListener(e -> {
+    Game.world().addUnloadedListener(e -> {
       if (e == this.environment) {
         loop.detach(this);
       }
     });
-    Game.addEnvironmentLoadedListener(e -> {
+    Game.world().addLoadedListener(e -> {
       if (e == this.environment) {
         loop.attach(this);
       }

--- a/src/de/gurkenlabs/litiengine/environment/Environment.java
+++ b/src/de/gurkenlabs/litiengine/environment/Environment.java
@@ -1159,6 +1159,11 @@ public class Environment implements IEnvironment {
    * @param entity
    */
   private void load(final IEntity entity) {
+    // an entity can only exist on one environment at a time, so remove it from the current one
+    if (entity.getEnvironment() != null) {
+      entity.getEnvironment().remove(entity);
+    }
+    
     // 1. add to physics engine
     this.loadPhysicsEntity(entity);
 
@@ -1172,7 +1177,7 @@ public class Environment implements IEnvironment {
       this.updateColorLayers(entity);
     }
 
-    entity.loaded();
+    entity.loaded(this);
   }
 
   private void loadPhysicsEntity(IEntity entity) {
@@ -1253,6 +1258,6 @@ public class Environment implements IEnvironment {
       em.deactivate();
     }
 
-    entity.removed();
+    entity.removed(this);
   }
 }

--- a/src/de/gurkenlabs/litiengine/environment/Environment.java
+++ b/src/de/gurkenlabs/litiengine/environment/Environment.java
@@ -89,7 +89,6 @@ public class Environment implements IEnvironment {
   private boolean initialized;
   private IMap map;
   private int localIdSequence = 0;
-  private String identifier;
 
   static {
     registerMapObjectLoader(new PropMapObjectLoader());
@@ -109,8 +108,6 @@ public class Environment implements IEnvironment {
     if (this.getMap() != null) {
       Game.physics().setBounds(this.getMap().getBounds());
     }
-
-    this.identifier = getEnvironmentIdentifier(this.getMap());
   }
 
   public Environment(final String mapPath) {
@@ -119,8 +116,6 @@ public class Environment implements IEnvironment {
     if (this.getMap() != null) {
       Game.physics().setBounds(this.getMap().getBounds());
     }
-
-    this.identifier = getEnvironmentIdentifier(this.getMap());
   }
 
   private Environment() {
@@ -740,11 +735,6 @@ public class Environment implements IEnvironment {
   }
 
   @Override
-  public String identifier() {
-    return this.identifier;
-  }
-
-  @Override
   public void load() {
     this.init();
     if (this.loaded) {
@@ -1086,16 +1076,6 @@ public class Environment implements IEnvironment {
       }
     }
     return null;
-  }
-
-  private static String getEnvironmentIdentifier(IMap map) {
-    StringBuilder sb = new StringBuilder("env: ");
-    if (map != null && map.getName() != null) {
-      sb.append(map.getName().toLowerCase() + " ");
-    }
-
-    sb.append("#" + ++environmentIdSequence);
-    return sb.toString();
   }
 
   private String render(Graphics2D g, RenderType renderType) {

--- a/src/de/gurkenlabs/litiengine/environment/Environment.java
+++ b/src/de/gurkenlabs/litiengine/environment/Environment.java
@@ -317,7 +317,7 @@ public class Environment implements IEnvironment {
 
     this.initialized = false;
 
-    this.fireEvent(l -> l.environmentCleared(this));
+    this.fireEvent(l -> l.cleared(this));
   }
 
   @Override
@@ -732,7 +732,7 @@ public class Environment implements IEnvironment {
       this.addAmbientLight();
     }
 
-    this.fireEvent(l -> l.environmentInitialized(this));
+    this.fireEvent(l -> l.initialized(this));
     this.initialized = true;
   }
 
@@ -770,7 +770,7 @@ public class Environment implements IEnvironment {
     }
 
     this.loaded = true;
-    this.fireEvent(l -> l.environmentLoaded(this));
+    this.fireEvent(l -> l.loaded(this));
   }
 
   @Override
@@ -1042,7 +1042,7 @@ public class Environment implements IEnvironment {
     }
 
     this.loaded = false;
-    this.fireEvent(l -> l.environmentUnloaded(this));
+    this.fireEvent(l -> l.unloaded(this));
   }
 
   @Override
@@ -1093,7 +1093,7 @@ public class Environment implements IEnvironment {
   private static String getEnvironmentIdentifier(IMap map) {
     StringBuilder sb = new StringBuilder("env: ");
     if (map != null && map.getName() != null) {
-      sb.append(map.getName() + " ");
+      sb.append(map.getName().toLowerCase() + " ");
     }
 
     sb.append("#" + ++environmentIdSequence);

--- a/src/de/gurkenlabs/litiengine/environment/EnvironmentAdapter.java
+++ b/src/de/gurkenlabs/litiengine/environment/EnvironmentAdapter.java
@@ -9,18 +9,18 @@ package de.gurkenlabs.litiengine.environment;
 public abstract class EnvironmentAdapter implements EnvironmentListener {
 
   @Override
-  public void environmentLoaded(IEnvironment environment) {
+  public void loaded(IEnvironment environment) {
   }
 
   @Override
-  public void environmentUnloaded(IEnvironment environment) {
+  public void unloaded(IEnvironment environment) {
   }
 
   @Override
-  public void environmentCleared(IEnvironment environment) {
+  public void cleared(IEnvironment environment) {
   }
 
   @Override
-  public void environmentInitialized(IEnvironment environment) {
+  public void initialized(IEnvironment environment) {
   }
 }

--- a/src/de/gurkenlabs/litiengine/environment/EnvironmentListener.java
+++ b/src/de/gurkenlabs/litiengine/environment/EnvironmentListener.java
@@ -8,14 +8,7 @@ package de.gurkenlabs.litiengine.environment;
  * @see IEnvironment#clear()
  * @see IEnvironment#init()
  */
-public interface EnvironmentListener extends EnvironmentLoadedListener {
-  /**
-   * This method was called after the environment was unloaded.
-   * 
-   * @param environment
-   *          The environment that was unloaded.
-   */
-  public void environmentUnloaded(IEnvironment environment);
+public interface EnvironmentListener extends EnvironmentLoadedListener, EnvironmentUnloadedListener {
 
   /**
    * This method was called after the environment was cleared.
@@ -23,7 +16,7 @@ public interface EnvironmentListener extends EnvironmentLoadedListener {
    * @param environment
    *          The environment that was cleared.
    */
-  public void environmentCleared(IEnvironment environment);
+  public void cleared(IEnvironment environment);
 
   /**
    * This method was called after the environment was initialized.
@@ -31,5 +24,5 @@ public interface EnvironmentListener extends EnvironmentLoadedListener {
    * @param environment
    *          The environment that was initialized.
    */
-  public void environmentInitialized(IEnvironment environment);
+  public void initialized(IEnvironment environment);
 }

--- a/src/de/gurkenlabs/litiengine/environment/EnvironmentLoadedListener.java
+++ b/src/de/gurkenlabs/litiengine/environment/EnvironmentLoadedListener.java
@@ -15,5 +15,5 @@ public interface EnvironmentLoadedListener extends EventListener {
    * @param environment
    *          The environment that was loaded.
    */
-  public void environmentLoaded(IEnvironment environment);
+  public void loaded(IEnvironment environment);
 }

--- a/src/de/gurkenlabs/litiengine/environment/EnvironmentUnloadedListener.java
+++ b/src/de/gurkenlabs/litiengine/environment/EnvironmentUnloadedListener.java
@@ -15,5 +15,5 @@ public interface EnvironmentUnloadedListener extends EventListener {
    * @param environment
    *          The environment that was loaded.
    */
-  public void environmentUnloaded(IEnvironment environment);
+  public void unloaded(IEnvironment environment);
 }

--- a/src/de/gurkenlabs/litiengine/environment/GameWorld.java
+++ b/src/de/gurkenlabs/litiengine/environment/GameWorld.java
@@ -1,0 +1,75 @@
+package de.gurkenlabs.litiengine.environment;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.graphics.ICamera;
+
+public final class GameWorld {
+  private final List<EnvironmentLoadedListener> loadedListeners = new CopyOnWriteArrayList<>();
+  private final List<EnvironmentUnloadedListener> unloadedListeners = new CopyOnWriteArrayList<>();
+
+  private IEnvironment environment;
+  private ICamera camera;
+
+  public void addLoadedListener(EnvironmentLoadedListener listener) {
+    this.loadedListeners.add(listener);
+  }
+
+  public void removeLoadedListener(EnvironmentLoadedListener listener) {
+    this.loadedListeners.remove(listener);
+  }
+
+  public void addUnloadedListener(EnvironmentUnloadedListener listener) {
+    this.unloadedListeners.add(listener);
+  }
+
+  public void removeUnloadedListener(EnvironmentUnloadedListener listener) {
+    this.unloadedListeners.remove(listener);
+  }
+
+  public ICamera camera() {
+    return this.camera;
+  }
+
+  public IEnvironment environment() {
+    return this.environment;
+  }
+
+  public void loadEnvironment(final IEnvironment env) {
+    unloadEnvironment();
+
+    environment = env;
+    if (this.environment() != null) {
+      this.environment().load();
+    }
+
+    for (final EnvironmentLoadedListener listener : loadedListeners) {
+      listener.environmentLoaded(environment());
+    }
+  }
+
+  public void unloadEnvironment() {
+    if (this.environment() != null) {
+      this.environment().unload();
+
+      for (final EnvironmentUnloadedListener listener : unloadedListeners) {
+        listener.environmentUnloaded(this.environment());
+      }
+    }
+  }
+
+  public void setCamera(final ICamera cam) {
+    if (this.camera() != null) {
+      Game.loop().detach(camera);
+    }
+
+    camera = cam;
+
+    if (!Game.isInNoGUIMode()) {
+      Game.loop().attach(cam);
+      this.camera().updateFocus();
+    }
+  }
+}

--- a/src/de/gurkenlabs/litiengine/environment/GameWorld.java
+++ b/src/de/gurkenlabs/litiengine/environment/GameWorld.java
@@ -1,14 +1,23 @@
 package de.gurkenlabs.litiengine.environment;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.graphics.ICamera;
+import de.gurkenlabs.litiengine.resources.Resources;
 
 public final class GameWorld {
   private final List<EnvironmentLoadedListener> loadedListeners = new CopyOnWriteArrayList<>();
   private final List<EnvironmentUnloadedListener> unloadedListeners = new CopyOnWriteArrayList<>();
+  private final Map<String, Collection<EnvironmentListener>> environmentListeners = new ConcurrentHashMap<>();
+  
+  private final Map<String, IEnvironment> environments = new ConcurrentHashMap<>();
 
   private IEnvironment environment;
   private ICamera camera;
@@ -29,6 +38,32 @@ public final class GameWorld {
     this.unloadedListeners.remove(listener);
   }
 
+  public void addListener(String mapName, EnvironmentListener listener) {
+    if (mapName == null || mapName.isEmpty()) {
+      return;
+    }
+
+    String mapIdentifier = mapName.toLowerCase();
+    if (!this.environmentListeners.containsKey(mapIdentifier)) {
+      this.environmentListeners.put(mapIdentifier, Collections.synchronizedCollection(ConcurrentHashMap.newKeySet()));
+    }
+
+    this.environmentListeners.get(mapIdentifier).add(listener);
+  }
+
+  public void removeListener(String mapName, EnvironmentListener listener) {
+    if (mapName == null || mapName.isEmpty()) {
+      return;
+    }
+
+    String mapIdentifier = mapName.toLowerCase();
+    if (!this.environmentListeners.containsKey(mapIdentifier)) {
+      return;
+    }
+
+    this.environmentListeners.get(mapIdentifier).remove(listener);
+  }
+
   public ICamera camera() {
     return this.camera;
   }
@@ -37,16 +72,89 @@ public final class GameWorld {
     return this.environment;
   }
 
+  public Collection<IEnvironment> getEnvironments() {
+    return this.environments.values();
+  }
+
+  public IEnvironment getEnvironment(String environmentIdentifier) {
+    if (environmentIdentifier == null || environmentIdentifier.isEmpty()) {
+      return null;
+    }
+
+    return this.getEnvironments().stream().filter(e -> e.identifier().equals(environmentIdentifier)).findFirst().orElse(null);
+  }
+
+  public IEnvironment getEnvironmentByMapName(String mapName) {
+    if (mapName == null || mapName.isEmpty()) {
+      return null;
+    }
+
+    IMap map = Resources.maps().get(mapName);
+    return this.getEnvironment(map);
+  }
+
+  public IEnvironment getEnvironment(IMap map) {
+    if (map == null || map.getName() == null || map.getName().isEmpty()) {
+      return null;
+    }
+
+    IEnvironment env = this.getEnvironments().stream().filter(e -> e.getMap().equals(map)).findFirst().orElse(null);
+    if (env != null) {
+      return env;
+    }
+
+    env = new Environment(map);
+    this.addEnvironment(env);
+
+    return env;
+  }
+
+  public boolean containsEnvironment(String identifier) {
+    return this.getEnvironment(identifier) != null;
+  }
+
   public void loadEnvironment(final IEnvironment env) {
     unloadEnvironment();
 
-    environment = env;
-    if (this.environment() != null) {
-      this.environment().load();
+    if (env != null) {
+      this.addEnvironment(env);
+
+      env.load();
+      for (final EnvironmentLoadedListener listener : this.loadedListeners) {
+        listener.loaded(env);
+      }
     }
 
-    for (final EnvironmentLoadedListener listener : loadedListeners) {
-      listener.environmentLoaded(environment());
+    this.environment = env;
+  }
+
+  public IEnvironment loadEnvironmentByMapName(String mapName) {
+    IEnvironment env = this.getEnvironment(mapName);
+    this.loadEnvironment(env);
+    return env;
+  }
+
+  public IEnvironment loadEnvironment(IMap map) {
+    IEnvironment env = this.getEnvironment(map);
+    this.loadEnvironment(env);
+    return env;
+  }
+
+  private void addEnvironment(IEnvironment env) {
+    if (this.containsEnvironment(env.identifier())) {
+      return;
+    }
+
+    this.environments.put(env.identifier(), env);
+
+    // wire up all previously registered listeners
+    if (env.getMap() != null && env.getMap().getName() != null) {
+      String mapName = env.getMap().getName().toLowerCase();
+      if (this.environmentListeners.containsKey(mapName)) {
+        for (EnvironmentListener listener : this.environmentListeners.get(mapName)) {
+          env.addListener(listener);
+        }
+      }
     }
   }
 
@@ -54,10 +162,44 @@ public final class GameWorld {
     if (this.environment() != null) {
       this.environment().unload();
 
-      for (final EnvironmentUnloadedListener listener : unloadedListeners) {
-        listener.environmentUnloaded(this.environment());
+      for (final EnvironmentUnloadedListener listener : this.unloadedListeners) {
+        listener.unloaded(this.environment());
       }
     }
+
+    this.environment = null;
+  }
+
+  public IEnvironment reset(String mapName) {
+    if (mapName == null || mapName.isEmpty()) {
+      return null;
+    }
+
+    return this.getEnvironment(Resources.maps().get(mapName));
+  }
+
+  public IEnvironment reset(IMap map) {
+    if (map == null) {
+      return null;
+    }
+
+    IEnvironment env = this.getEnvironment(map);
+    if (env != null) {
+      this.environments.remove(env.identifier());
+
+      if (env.getMap() != null && env.getMap().getName() != null) {
+        
+        // unwire all registered listeners for this particular map
+        String mapName = map.getName().toLowerCase();
+        if (this.environmentListeners.containsKey(mapName)) {
+          for (EnvironmentListener listener : this.environmentListeners.get(mapName)) {
+            env.removeListener(listener);
+          }
+        }
+      }
+    }
+
+    return this.getEnvironment(map);
   }
 
   public void setCamera(final ICamera cam) {

--- a/src/de/gurkenlabs/litiengine/environment/GameWorld.java
+++ b/src/de/gurkenlabs/litiengine/environment/GameWorld.java
@@ -203,7 +203,7 @@ public final class GameWorld implements IUpdateable {
    */
   public void loadEnvironment(final IEnvironment env) {
     unloadEnvironment();
-
+    this.environment = env;
     if (env != null) {
       this.addEnvironment(env);
 
@@ -220,8 +220,6 @@ public final class GameWorld implements IUpdateable {
         }
       }
     }
-
-    this.environment = env;
   }
 
   /**

--- a/src/de/gurkenlabs/litiengine/environment/GameWorld.java
+++ b/src/de/gurkenlabs/litiengine/environment/GameWorld.java
@@ -68,6 +68,19 @@ public final class GameWorld {
     return this.camera;
   }
 
+  public void clear() {
+    this.unloadEnvironment();
+    this.environments.clear();
+    this.setCamera(null);
+
+    this.environmentListeners.clear();
+    this.environmentLoadedListeners.clear();
+    this.environmentUnloadedListeners.clear();
+
+    this.loadedListeners.clear();
+    this.unloadedListeners.clear();
+  }
+
   public IEnvironment environment() {
     return this.environment;
   }
@@ -123,6 +136,16 @@ public final class GameWorld {
       for (final EnvironmentLoadedListener listener : this.loadedListeners) {
         listener.loaded(env);
       }
+
+      // call map specific listeners
+      if (env.getMap() != null && env.getMap().getName() != null) {
+        String mapName = env.getMap().getName().toLowerCase();
+        if (this.environmentLoadedListeners.containsKey(mapName)) {
+          for (EnvironmentLoadedListener listener : this.environmentLoadedListeners.get(mapName)) {
+            listener.loaded(env);
+          }
+        }
+      }
     }
 
     this.environment = env;
@@ -164,6 +187,16 @@ public final class GameWorld {
 
       for (final EnvironmentUnloadedListener listener : this.unloadedListeners) {
         listener.unloaded(this.environment());
+      }
+
+      // call map specific listeners
+      if (this.environment().getMap() != null && this.environment().getMap().getName() != null) {
+        String mapName = this.environment().getMap().getName().toLowerCase();
+        if (this.environmentUnloadedListeners.containsKey(mapName)) {
+          for (EnvironmentUnloadedListener listener : this.environmentUnloadedListeners.get(mapName)) {
+            listener.unloaded(this.environment());
+          }
+        }
       }
     }
 

--- a/src/de/gurkenlabs/litiengine/environment/GameWorld.java
+++ b/src/de/gurkenlabs/litiengine/environment/GameWorld.java
@@ -32,12 +32,10 @@ public final class GameWorld implements IUpdateable {
       return;
     }
 
-    if (this.environment().getMap() != null && this.environment().getMap().getName() != null) {
-      String mapName = this.environment().getMap().getName().toLowerCase();
-      if (this.updatables.containsKey(mapName)) {
-        for (IUpdateable updatable : this.updatables.get(mapName)) {
-          updatable.update();
-        }
+    String mapName = getMapName(this.environment());
+    if (mapName != null && this.updatables.containsKey(mapName)) {
+      for (IUpdateable updatable : this.updatables.get(mapName)) {
+        updatable.update();
       }
     }
   }
@@ -46,7 +44,7 @@ public final class GameWorld implements IUpdateable {
     this.loadedListeners.add(listener);
   }
 
-  public void removeLoadedListener(EnvironmentLoadedListener listener) {
+  public void removeLoadedListener(EnvironmentLoadedListener listener) { 
     this.loadedListeners.remove(listener);
   }
 
@@ -90,10 +88,32 @@ public final class GameWorld implements IUpdateable {
     remove(this.updatables, mapName, updateable);
   }
 
+  /**
+   * Gets the game's current <code>Camera</code>.
+   * 
+   * @return The currently active camera.
+   * 
+   * @see ICamera
+   */
   public ICamera camera() {
     return this.camera;
   }
 
+  /**
+   * Gets the game's current <code>Environment</code>.
+   * 
+   * @return The currently active environment.
+   * 
+   * @see Environment
+   */
+  public IEnvironment environment() {
+    return this.environment;
+  }
+
+  /**
+   * Clears the currently active camera and environment, removes all previously loaded environments
+   * and clears all listener lists.
+   */
   public void clear() {
     this.unloadEnvironment();
     this.environments.clear();
@@ -107,14 +127,23 @@ public final class GameWorld implements IUpdateable {
     this.unloadedListeners.clear();
   }
 
-  public IEnvironment environment() {
-    return this.environment;
-  }
-
+  /**
+   * Gets all environments that are known to the game world.
+   * 
+   * @return All known environments.
+   */
   public Collection<IEnvironment> getEnvironments() {
     return this.environments.values();
   }
 
+  /**
+   * Gets the environment that's related to the specified mapName.<br>
+   * This method implicitly creates a new <code>Environment</code> if necessary.
+   * 
+   * @param mapName
+   *          The map name by which the environment is identified.
+   * @return The environment for the map name or null if no such map can be found.
+   */
   public IEnvironment getEnvironment(String mapName) {
     if (mapName == null || mapName.isEmpty()) {
       return null;
@@ -124,6 +153,14 @@ public final class GameWorld implements IUpdateable {
     return this.getEnvironment(map);
   }
 
+  /**
+   * Gets the environment that's related to the specified map.<br>
+   * This method implicitly creates a new <code>Environment</code> if necessary.
+   * 
+   * @param map
+   *          The map by which the environment is identified.
+   * @return The environment for the map or null if no such map can be found.
+   */
   public IEnvironment getEnvironment(IMap map) {
     if (map == null || map.getName() == null || map.getName().isEmpty()) {
       return null;
@@ -140,10 +177,30 @@ public final class GameWorld implements IUpdateable {
     return env;
   }
 
-  public boolean containsEnvironment(String identifier) {
-    return this.environments.containsKey(identifier.toLowerCase());
+  /**
+   * Indicates whether this instance already contains an <code>Environment</code> for the specified map name.
+   * 
+   * @param mapName
+   *          The map name by which the environment is identified.
+   * @return True if the game world already has an environment for the specified map name; otherwise false.
+   */
+  public boolean containsEnvironment(String mapName) {
+    return this.environments.containsKey(mapName.toLowerCase());
   }
 
+  /**
+   * Loads the specified <code>Environment</code> and sets it as current environment of the game.
+   * This implicitly unloads the previously loaded environment (if present).
+   * 
+   * <p>
+   * <i>The loaded environment can then be accessed via <code>GameWorld#environment()</code>.</i>
+   * </p>
+   * 
+   * @param env
+   *          The environment to be loaded.
+   * 
+   * @see GameWorld#environment()
+   */
   public void loadEnvironment(final IEnvironment env) {
     unloadEnvironment();
 
@@ -167,18 +224,51 @@ public final class GameWorld implements IUpdateable {
     this.environment = env;
   }
 
+  /**
+   * Loads the <code>Environment</code> that is identified by the specified map name and sets it as current environment of the game.
+   * This implicitly unloads the previously loaded environment (if present).
+   * 
+   * <p>
+   * <i>The loaded environment can then be accessed via <code>GameWorld#environment()</code>.</i>
+   * </p>
+   * 
+   * @param mapName
+   *          The map name by which the environment is identified.
+   * @return The loaded environment.
+   * 
+   * @see GameWorld#environment()
+   * @see GameWorld#loadEnvironment(IEnvironment)
+   */
   public IEnvironment loadEnvironment(String mapName) {
     IEnvironment env = this.getEnvironment(mapName);
     this.loadEnvironment(env);
     return env;
   }
 
+  /**
+   * Loads the <code>Environment</code> that is identified by the specified map and sets it as current environment of the game.
+   * This implicitly unloads the previously loaded environment (if present).
+   * 
+   * <p>
+   * <i>The loaded environment can then be accessed via <code>GameWorld#environment()</code>.</i>
+   * </p>
+   * 
+   * @param map
+   *          The map by which the environment is identified.
+   * @return The loaded environment.
+   * 
+   * @see GameWorld#environment()
+   * @see GameWorld#loadEnvironment(IEnvironment)
+   */
   public IEnvironment loadEnvironment(IMap map) {
     IEnvironment env = this.getEnvironment(map);
     this.loadEnvironment(env);
     return env;
   }
 
+  /**
+   * Unloads the current <code>Environment</code> and sets it to null.
+   */
   public void unloadEnvironment() {
     if (this.environment() != null) {
       this.environment().unload();
@@ -199,6 +289,21 @@ public final class GameWorld implements IUpdateable {
     this.environment = null;
   }
 
+  /**
+   * Resets the previously loaded <code>Environment</code> for the specified map name so that it can be re-initiated upon the next access.
+   * 
+   * <p>
+   * <i>This can be used if one wants to completely reset the state of a level to its initial state. It'll just throw away the current environment
+   * instance and reload a new one upon the next access.</i>
+   * </p>
+   * 
+   * @param mapName
+   *          The map name by which the environment is identified.
+   * @return The environment instance that was reset or null if none was previously loaded.
+   * 
+   * @see GameWorld#getEnvironment(String)
+   * @see GameWorld#reset(IMap)
+   */
   public IEnvironment reset(String mapName) {
     if (mapName == null || mapName.isEmpty()) {
       return null;
@@ -207,6 +312,21 @@ public final class GameWorld implements IUpdateable {
     return this.getEnvironment(Resources.maps().get(mapName));
   }
 
+  /**
+   * Resets the previously loaded <code>Environment</code> for the specified map so that it can be re-initiated upon the next access.
+   * 
+   * <p>
+   * <i>This can be used if one wants to completely reset the state of a level to its initial state. It'll just throw away the current environment
+   * instance and reload a new one upon the next access.</i>
+   * </p>
+   * 
+   * @param map
+   *          The map by which the environment is identified.
+   * @return The environment instance that was reset or null if none was previously loaded.
+   * 
+   * @see GameWorld#getEnvironment(String)
+   * @see GameWorld#reset(IMap)
+   */
   public IEnvironment reset(IMap map) {
     if (map == null) {
       return null;
@@ -227,9 +347,15 @@ public final class GameWorld implements IUpdateable {
       }
     }
 
-    return this.getEnvironment(map);
+    return env;
   }
 
+  /**
+   * Sets the active camera of the game.
+   * 
+   * @param cam
+   *          The new camera to be set.
+   */
   public void setCamera(final ICamera cam) {
     if (this.camera() != null) {
       Game.loop().detach(camera);

--- a/src/de/gurkenlabs/litiengine/environment/IEnvironment.java
+++ b/src/de/gurkenlabs/litiengine/environment/IEnvironment.java
@@ -195,7 +195,9 @@ public interface IEnvironment extends IInitializable, IRenderable {
   public Collection<Trigger> getTriggers();
 
   public Collection<IRenderable> getRenderables(RenderType renderType);
-
+  
+  public String identifier();
+  
   public boolean isLoaded();
 
   public void load();

--- a/src/de/gurkenlabs/litiengine/environment/IEnvironment.java
+++ b/src/de/gurkenlabs/litiengine/environment/IEnvironment.java
@@ -196,8 +196,6 @@ public interface IEnvironment extends IInitializable, IRenderable {
 
   public Collection<IRenderable> getRenderables(RenderType renderType);
   
-  public String identifier();
-  
   public boolean isLoaded();
 
   public void load();

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/MapUtilities.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/MapUtilities.java
@@ -53,11 +53,11 @@ public final class MapUtilities {
   }
 
   public static Point2D getCenterMapLocation() {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return new Point2D.Double();
     }
 
-    return getCenterMapLocation(Game.getEnvironment().getMap());
+    return getCenterMapLocation(Game.world().environment().getMap());
   }
 
   public static Point2D getCenterMapLocation(IMap map) {
@@ -65,11 +65,11 @@ public final class MapUtilities {
   }
 
   public static Rectangle2D getTileBoundingBox(final Point2D mapLocation) {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return new Rectangle2D.Double();
     }
 
-    return getTileBoundingBox(Game.getEnvironment().getMap(), mapLocation);
+    return getTileBoundingBox(Game.world().environment().getMap(), mapLocation);
   }
 
   public static Rectangle2D getTileBoundingBox(final IMap map, final Point2D mapLocation) {
@@ -82,10 +82,10 @@ public final class MapUtilities {
   }
 
   public static Rectangle2D getTileBoundingBox(final Point tile) {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return new Rectangle2D.Double();
     }
-    return getTileBoundingBox(Game.getEnvironment().getMap(), tile);
+    return getTileBoundingBox(Game.world().environment().getMap(), tile);
   }
 
   public static Rectangle2D getTileBoundingBox(final IMap map, final Point tile) {
@@ -109,10 +109,10 @@ public final class MapUtilities {
   }
 
   public static Point getTile(final Point2D mapLocation) {
-    if (Game.getEnvironment() == null) {
+    if (Game.world().environment() == null) {
       return new Point(-1, -1);
     }
-    return getTile(Game.getEnvironment().getMap(), mapLocation);
+    return getTile(Game.world().environment().getMap(), mapLocation);
   }
 
   public static Point getTile(final IMap map, final Point2D mapLocation) {
@@ -222,11 +222,11 @@ public final class MapUtilities {
   }
 
   public static ITile getTopMostTile(final Point2D location) {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return null;
     }
 
-    return getTopMostTile(Game.getEnvironment().getMap(), location);
+    return getTopMostTile(Game.world().environment().getMap(), location);
   }
 
   public static ITile getTopMostTile(final IMap map, final Point2D location) {
@@ -238,11 +238,11 @@ public final class MapUtilities {
   }
 
   public static ITile getTopMostTile(final Point point) {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return null;
     }
 
-    return getTopMostTile(Game.getEnvironment().getMap(), point);
+    return getTopMostTile(Game.world().environment().getMap(), point);
   }
 
   public static ITile getTopMostTile(final IMap map, final Point point) {

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
@@ -71,7 +71,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   public MapObject(MapObject mapObjectToBeCopied) {
     super(mapObjectToBeCopied);
     this.setName(mapObjectToBeCopied.getName());
-    this.setId(Game.getEnvironment().getNextMapId());
+    this.setId(Game.world().environment().getNextMapId());
     this.polyline = (mapObjectToBeCopied.getPolyline() != null && !mapObjectToBeCopied.getPolyline().getPoints().isEmpty()) ? new Polyline(mapObjectToBeCopied.getPolyline()) : null;
     this.setType(mapObjectToBeCopied.getType());
     this.setX(mapObjectToBeCopied.getX());

--- a/src/de/gurkenlabs/litiengine/graphics/Camera.java
+++ b/src/de/gurkenlabs/litiengine/graphics/Camera.java
@@ -195,7 +195,7 @@ public class Camera implements ICamera {
 
   @Override
   public void update() {
-    if (Game.getCamera() != null && !Game.getCamera().equals(this)) {
+    if (Game.world().camera() != null && !Game.world().camera().equals(this)) {
       return;
     }
 
@@ -253,11 +253,11 @@ public class Camera implements ICamera {
 
   // TODO: write a unit test for this
   protected Point2D clampToMap(Point2D focus) {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null || !this.isClampToMap()) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null || !this.isClampToMap()) {
       return focus;
     }
 
-    final Dimension mapSize = Game.getEnvironment().getMap().getSizeInPixels();
+    final Dimension mapSize = Game.world().environment().getMap().getSizeInPixels();
 
     // TODO: Implement special handling for maps that are smaller than the camera area: use Align, Valign to determine where to render them
     final Dimension resolution = Game.window().getResolution();

--- a/src/de/gurkenlabs/litiengine/graphics/ColorLayer.java
+++ b/src/de/gurkenlabs/litiengine/graphics/ColorLayer.java
@@ -35,7 +35,7 @@ public abstract class ColorLayer implements IRenderable {
 
   @Override
   public void render(Graphics2D g) {
-    final Rectangle2D viewport = Game.getCamera().getViewport();
+    final Rectangle2D viewport = Game.world().camera().getViewport();
 
     final IMap map = this.getEnvironment().getMap();
 

--- a/src/de/gurkenlabs/litiengine/graphics/DebugRenderer.java
+++ b/src/de/gurkenlabs/litiengine/graphics/DebugRenderer.java
@@ -80,7 +80,7 @@ public class DebugRenderer {
   public static void renderMapDebugInfo(final Graphics2D g, final IMap map) {
     // draw collision boxes from shape layer
     if (Game.config().debug().renderCollisionBoxes()) {
-      final BasicStroke shapeStroke = new BasicStroke(1 / Game.getCamera().getRenderScale());
+      final BasicStroke shapeStroke = new BasicStroke(1 / Game.world().camera().getRenderScale());
       for (final Rectangle2D shape : Game.physics().getStaticCollisionBoxes()) {
         g.setColor(Color.RED);
         Game.graphics().renderOutline(g, shape, shapeStroke);
@@ -109,8 +109,8 @@ public class DebugRenderer {
   private static void drawMapId(final Graphics2D g, final IEntity entity) {
     g.setColor(Color.RED);
     g.setFont(g.getFont().deriveFont(Font.PLAIN, 4f));
-    final int x = (int) Game.getCamera().getViewportDimensionCenter(entity).getX() + 10;
-    final int y = (int) Game.getCamera().getViewportDimensionCenter(entity).getY();
+    final int x = (int) Game.world().camera().getViewportDimensionCenter(entity).getX() + 10;
+    final int y = (int) Game.world().camera().getViewportDimensionCenter(entity).getY();
     TextRenderer.render(g, Integer.toString(entity.getMapId()), x, y);
     final String locationString = "[x:" + new DecimalFormat("##.##").format(entity.getX()) + ";y:" + new DecimalFormat("##.##").format(entity.getY()) + "]";
     TextRenderer.render(g, locationString, x, y + 5.0);
@@ -128,7 +128,7 @@ public class DebugRenderer {
     final String locationText = tileLocation.x + ", " + tileLocation.y;
     g.setFont(g.getFont().deriveFont(3f));
     final FontMetrics fm = g.getFontMetrics();
-    final Point2D relative = Game.getCamera().getViewportLocation(playerTile.getX(), playerTile.getY());
+    final Point2D relative = Game.world().camera().getViewportLocation(playerTile.getX(), playerTile.getY());
     TextRenderer.render(g, locationText, (float) (relative.getX() + playerTile.getWidth() + 3), (float) (relative.getY() + fm.getHeight()));
 
     final List<ITile> tiles = MapUtilities.getTilesByPixelLocation(map, location);

--- a/src/de/gurkenlabs/litiengine/graphics/FreeFlightCamera.java
+++ b/src/de/gurkenlabs/litiengine/graphics/FreeFlightCamera.java
@@ -52,7 +52,7 @@ public class FreeFlightCamera extends Camera implements IUpdateable {
   }
 
   private void handleFreeFlightCamera() {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return;
     }
 

--- a/src/de/gurkenlabs/litiengine/graphics/RenderEngine.java
+++ b/src/de/gurkenlabs/litiengine/graphics/RenderEngine.java
@@ -71,8 +71,8 @@ public final class RenderEngine {
     }
     g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
 
-    final Point2D viewPortLocation = Game.getCamera().getViewportLocation(x, y);
-    g.drawString(text, (float) viewPortLocation.getX() * Game.getCamera().getRenderScale(), (float) viewPortLocation.getY() * Game.getCamera().getRenderScale());
+    final Point2D viewPortLocation = Game.world().camera().getViewportLocation(x, y);
+    g.drawString(text, (float) viewPortLocation.getX() * Game.world().camera().getRenderScale(), (float) viewPortLocation.getY() * Game.world().camera().getRenderScale());
     g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, GuiProperties.getDefaultAppearance().getTextAntialiasing());
   }
 
@@ -85,11 +85,11 @@ public final class RenderEngine {
       return;
     }
 
-    ShapeRenderer.renderTransformed(g, shape, AffineTransform.getTranslateInstance(Game.getCamera().getPixelOffsetX(), Game.getCamera().getPixelOffsetY()));
+    ShapeRenderer.renderTransformed(g, shape, AffineTransform.getTranslateInstance(Game.world().camera().getPixelOffsetX(), Game.world().camera().getPixelOffsetY()));
   }
 
   public void renderOutline(final Graphics2D g, final Shape shape) {
-    renderOutline(g, shape, new BasicStroke(1 / Game.getCamera().getRenderScale()));
+    renderOutline(g, shape, new BasicStroke(1 / Game.world().camera().getRenderScale()));
   }
 
   public void renderOutline(final Graphics2D g, final Shape shape, final Stroke stroke) {
@@ -97,7 +97,7 @@ public final class RenderEngine {
       return;
     }
 
-    ShapeRenderer.renderOutlineTransformed(g, shape, AffineTransform.getTranslateInstance(Game.getCamera().getPixelOffsetX(), Game.getCamera().getPixelOffsetY()), stroke);
+    ShapeRenderer.renderOutlineTransformed(g, shape, AffineTransform.getTranslateInstance(Game.world().camera().getPixelOffsetX(), Game.world().camera().getPixelOffsetY()), stroke);
   }
 
   public boolean canRender(final IEntity entity) {
@@ -178,7 +178,7 @@ public final class RenderEngine {
     // in order to render the entities in a 2.5D manner, we sort them by their
     // max Y Coordinate
 
-    final List<? extends IEntity> entitiesToRender = entities.stream().filter(x -> Game.getCamera().getViewport().intersects(x.getBoundingBox())).collect(Collectors.toList());
+    final List<? extends IEntity> entitiesToRender = entities.stream().filter(x -> Game.world().camera().getViewport().intersects(x.getBoundingBox())).collect(Collectors.toList());
 
     if (sort) {
       // THIS COSTS THE MOST TIME OF THE RENDERING LOOP... MAYBE USE A
@@ -242,12 +242,12 @@ public final class RenderEngine {
       if (animationController instanceof IEntityAnimationController && ((IEntityAnimationController) animationController).isAutoScaling()) {
         final double ratioX = entity.getWidth() / img.getWidth();
         final double ratioY = entity.getHeight() / img.getHeight();
-        ImageRenderer.renderScaled(g, img, Game.getCamera().getViewportLocation(entity.getLocation()), ratioX, ratioY);
+        ImageRenderer.renderScaled(g, img, Game.world().camera().getViewportLocation(entity.getLocation()), ratioX, ratioY);
       } else {
         float deltaX = (entity.getWidth() - img.getWidth()) / 2.0f;
         float deltaY = (entity.getHeight() - img.getHeight()) / 2.0f;
 
-        ImageRenderer.renderTransformed(g, img, Game.getCamera().getViewportLocation(entity.getX() + deltaX, entity.getY() + deltaY), animationController.getAffineTransform());
+        ImageRenderer.renderTransformed(g, img, Game.world().camera().getViewportLocation(entity.getX() + deltaX, entity.getY() + deltaY), animationController.getAffineTransform());
       }
     }
 
@@ -268,7 +268,7 @@ public final class RenderEngine {
     }
 
     // draw layers
-    this.mapRenderer.get(map.getOrientation()).render(g, map, Game.getCamera().getViewport(), renderTypes);
+    this.mapRenderer.get(map.getOrientation()).render(g, map, Game.world().camera().getViewport(), renderTypes);
   }
 
   /**

--- a/src/de/gurkenlabs/litiengine/graphics/animation/EntityAnimationController.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/EntityAnimationController.java
@@ -71,7 +71,7 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
   public void update() {
     super.update();
 
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return;
     }
 
@@ -115,7 +115,7 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
 
   @Override
   public void scaleSprite(float scaleX, float scaleY) {
-    final Point2D point = Game.getCamera().getViewportLocation(this.getEntity());
+    final Point2D point = Game.world().camera().getViewportLocation(this.getEntity());
     double deltaX = (point.getX() - (point.getX() * scaleX));
     double deltaY = (point.getY() - (point.getY() * scaleY));
 

--- a/src/de/gurkenlabs/litiengine/graphics/emitters/Emitter.java
+++ b/src/de/gurkenlabs/litiengine/graphics/emitters/Emitter.java
@@ -146,8 +146,8 @@ public abstract class Emitter extends Entity implements IUpdateable, ITimeToLive
 
   public void delete() {
     this.deactivate();
-    if (Game.getEnvironment() != null) {
-      Game.getEnvironment().remove(this);
+    if (Game.world().environment() != null) {
+      Game.world().environment().remove(this);
     }
   }
 
@@ -497,7 +497,7 @@ public abstract class Emitter extends Entity implements IUpdateable, ITimeToLive
       return;
     }
 
-    if (Game.screens() != null && Game.getCamera() != null && !Game.getCamera().getViewport().intersects(this.getBoundingBox())) {
+    if (Game.screens() != null && Game.world().camera() != null && !Game.world().camera().getViewport().intersects(this.getBoundingBox())) {
       return;
     }
 

--- a/src/de/gurkenlabs/litiengine/graphics/emitters/particles/Particle.java
+++ b/src/de/gurkenlabs/litiengine/graphics/emitters/particles/Particle.java
@@ -140,7 +140,7 @@ public abstract class Particle implements ITimeToLive {
   public Point2D getRenderLocation(Point2D effectLocation) {
     // if we have a camera, we need to render the particle relative to the
     // viewport
-    Point2D newEffectLocation = Game.screens() != null ? Game.getCamera().getViewportLocation(effectLocation) : effectLocation;
+    Point2D newEffectLocation = Game.screens() != null ? Game.world().camera().getViewportLocation(effectLocation) : effectLocation;
     return this.getAbsoluteLocation(newEffectLocation);
   }
 

--- a/src/de/gurkenlabs/litiengine/gui/SpeechBubble.java
+++ b/src/de/gurkenlabs/litiengine/gui/SpeechBubble.java
@@ -83,7 +83,7 @@ public class SpeechBubble implements IUpdateable, IRenderable, IEntityProvider {
 
     this.lastTextDispay = Game.loop().getTicks();
     this.createBubbleImage();
-    Game.getEnvironment().add(this, RenderType.UI);
+    Game.world().environment().add(this, RenderType.UI);
     Game.renderLoop().attach(this);
     activeSpeechBubbles.put(entity, this);
   }
@@ -175,7 +175,7 @@ public class SpeechBubble implements IUpdateable, IRenderable, IEntityProvider {
   @Override
   public void update() {
     if (this.currentText == null) {
-      Game.getEnvironment().removeRenderable(this);
+      Game.world().environment().removeRenderable(this);
       Game.renderLoop().detach(this);
 
       if (activeSpeechBubbles.containsKey(this.getEntity()) && activeSpeechBubbles.get(this.getEntity()).equals(this)) {
@@ -185,7 +185,7 @@ public class SpeechBubble implements IUpdateable, IRenderable, IEntityProvider {
       return;
     }
 
-    this.entityCenter = Game.getCamera().getViewportLocation(this.getEntity().getCenter());
+    this.entityCenter = Game.world().camera().getViewportLocation(this.getEntity().getCenter());
 
     // old text was displayed long enough
     if (this.lastTextDispay != 0 && Game.loop().getDeltaTime(this.lastTextDispay) > this.currentTextDisplayTime) {
@@ -208,7 +208,7 @@ public class SpeechBubble implements IUpdateable, IRenderable, IEntityProvider {
   }
 
   private void cancel() {
-    Game.getEnvironment().removeRenderable(this);
+    Game.world().environment().removeRenderable(this);
     Game.renderLoop().detach(this);
     if (activeSpeechBubbles.get(this.getEntity()) != null && activeSpeechBubbles.remove(this.getEntity()).equals(this)) {
       activeSpeechBubbles.remove(this.getEntity());

--- a/src/de/gurkenlabs/litiengine/gui/screens/GameScreen.java
+++ b/src/de/gurkenlabs/litiengine/gui/screens/GameScreen.java
@@ -15,8 +15,8 @@ public class GameScreen extends Screen {
 
   @Override
   public void render(final Graphics2D g) {
-    if (Game.getEnvironment() != null) {
-      Game.getEnvironment().render(g);
+    if (Game.world().environment() != null) {
+      Game.world().environment().render(g);
     }
 
     super.render(g);

--- a/src/de/gurkenlabs/litiengine/input/Mouse.java
+++ b/src/de/gurkenlabs/litiengine/input/Mouse.java
@@ -64,7 +64,7 @@ public class Mouse implements IMouse {
       throw e;
     }
 
-    this.location = new Point2D.Double(Game.getCamera().getViewport().getCenterX(), Game.getCamera().getViewport().getCenterY());
+    this.location = new Point2D.Double(Game.world().camera().getViewport().getCenterX(), Game.world().camera().getViewport().getCenterY());
     this.lastLocation = this.location;
     this.sensitivity = Game.config().input().getMouseSensitivity();
     this.grabMouse = true;
@@ -77,7 +77,7 @@ public class Mouse implements IMouse {
 
   @Override
   public Point2D getMapLocation() {
-    return Game.getCamera().getMapLocation(new Point2D.Double(this.getLocation().getX() / Game.getCamera().getRenderScale(), this.getLocation().getY() / Game.getCamera().getRenderScale()));
+    return Game.world().camera().getMapLocation(new Point2D.Double(this.getLocation().getX() / Game.world().camera().getRenderScale(), this.getLocation().getY() / Game.world().camera().getRenderScale()));
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/pathfinding/astar/AStarGrid.java
+++ b/src/de/gurkenlabs/litiengine/pathfinding/astar/AStarGrid.java
@@ -125,7 +125,7 @@ public class AStarGrid implements IRenderable {
 
   @Override
   public void render(Graphics2D g) {
-    final Rectangle2D viewport = Game.getCamera().getViewport();
+    final Rectangle2D viewport = Game.world().camera().getViewport();
 
     final AStarNode startNode = this.getNode(viewport.getX(), viewport.getY());
     final AStarNode endNode = this.getNode(viewport.getMaxX(), viewport.getMaxY());
@@ -183,7 +183,7 @@ public class AStarGrid implements IRenderable {
 
     // by default we calculate a penalty for props that cannot be destroyed
     int penalty = 0;
-    for (Prop prop : Game.getEnvironment().getProps()) {
+    for (Prop prop : Game.world().environment().getProps()) {
       if (!prop.hasCollision() || !prop.isIndestructible() || !prop.getBoundingBox().intersects(node.getBounds())) {
         continue;
       }

--- a/src/de/gurkenlabs/litiengine/resources/Maps.java
+++ b/src/de/gurkenlabs/litiengine/resources/Maps.java
@@ -15,8 +15,17 @@ public final class Maps extends ResourcesContainer<IMap> {
   Maps() {
   }
 
+  public static boolean isSupported(String fileName) {
+    String extension = FileUtilities.getExtension(fileName);
+    return extension != null && !extension.isEmpty() && extension.equalsIgnoreCase(Map.FILE_EXTENSION);
+  }
+
   @Override
   protected IMap load(String resourceName) throws TmxException {
+    if (!isSupported(resourceName)) {
+      return null;
+    }
+
     Map map;
     try {
       map = XmlUtilities.readFromFile(Map.class, resourceName);
@@ -44,5 +53,14 @@ public final class Maps extends ResourcesContainer<IMap> {
     map.updateTileTerrain();
 
     return map;
+  }
+
+  @Override
+  protected String getAlias(String resourceName, IMap resource) {
+    if (resource == null || resource.getName() == null || resource.getName().isEmpty() || resource.getName().equalsIgnoreCase(resourceName)) {
+      return null;
+    }
+
+    return resource.getName();
   }
 }

--- a/src/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
@@ -26,11 +26,13 @@ public abstract class ResourcesContainer<T> {
   private static final Logger log = Logger.getLogger(ResourcesContainer.class.getName());
 
   private final Map<String, T> resources;
+  private final Map<String, String> aliases;
   private final List<ResourcesContainerListener<T>> listeners;
   private final List<ResourcesContainerClearedListener> clearedListeners;
 
   protected ResourcesContainer() {
     this.resources = new ConcurrentHashMap<>();
+    this.aliases = new ConcurrentHashMap<>();
     this.listeners = new CopyOnWriteArrayList<>();
     this.clearedListeners = new CopyOnWriteArrayList<>();
   }
@@ -235,11 +237,12 @@ public abstract class ResourcesContainer<T> {
     }
 
     // the case is ignored when retrieving resources
-    String identifier = resourceName.toLowerCase();
+    String identifier = this.getIdentifier(resourceName);
 
     if (forceLoad) {
-      T resource = this.loadResource(resourceName);
+      T resource = this.loadResource(identifier);
       this.resources.put(identifier, resource);
+
       return resource;
     } else {
       return this.resources.computeIfAbsent(identifier, this::loadResource);
@@ -282,7 +285,8 @@ public abstract class ResourcesContainer<T> {
    * to check whether a resource is present while also fetching it from the container.
    * </p>
    * 
-   * @param resourceName The name of the resource.
+   * @param resourceName
+   *          The name of the resource.
    * 
    * @return An Optional instance that holds the resource instance, if present on this container.
    * 
@@ -296,14 +300,15 @@ public abstract class ResourcesContainer<T> {
 
   protected abstract T load(String resourceName) throws Exception;
 
+  protected String getAlias(String resourceName, T resource) {
+    return null;
+  }
+
   protected Map<String, T> getResources() {
     return this.resources;
   }
 
-  private T loadResource(String resourceName) {
-    // the case is ignored when retrieving resources
-    String identifier = resourceName.toLowerCase();
-
+  private T loadResource(String identifier) {
     T newResource;
     try {
       newResource = this.load(identifier);
@@ -313,9 +318,27 @@ public abstract class ResourcesContainer<T> {
     }
 
     for (ResourcesContainerListener<T> listener : this.listeners) {
-      listener.added(resourceName, newResource);
+      listener.added(identifier, newResource);
+    }
+
+    String alias = this.getAlias(identifier, newResource);
+    if (alias != null) {
+      this.aliases.put(alias.toLowerCase(), identifier);
     }
 
     return newResource;
+  }
+
+  private String getIdentifier(String resourceName) {
+    String res = resourceName.toLowerCase();
+    if (this.resources.containsKey(res)) {
+      return res;
+    }
+
+    if (this.aliases.containsKey(res)) {
+      return this.aliases.get(res);
+    }
+
+    return res;
   }
 }

--- a/src/de/gurkenlabs/litiengine/sound/SoundEngine.java
+++ b/src/de/gurkenlabs/litiengine/sound/SoundEngine.java
@@ -24,7 +24,7 @@ public final class SoundEngine implements ISoundEngine, IUpdateable, ILaunchable
   public SoundEngine() {
     this.sounds = Collections.synchronizedList(new ArrayList<>());
     this.maxDist = DEFAULT_MAX_DISTANCE;
-    this.setListenerLocationCallback(old -> Game.getCamera().getFocus());
+    this.setListenerLocationCallback(old -> Game.world().camera().getFocus());
   }
 
   @Override
@@ -112,7 +112,7 @@ public final class SoundEngine implements ISoundEngine, IUpdateable, ILaunchable
   @Override
   public void start() {
     Input.getLoop().attach(this);
-    this.listenerLocation = Game.getCamera().getFocus();
+    this.listenerLocation = Game.world().camera().getFocus();
   }
 
   @Override

--- a/tests/de/gurkenlabs/litiengine/GameTest.java
+++ b/tests/de/gurkenlabs/litiengine/GameTest.java
@@ -49,7 +49,7 @@ public class GameTest {
     assertFalse(started.wasCalled);
     assertNotNull(Game.renderLoop());
     assertNotNull(Game.loop());
-    assertNotNull(Game.getCamera());
+    assertNotNull(Game.world().camera());
     assertNotNull(Game.screens());
     assertNotNull(Game.physics());
     assertNotNull(Game.graphics());

--- a/tests/de/gurkenlabs/litiengine/environment/EnvironmentEventTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/EnvironmentEventTests.java
@@ -32,7 +32,7 @@ public class EnvironmentEventTests {
 
     this.testEnvironment.init();
 
-    verify(environmentListener, times(1)).environmentInitialized(this.testEnvironment);
+    verify(environmentListener, times(1)).initialized(this.testEnvironment);
 
   }
 
@@ -43,7 +43,7 @@ public class EnvironmentEventTests {
 
     this.testEnvironment.load();
 
-    verify(environmentListener, times(1)).environmentLoaded(this.testEnvironment);
+    verify(environmentListener, times(1)).loaded(this.testEnvironment);
   }
 
   @Test

--- a/tests/de/gurkenlabs/litiengine/environment/GameWorldTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/GameWorldTests.java
@@ -89,6 +89,34 @@ public class GameWorldTests {
     assertTrue(map2Initialized.wasCalled);
   }
 
+  @Test
+  public void testMapSpecificLoadedListeners() {
+    Status mapLoaded = new Status();
+
+    Game.world().addLoadedListener("test-map", e -> mapLoaded.wasCalled = true);
+
+    IMap map = Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx");
+
+    Game.world().loadEnvironment(map);
+
+    assertTrue(mapLoaded.wasCalled);
+  }
+
+  @Test
+  public void testMapSpecificUnloadedListeners() {
+    Status mapUnloaded = new Status();
+
+    Game.world().addUnloadedListener("test-map", e -> mapUnloaded.wasCalled = true);
+
+    IMap map = Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx");
+
+    Game.world().loadEnvironment(map);
+
+    Game.world().unloadEnvironment();
+
+    assertTrue(mapUnloaded.wasCalled);
+  }
+
   private class Status {
     boolean wasCalled = false;
   }

--- a/tests/de/gurkenlabs/litiengine/environment/GameWorldTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/GameWorldTests.java
@@ -1,0 +1,95 @@
+package de.gurkenlabs.litiengine.environment;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.environment.tilemap.IMap;
+import de.gurkenlabs.litiengine.resources.Resources;
+
+public class GameWorldTests {
+
+  @BeforeAll
+  public static void initGame() {
+
+    // necessary because the environment need access to the game loop and other
+    // stuff
+    Game.init(Game.COMMADLINE_ARG_NOGUI);
+  }
+
+  @AfterAll
+  public static void terminateGame() {
+    Game.terminate();
+  }
+
+  @Test
+  public void testListeners() {
+    Status mapLoaded = new Status();
+    Status mapUnloaded = new Status();
+    Status mapInitialized = new Status();
+    Status mapCleared = new Status();
+    Status map2Loaded = new Status();
+    Status map2Initialized = new Status();
+
+    Game.world().addListener("test-map", new EnvironmentAdapter() {
+      @Override
+      public void initialized(IEnvironment environment) {
+        mapInitialized.wasCalled = true;
+      }
+
+      @Override
+      public void loaded(IEnvironment environment) {
+        mapLoaded.wasCalled = true;
+      }
+
+      @Override
+      public void unloaded(IEnvironment environment) {
+        mapUnloaded.wasCalled = true;
+      }
+
+      @Override
+      public void cleared(IEnvironment environment) {
+        mapCleared.wasCalled = true;
+      }
+    });
+
+    Game.world().addListener("test-mapobject", new EnvironmentAdapter() {
+
+      @Override
+      public void initialized(IEnvironment environment) {
+        map2Initialized.wasCalled = true;
+      }
+
+      @Override
+      public void loaded(IEnvironment environment) {
+        map2Loaded.wasCalled = true;
+      }
+    });
+
+    IMap map = Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx");
+
+    IEnvironment env = Game.world().loadEnvironment(map);
+
+    assertTrue(mapLoaded.wasCalled);
+    assertTrue(mapInitialized.wasCalled);
+
+    env.clear();
+
+    assertTrue(mapCleared.wasCalled);
+
+    IMap map2 = Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-mapobject.tmx");
+
+    Game.world().loadEnvironment(map2);
+
+    assertTrue(mapUnloaded.wasCalled);
+    assertTrue(map2Loaded.wasCalled);
+    assertTrue(map2Initialized.wasCalled);
+  }
+
+  private class Status {
+    boolean wasCalled = false;
+  }
+}

--- a/tests/de/gurkenlabs/litiengine/environment/TriggerTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/TriggerTests.java
@@ -28,7 +28,7 @@ public class TriggerTests {
     trigger.addTarget(456);
 
     IEnvironment env = mock(IEnvironment.class);
-    Game.loadEnvironment(env);
+    Game.world().loadEnvironment(env);
     Game.init(Game.COMMADLINE_ARG_NOGUI);
     when(env.get(456)).thenReturn(target);
 

--- a/tests/de/gurkenlabs/litiengine/environment/TriggerTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/TriggerTests.java
@@ -44,7 +44,6 @@ public class TriggerTests {
     trigger.addTarget(456);
 
     IEnvironment env = mock(IEnvironment.class);
-    when(env.identifier()).thenReturn("env: #123");
     Game.world().loadEnvironment(env);
     when(env.get(456)).thenReturn(target);
 

--- a/tests/de/gurkenlabs/litiengine/environment/TriggerTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/TriggerTests.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import de.gurkenlabs.litiengine.Game;
@@ -16,6 +18,20 @@ import de.gurkenlabs.litiengine.entities.Trigger;
 import de.gurkenlabs.litiengine.entities.Trigger.TriggerActivation;
 
 public class TriggerTests {
+  @BeforeAll
+  public static void initGame() {
+
+    // necessary because the environment need access to the game loop and other
+    // stuff
+    Game.init(Game.COMMADLINE_ARG_NOGUI);
+  }
+
+  @AfterAll
+  public static void terminateGame() {
+    Game.terminate();
+  }
+  
+  
   @Test
   public void testInteractTrigger() {
     Trigger trigger = new Trigger(TriggerActivation.INTERACT, "testrigger", "testmessage");
@@ -28,8 +44,8 @@ public class TriggerTests {
     trigger.addTarget(456);
 
     IEnvironment env = mock(IEnvironment.class);
+    when(env.identifier()).thenReturn("env: #123");
     Game.world().loadEnvironment(env);
-    Game.init(Game.COMMADLINE_ARG_NOGUI);
     when(env.get(456)).thenReturn(target);
 
     assertFalse(trigger.isActivated());
@@ -38,7 +54,5 @@ public class TriggerTests {
 
     assertTrue(trigger.isActivated());
     verify(target, times(1)).sendMessage(trigger, trigger.getMessage());
-
-    Game.terminate();
   }
 }

--- a/tests/de/gurkenlabs/litiengine/resources/ResourcesTests.java
+++ b/tests/de/gurkenlabs/litiengine/resources/ResourcesTests.java
@@ -9,6 +9,8 @@ import java.awt.image.BufferedImage;
 
 import org.junit.jupiter.api.Test;
 
+import de.gurkenlabs.litiengine.environment.tilemap.IMap;
+
 public class ResourcesTests {
 
   @Test
@@ -38,5 +40,12 @@ public class ResourcesTests {
     assertEquals(testImage, Resources.images().remove(imageName));
 
     assertEquals(0, Resources.images().count());
+  }
+
+  @Test
+  public void testMapResourcesAlias() {
+    IMap map = Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx");
+    
+    assertEquals(map, Resources.maps().get("test-map"));
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/EditorScreen.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/EditorScreen.java
@@ -214,7 +214,7 @@ public class EditorScreen extends Screen {
       }
 
       if (Game.world().environment() != null) {
-        Game.world().loadEnvironment(null);
+        Game.world().unloadEnvironment();
       }
 
       // set up project settings
@@ -316,7 +316,7 @@ public class EditorScreen extends Screen {
       if (!this.mapComponent.getMaps().isEmpty()) {
         this.mapComponent.loadEnvironment(this.mapComponent.getMaps().get(0));
       } else {
-        Game.world().loadEnvironment(null);
+        Game.world().unloadEnvironment();
       }
 
       this.changeComponent(ComponentType.MAP);

--- a/utiliti/src/de/gurkenlabs/utiliti/EditorScreen.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/EditorScreen.java
@@ -117,9 +117,9 @@ public class EditorScreen extends Screen {
 
   @Override
   public void render(final Graphics2D g) {
-    Game.getCamera().updateFocus();
-    if (Game.getEnvironment() != null) {
-      Game.getEnvironment().render(g);
+    Game.world().camera().updateFocus();
+    if (Game.world().environment() != null) {
+      Game.world().environment().render(g);
     }
 
     if (Resources.images().count() > 200) {
@@ -129,7 +129,7 @@ public class EditorScreen extends Screen {
 
     if (this.currentResourceFile != null) {
       Game.window().setTitle(Game.info().getName() + " " + Game.info().getVersion() + " - " + this.currentResourceFile);
-      String mapName = Game.getEnvironment() != null && Game.getEnvironment().getMap() != null ? "\nMap: " + Game.getEnvironment().getMap().getName() : "";
+      String mapName = Game.world().environment() != null && Game.world().environment().getMap() != null ? "\nMap: " + Game.world().environment().getMap().getName() : "";
       Program.getTrayIcon().setToolTip(Game.info().getName() + " " + Game.info().getVersion() + "\n" + this.currentResourceFile + mapName);
     } else if (this.getProjectPath() != null) {
       Game.window().setTitle(Game.info().getTitle() + " - " + NEW_GAME_STRING);
@@ -145,7 +145,7 @@ public class EditorScreen extends Screen {
     g.setFont(g.getFont().deriveFont(11f));
     g.setColor(Color.WHITE);
     Point tile = Input.mouse().getTile();
-    TextRenderer.render(g, "x: " + (int) Input.mouse().getMapLocation().getX() + " y: " + (int) Input.mouse().getMapLocation().getY() + " tile: [" + tile.x + ", " + tile.y + "]" + " zoom: " + (int) (Game.getCamera().getRenderScale() * 100) + " %", 10,
+    TextRenderer.render(g, "x: " + (int) Input.mouse().getMapLocation().getX() + " y: " + (int) Input.mouse().getMapLocation().getY() + " tile: [" + tile.x + ", " + tile.y + "]" + " zoom: " + (int) (Game.world().camera().getRenderScale() * 100) + " %", 10,
         Game.window().getHeight() - 40);
     TextRenderer.render(g, Game.metrics().getFramesPerSecond() + " FPS", 10, Game.window().getHeight() - 20);
 
@@ -213,8 +213,8 @@ public class EditorScreen extends Screen {
         return;
       }
 
-      if (Game.getEnvironment() != null) {
-        Game.loadEnvironment(null);
+      if (Game.world().environment() != null) {
+        Game.world().loadEnvironment(null);
       }
 
       // set up project settings
@@ -316,7 +316,7 @@ public class EditorScreen extends Screen {
       if (!this.mapComponent.getMaps().isEmpty()) {
         this.mapComponent.loadEnvironment(this.mapComponent.getMaps().get(0));
       } else {
-        Game.loadEnvironment(null);
+        Game.world().loadEnvironment(null);
       }
 
       this.changeComponent(ComponentType.MAP);
@@ -478,11 +478,11 @@ public class EditorScreen extends Screen {
   }
 
   public void saveMapSnapshot() {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return;
     }
 
-    IMap currentMap = Game.getEnvironment().getMap();
+    IMap currentMap = Game.world().environment().getMap();
     BufferedImage img = Game.graphics().getMapRenderer(currentMap.getOrientation()).getImage(currentMap);
 
     try {

--- a/utiliti/src/de/gurkenlabs/utiliti/MapSelectionPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/MapSelectionPanel.java
@@ -148,7 +148,7 @@ public class MapSelectionPanel extends JSplitPane {
 
       if (this.mapList.getSelectedIndex() < EditorScreen.instance().getMapComponent().getMaps().size() && this.mapList.getSelectedIndex() >= 0) {
         Map map = EditorScreen.instance().getMapComponent().getMaps().get(this.mapList.getSelectedIndex());
-        if (Game.getEnvironment() != null && Game.getEnvironment().getMap().equals(map)) {
+        if (Game.world().environment() != null && Game.world().environment().getMap().equals(map)) {
           return;
         }
 
@@ -261,7 +261,7 @@ public class MapSelectionPanel extends JSplitPane {
           if (node.getUserObject() instanceof IconTreeListItem) {
             IconTreeListItem item = (IconTreeListItem) node.getUserObject();
             if (item.getUserObject() instanceof IEntity) {
-              IMapObject obj = Game.getEnvironment().getMap().getMapObject(((IEntity) item.getUserObject()).getMapId());
+              IMapObject obj = Game.world().environment().getMap().getMapObject(((IEntity) item.getUserObject()).getMapId());
               if (obj != null) {
                 EditorScreen.instance().getMapComponent().setFocus(obj, true);
               }
@@ -842,62 +842,62 @@ public class MapSelectionPanel extends JSplitPane {
   }
 
   private void updateMapObjectTree() {
-    this.nodeRoot.setUserObject(new IconTreeListItem(Game.getEnvironment().getEntities().size() + " " + Resources.strings().get("panel_mapselection_entities"), Icons.FOLDER));
+    this.nodeRoot.setUserObject(new IconTreeListItem(Game.world().environment().getEntities().size() + " " + Resources.strings().get("panel_mapselection_entities"), Icons.FOLDER));
     for (DefaultMutableTreeNode node : this.entityNodes) {
       node.removeAllChildren();
     }
 
-    this.nodeLights.setUserObject(new IconTreeListItem(Game.getEnvironment().getLightSources().size() + " " + Resources.strings().get("panel_mapselection_lights"), Icons.LIGHT));
-    this.nodeProps.setUserObject(new IconTreeListItem(Game.getEnvironment().getProps().size() + " " + Resources.strings().get("panel_mapselection_props"), Icons.PROP));
-    this.nodeCreatures.setUserObject(new IconTreeListItem(Game.getEnvironment().getCreatures().size() + " " + Resources.strings().get("panel_mapselection_creatures"), Icons.CREATURE));
-    this.nodeTriggers.setUserObject(new IconTreeListItem(Game.getEnvironment().getTriggers().size() + " " + Resources.strings().get("panel_mapselection_triggers"), Icons.TRIGGER));
-    this.nodeSpawnpoints.setUserObject(new IconTreeListItem(Game.getEnvironment().getSpawnPoints().size() + " " + Resources.strings().get("panel_mapselection_spawnpoints"), Icons.SPAWNPOINT));
-    this.nodeCollisionBoxes.setUserObject(new IconTreeListItem(Game.getEnvironment().getCollisionBoxes().size() + " " + Resources.strings().get("panel_mapselection_collboxes"), Icons.COLLISIONBOX));
-    this.nodeMapAreas.setUserObject(new IconTreeListItem(Game.getEnvironment().getAreas().size() + " " + Resources.strings().get("panel_mapselection_areas"), Icons.MAPAREA));
-    this.nodeStaticShadows.setUserObject(new IconTreeListItem(Game.getEnvironment().getStaticShadows().size() + " " + Resources.strings().get("panel_mapselection_shadow"), Icons.SHADOWBOX));
-    this.nodeEmitter.setUserObject(new IconTreeListItem(Game.getEnvironment().getEmitters().size() + " " + Resources.strings().get("panel_mapselection_emitter"), Icons.EMITTER));
+    this.nodeLights.setUserObject(new IconTreeListItem(Game.world().environment().getLightSources().size() + " " + Resources.strings().get("panel_mapselection_lights"), Icons.LIGHT));
+    this.nodeProps.setUserObject(new IconTreeListItem(Game.world().environment().getProps().size() + " " + Resources.strings().get("panel_mapselection_props"), Icons.PROP));
+    this.nodeCreatures.setUserObject(new IconTreeListItem(Game.world().environment().getCreatures().size() + " " + Resources.strings().get("panel_mapselection_creatures"), Icons.CREATURE));
+    this.nodeTriggers.setUserObject(new IconTreeListItem(Game.world().environment().getTriggers().size() + " " + Resources.strings().get("panel_mapselection_triggers"), Icons.TRIGGER));
+    this.nodeSpawnpoints.setUserObject(new IconTreeListItem(Game.world().environment().getSpawnPoints().size() + " " + Resources.strings().get("panel_mapselection_spawnpoints"), Icons.SPAWNPOINT));
+    this.nodeCollisionBoxes.setUserObject(new IconTreeListItem(Game.world().environment().getCollisionBoxes().size() + " " + Resources.strings().get("panel_mapselection_collboxes"), Icons.COLLISIONBOX));
+    this.nodeMapAreas.setUserObject(new IconTreeListItem(Game.world().environment().getAreas().size() + " " + Resources.strings().get("panel_mapselection_areas"), Icons.MAPAREA));
+    this.nodeStaticShadows.setUserObject(new IconTreeListItem(Game.world().environment().getStaticShadows().size() + " " + Resources.strings().get("panel_mapselection_shadow"), Icons.SHADOWBOX));
+    this.nodeEmitter.setUserObject(new IconTreeListItem(Game.world().environment().getEmitters().size() + " " + Resources.strings().get("panel_mapselection_emitter"), Icons.EMITTER));
 
-    for (LightSource light : Game.getEnvironment().getLightSources()) {
+    for (LightSource light : Game.world().environment().getLightSources()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(light));
       this.nodeLights.add(node);
     }
 
-    for (Prop prop : Game.getEnvironment().getProps()) {
+    for (Prop prop : Game.world().environment().getProps()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(prop));
       this.nodeProps.add(node);
     }
 
-    for (Creature creature : Game.getEnvironment().getCreatures()) {
+    for (Creature creature : Game.world().environment().getCreatures()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(creature));
       this.nodeCreatures.add(node);
     }
 
-    for (Trigger trigger : Game.getEnvironment().getTriggers()) {
+    for (Trigger trigger : Game.world().environment().getTriggers()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(trigger));
       this.nodeTriggers.add(node);
     }
 
-    for (Spawnpoint spawn : Game.getEnvironment().getSpawnPoints()) {
+    for (Spawnpoint spawn : Game.world().environment().getSpawnPoints()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(spawn));
       this.nodeSpawnpoints.add(node);
     }
 
-    for (CollisionBox coll : Game.getEnvironment().getCollisionBoxes()) {
+    for (CollisionBox coll : Game.world().environment().getCollisionBoxes()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(coll));
       this.nodeCollisionBoxes.add(node);
     }
 
-    for (MapArea area : Game.getEnvironment().getAreas()) {
+    for (MapArea area : Game.world().environment().getAreas()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(area));
       this.nodeMapAreas.add(node);
     }
 
-    for (StaticShadow shadow : Game.getEnvironment().getStaticShadows()) {
+    for (StaticShadow shadow : Game.world().environment().getStaticShadows()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(shadow));
       this.nodeStaticShadows.add(node);
     }
 
-    for (Emitter emitter : Game.getEnvironment().getEmitters()) {
+    for (Emitter emitter : Game.world().environment().getEmitters()) {
       DefaultMutableTreeNode node = new DefaultMutableTreeNode(new IconTreeListItem(emitter));
       this.nodeEmitter.add(node);
     }

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -136,7 +136,7 @@ public class Program {
     JOptionPane.setDefaultLocale(Locale.getDefault());
 
     userPreferences = Game.config().getConfigurationGroup("user_", UserPreferenceConfiguration.class);
-    Game.getCamera().onZoomChanged(zoom -> userPreferences.setZoom(zoom));
+    Game.world().camera().onZoomChanged(zoom -> userPreferences.setZoom(zoom));
 
     Game.screens().display(EditorScreen.instance());
 
@@ -207,11 +207,11 @@ public class Program {
 
   public static void updateScrollBars() {
     horizontalScroll.setMinimum(0);
-    horizontalScroll.setMaximum(Game.getEnvironment().getMap().getSizeInPixels().width);
+    horizontalScroll.setMaximum(Game.world().environment().getMap().getSizeInPixels().width);
     verticalScroll.setMinimum(0);
-    verticalScroll.setMaximum(Game.getEnvironment().getMap().getSizeInPixels().height);
-    horizontalScroll.setValue((int) Game.getCamera().getViewport().getCenterX());
-    verticalScroll.setValue((int) Game.getCamera().getViewport().getCenterY());
+    verticalScroll.setMaximum(Game.world().environment().getMap().getSizeInPixels().height);
+    horizontalScroll.setValue((int) Game.world().camera().getViewport().getCenterX());
+    verticalScroll.setValue((int) Game.world().camera().getViewport().getCenterY());
   }
 
   public static boolean notifyPendingChanges() {
@@ -414,16 +414,16 @@ public class Program {
         return;
       }
 
-      Point2D newFocus = new Point2D.Double(horizontalScroll.getValue(), Game.getCamera().getFocus().getY());
-      Game.getCamera().setFocus(newFocus);
+      Point2D newFocus = new Point2D.Double(horizontalScroll.getValue(), Game.world().camera().getFocus().getY());
+      Game.world().camera().setFocus(newFocus);
     });
 
     verticalScroll.addAdjustmentListener(e -> {
       if (EditorScreen.instance().getMapComponent().isLoading()) {
         return;
       }
-      Point2D newFocus = new Point2D.Double(Game.getCamera().getFocus().getX(), verticalScroll.getValue());
-      Game.getCamera().setFocus(newFocus);
+      Point2D newFocus = new Point2D.Double(Game.world().camera().getFocus().getX(), verticalScroll.getValue());
+      Game.world().camera().setFocus(newFocus);
     });
   }
 
@@ -575,7 +575,7 @@ public class Program {
     reassignIDs.addActionListener(a -> {
       try {
         int minID = Integer.parseInt(JOptionPane.showInputDialog(Resources.strings().get("panel_reassignMapIds"), 1));
-        EditorScreen.instance().getMapComponent().reassignIds(Game.getEnvironment().getMap(), minID);
+        EditorScreen.instance().getMapComponent().reassignIds(Game.world().environment().getMap(), minID);
       } catch (Exception e) {
         log.log(Level.SEVERE, "No parseable Integer found upon reading the min Map ID input. Try again.");
       }
@@ -593,24 +593,24 @@ public class Program {
       }
 
       MapPropertyPanel panel = new MapPropertyPanel();
-      panel.bind(Game.getEnvironment().getMap());
+      panel.bind(Game.world().environment().getMap());
 
       int option = JOptionPane.showConfirmDialog(Game.window().getRenderComponent(), panel, Resources.strings().get("menu_mapProperties"), JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE);
       if (option == JOptionPane.OK_OPTION) {
         panel.saveChanges();
 
-        final String colorProp = Game.getEnvironment().getMap().getStringValue(MapProperty.AMBIENTCOLOR);
+        final String colorProp = Game.world().environment().getMap().getStringValue(MapProperty.AMBIENTCOLOR);
         try {
           if (colorProp != null && !colorProp.isEmpty()) {
             Color ambientColor = ColorHelper.decode(colorProp);
-            Game.getEnvironment().getAmbientLight().setColor(ambientColor);
+            Game.world().environment().getAmbientLight().setColor(ambientColor);
           }
         } catch (final NumberFormatException nfe) {
           log.log(Level.SEVERE, nfe.getLocalizedMessage(), nfe);
         }
 
         EditorScreen.instance().getMapComponent().loadMaps(EditorScreen.instance().getGameFile().getMaps());
-        EditorScreen.instance().getMapComponent().loadEnvironment((Map) Game.getEnvironment().getMap());
+        EditorScreen.instance().getMapComponent().loadEnvironment((Map) Game.world().environment().getMap());
       }
     });
 
@@ -909,14 +909,14 @@ public class Program {
     spinnerAmbientAlpha.setMaximumSize(new Dimension(50, 50));
     spinnerAmbientAlpha.setEnabled(true);
     spinnerAmbientAlpha.addChangeListener(e -> {
-      if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null || isChanging) {
+      if (Game.world().environment() == null || Game.world().environment().getMap() == null || isChanging) {
         return;
       }
 
-      Game.getEnvironment().getAmbientLight().setAlpha((int) spinnerAmbientAlpha.getValue());
-      String hex = ColorHelper.encode(Game.getEnvironment().getAmbientLight().getColor());
+      Game.world().environment().getAmbientLight().setAlpha((int) spinnerAmbientAlpha.getValue());
+      String hex = ColorHelper.encode(Game.world().environment().getAmbientLight().getColor());
       colorText.setText(hex);
-      Game.getEnvironment().getMap().setValue(MapProperty.AMBIENTCOLOR, hex);
+      Game.world().environment().getMap().setValue(MapProperty.AMBIENTCOLOR, hex);
 
     });
 
@@ -927,7 +927,7 @@ public class Program {
     colorText.setEnabled(false);
 
     colorButton.addActionListener(a -> {
-      if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null || isChanging) {
+      if (Game.world().environment() == null || Game.world().environment().getMap() == null || isChanging) {
         return;
       }
 
@@ -943,9 +943,9 @@ public class Program {
 
       spinnerAmbientAlpha.setValue(result.getAlpha());
 
-      Game.getEnvironment().getMap().setValue(MapProperty.AMBIENTCOLOR, colorText.getText());
-      Game.getEnvironment().getAmbientLight().setColor(result);
-      String hex = ColorHelper.encode(Game.getEnvironment().getAmbientLight().getColor());
+      Game.world().environment().getMap().setValue(MapProperty.AMBIENTCOLOR, colorText.getText());
+      Game.world().environment().getAmbientLight().setColor(result);
+      String hex = ColorHelper.encode(Game.world().environment().getAmbientLight().getColor());
       colorText.setText(hex);
     });
 

--- a/utiliti/src/de/gurkenlabs/utiliti/UndoManager.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/UndoManager.java
@@ -49,12 +49,12 @@ public class UndoManager {
   }
 
   public static UndoManager instance() {
-    if (instance.containsKey(Game.getEnvironment().getMap().getName())) {
-      return instance.get(Game.getEnvironment().getMap().getName());
+    if (instance.containsKey(Game.world().environment().getMap().getName())) {
+      return instance.get(Game.world().environment().getMap().getName());
     }
 
-    UndoManager newUndoManager = new UndoManager(Game.getEnvironment().getMap().getName());
-    instance.put(Game.getEnvironment().getMap().getName(), newUndoManager);
+    UndoManager newUndoManager = new UndoManager(Game.world().environment().getMap().getName());
+    instance.put(Game.world().environment().getMap().getName(), newUndoManager);
     return newUndoManager;
   }
 
@@ -272,9 +272,9 @@ public class UndoManager {
       target.setValue(prop.getKey(), prop.getValue());
     }
 
-    Game.getEnvironment().reloadFromMap(target.getId());
+    Game.world().environment().reloadFromMap(target.getId());
     if (MapObjectType.get(target.getType()) == MapObjectType.LIGHTSOURCE) {
-      Game.getEnvironment().getAmbientLight().updateSection(MapObject.getBounds2D((MapObject) target, (MapObject) restore));
+      Game.world().environment().getAmbientLight().updateSection(MapObject.getBounds2D((MapObject) target, (MapObject) restore));
     }
 
     if (EditorScreen.instance().getMapComponent().getFocusedMapObject() != null && EditorScreen.instance().getMapComponent().getFocusedMapObject().getId() == target.getId()) {
@@ -330,7 +330,7 @@ public class UndoManager {
     public UndoState(IMapObject target, OperationType operationType) {
       this.operation = UndoManager.this.operation;
       this.target = target;
-      this.layer = Game.getEnvironment().getMap().getMapObjectLayer(target);
+      this.layer = Game.world().environment().getMap().getMapObjectLayer(target);
       this.oldMapObject = null;
       this.newMapObject = null;
       this.operationType = operationType;
@@ -343,7 +343,7 @@ public class UndoManager {
       this.newMapObject = operationType != OperationType.DELETE ? newMapObject : null;
       this.operationType = operationType;
 
-      this.layer = Game.getEnvironment().getMap().getMapObjectLayer(target);
+      this.layer = Game.world().environment().getMap().getMapObjectLayer(target);
     }
 
     @Override

--- a/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
@@ -174,7 +174,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     this.transformRects = new ConcurrentHashMap<>();
     this.dragLocationMapObjects = new ConcurrentHashMap<>();
     this.screen = screen;
-    Game.getCamera().onZoomChanged(zoom -> {
+    Game.world().camera().onZoomChanged(zoom -> {
       this.currentTransformRectSize = TRANSFORM_RECT_SIZE / zoom;
       this.updateTransformControls();
     });
@@ -202,13 +202,13 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
   @Override
   public void render(Graphics2D g) {
-    if (Game.getEnvironment() == null) {
+    if (Game.world().environment() == null) {
       return;
     }
 
     this.renderGrid(g);
 
-    final BasicStroke shapeStroke = new BasicStroke(1 / Game.getCamera().getRenderScale());
+    final BasicStroke shapeStroke = new BasicStroke(1 / Game.world().camera().getRenderScale());
     if (Program.getUserPreferences().isRenderBoundingBoxes()) {
       this.renderMapObjectBounds(g);
     }
@@ -278,16 +278,16 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   }
 
   public IMapObject getFocusedMapObject() {
-    if (Game.getEnvironment() != null && Game.getEnvironment().getMap() != null) {
-      return this.focusedObjects.get(Game.getEnvironment().getMap().getName());
+    if (Game.world().environment() != null && Game.world().environment().getMap() != null) {
+      return this.focusedObjects.get(Game.world().environment().getMap().getName());
     }
 
     return null;
   }
 
   public List<IMapObject> getSelectedMapObjects() {
-    final String map = Game.getEnvironment().getMap().getName();
-    if (Game.getEnvironment() != null && Game.getEnvironment().getMap() != null && this.selectedObjects.containsKey(map)) {
+    final String map = Game.world().environment().getMap().getName();
+    if (Game.world().environment() != null && Game.world().environment().getMap() != null && this.selectedObjects.containsKey(map)) {
       return this.selectedObjects.get(map);
     }
 
@@ -304,7 +304,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
   @Override
   public void prepare() {
-    Game.getCamera().setZoom(zooms[this.currentZoomIndex], 0);
+    Game.world().camera().setZoom(zooms[this.currentZoomIndex], 0);
     if (!this.initialized) {
       Game.window().getRenderComponent().addFocusListener(new FocusAdapter() {
         @Override
@@ -329,10 +329,10 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     }
     this.loading = true;
     try {
-      if (Game.getEnvironment() != null && Game.getEnvironment().getMap() != null) {
-        final String mapName = Game.getEnvironment().getMap().getName();
-        double x = Game.getCamera().getFocus().getX();
-        double y = Game.getCamera().getFocus().getY();
+      if (Game.world().environment() != null && Game.world().environment().getMap() != null) {
+        final String mapName = Game.world().environment().getMap().getName();
+        double x = Game.world().camera().getFocus().getX();
+        double y = Game.world().camera().getFocus().getY();
         Point2D newPoint = new Point2D.Double(x, y);
         this.cameraFocus.put(mapName, newPoint);
         this.selectedLayers.put(mapName, EditorScreen.instance().getMapSelectionPanel().getSelectedLayerIndex());
@@ -347,7 +347,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         this.cameraFocus.put(map.getName(), newFocus);
       }
 
-      Game.getCamera().setFocus(new Point2D.Double(newFocus.getX(), newFocus.getY()));
+      Game.world().camera().setFocus(new Point2D.Double(newFocus.getX(), newFocus.getY()));
 
       if (!this.environments.containsKey(map.getName())) {
         Environment env = new Environment(map);
@@ -355,7 +355,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         this.environments.put(map.getName(), env);
       }
 
-      Game.loadEnvironment(this.environments.get(map.getName()));
+      Game.world().loadEnvironment(this.environments.get(map.getName()));
 
       Program.updateScrollBars();
 
@@ -376,11 +376,11 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   }
 
   public void reloadEnvironment() {
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return;
     }
 
-    this.loadEnvironment((Map) Game.getEnvironment().getMap());
+    this.loadEnvironment((Map) Game.world().environment().getMap());
   }
 
   public void add(IMapObject mapObject) {
@@ -395,9 +395,9 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     this.getSelectedMapObjects().clear();
     this.setFocus(null, true);
     for (IMapObject mapObject : layer.getMapObjects()) {
-      Game.getEnvironment().loadFromMap(mapObject.getId());
+      Game.world().environment().loadFromMap(mapObject.getId());
       if (MapObjectType.get(mapObject.getType()) == MapObjectType.LIGHTSOURCE) {
-        Game.getEnvironment().getAmbientLight().updateSection(mapObject.getBoundingBox());
+        Game.world().environment().getAmbientLight().updateSection(mapObject.getBoundingBox());
       }
       this.setSelection(mapObject, false);
       this.setFocus(mapObject, false);
@@ -412,9 +412,9 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     }
     for (IMapObject mapObject : layer.getMapObjects()) {
       if (MapObjectType.get(mapObject.getType()) == MapObjectType.LIGHTSOURCE) {
-        Game.getEnvironment().getAmbientLight().updateSection(mapObject.getBoundingBox());
+        Game.world().environment().getAmbientLight().updateSection(mapObject.getBoundingBox());
       }
-      Game.getEnvironment().remove(mapObject.getId());
+      Game.world().environment().remove(mapObject.getId());
       if (mapObject.equals(this.getFocusedMapObject())) {
         this.setFocus(null, true);
       }
@@ -428,9 +428,9 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     }
 
     layer.addMapObject(mapObject);
-    Game.getEnvironment().loadFromMap(mapObject.getId());
+    Game.world().environment().loadFromMap(mapObject.getId());
     if (MapObjectType.get(mapObject.getType()) == MapObjectType.LIGHTSOURCE) {
-      Game.getEnvironment().getAmbientLight().updateSection(mapObject.getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(mapObject.getBoundingBox());
     }
 
     Game.window().getRenderComponent().requestFocus();
@@ -518,10 +518,10 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     }
 
     MapObjectType type = MapObjectType.get(mapObject.getType());
-    Game.getEnvironment().getMap().removeMapObject(mapObject.getId());
-    Game.getEnvironment().remove(mapObject.getId());
+    Game.world().environment().getMap().removeMapObject(mapObject.getId());
+    Game.world().environment().remove(mapObject.getId());
     if (type == MapObjectType.STATICSHADOW || type == MapObjectType.LIGHTSOURCE) {
-      Game.getEnvironment().getAmbientLight().updateSection(mapObject.getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(mapObject.getBoundingBox());
     }
 
     if (mapObject.equals(this.getFocusedMapObject())) {
@@ -552,7 +552,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         return;
       }
 
-      Game.getCamera().setFocus(new Point2D.Double(focus.getCenterX(), focus.getCenterY()));
+      Game.world().camera().setFocus(new Point2D.Double(focus.getCenterX(), focus.getCenterY()));
     }
   }
 
@@ -595,7 +595,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         return;
       }
 
-      if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+      if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
         return;
       }
 
@@ -606,9 +606,9 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       EditorScreen.instance().getMapObjectPanel().bind(mapObject);
       EditorScreen.instance().getMapSelectionPanel().focus(mapObject);
       if (mapObject == null) {
-        this.focusedObjects.remove(Game.getEnvironment().getMap().getName());
+        this.focusedObjects.remove(Game.world().environment().getMap().getName());
       } else {
-        this.focusedObjects.put(Game.getEnvironment().getMap().getName(), mapObject);
+        this.focusedObjects.put(Game.world().environment().getMap().getName(), mapObject);
       }
 
       for (Consumer<IMapObject> cons : this.focusChangedConsumer) {
@@ -631,7 +631,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    final String map = Game.getEnvironment().getMap().getName();
+    final String map = Game.world().environment().getMap().getName();
     if (!this.selectedObjects.containsKey(map)) {
       this.selectedObjects.put(map, new CopyOnWriteArrayList<>());
     }
@@ -658,7 +658,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    final String map = Game.getEnvironment().getMap().getName();
+    final String map = Game.world().environment().getMap().getName();
     if (!this.selectedObjects.containsKey(map)) {
       this.selectedObjects.put(map, new CopyOnWriteArrayList<>());
     }
@@ -716,16 +716,16 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    if (Game.getEnvironment() == null || Game.getEnvironment().getMap() == null) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return;
     }
 
-    int n = JOptionPane.showConfirmDialog(Game.window().getRenderComponent(), Resources.strings().get("hud_deleteMapMessage") + "\n" + Game.getEnvironment().getMap().getName(), Resources.strings().get("hud_deleteMap"), JOptionPane.YES_NO_OPTION);
+    int n = JOptionPane.showConfirmDialog(Game.window().getRenderComponent(), Resources.strings().get("hud_deleteMapMessage") + "\n" + Game.world().environment().getMap().getName(), Resources.strings().get("hud_deleteMap"), JOptionPane.YES_NO_OPTION);
     if (n != JOptionPane.YES_OPTION) {
       return;
     }
 
-    this.getMaps().removeIf(x -> x.getName().equals(Game.getEnvironment().getMap().getName()));
+    this.getMaps().removeIf(x -> x.getName().equals(Game.world().environment().getMap().getName()));
 
     // TODO: remove all tile sets from the game file that are no longer needed
     // by any other map.
@@ -832,7 +832,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    Map map = (Map) Game.getEnvironment().getMap();
+    Map map = (Map) Game.world().environment().getMap();
     if (map == null) {
       return;
     }
@@ -911,16 +911,16 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   }
 
   private static boolean mapIsNull() {
-    return Game.getEnvironment() == null || Game.getEnvironment().getMap() == null;
+    return Game.world().environment() == null || Game.world().environment().getMap() == null;
   }
 
   private static IMapObjectLayer getCurrentLayer() {
     int layerIndex = EditorScreen.instance().getMapSelectionPanel().getSelectedLayerIndex();
-    if (layerIndex < 0 || layerIndex >= Game.getEnvironment().getMap().getMapObjectLayers().size()) {
+    if (layerIndex < 0 || layerIndex >= Game.world().environment().getMap().getMapObjectLayers().size()) {
       layerIndex = 0;
     }
 
-    return Game.getEnvironment().getMap().getMapObjectLayers().get(layerIndex);
+    return Game.world().environment().getMap().getMapObjectLayers().get(layerIndex);
   }
 
   private IMapObject createNewMapObject(MapObjectType type) {
@@ -934,7 +934,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     float height = (float) this.newObjectArea.getHeight();
     mo.setWidth(width == 0 ? 16 : width);
     mo.setHeight(height == 0 ? 16 : height);
-    mo.setId(Game.getEnvironment().getNextMapId());
+    mo.setId(Game.world().environment().getNextMapId());
     mo.setName("");
 
     switch (type) {
@@ -1102,9 +1102,9 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     transformObject.setX(this.snapX(newX));
     transformObject.setY(this.snapY(newY));
 
-    Game.getEnvironment().reloadFromMap(transformObject.getId());
+    Game.world().environment().reloadFromMap(transformObject.getId());
     if (MapObjectType.get(transformObject.getType()) == MapObjectType.LIGHTSOURCE) {
-      Game.getEnvironment().getAmbientLight().updateSection(transformObject.getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(transformObject.getBoundingBox());
     }
 
     EditorScreen.instance().getMapObjectPanel().bind(transformObject);
@@ -1174,7 +1174,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       double y = Math.min(beforeBounds.getY(), afterBounds.getY());
       double width = Math.max(beforeBounds.getMaxX(), afterBounds.getMaxX()) - x;
       double height = Math.max(beforeBounds.getMaxY(), afterBounds.getMaxY()) - y;
-      Game.getEnvironment().getAmbientLight().updateSection(new Rectangle2D.Double(x, y, width, height));
+      Game.world().environment().getAmbientLight().updateSection(new Rectangle2D.Double(x, y, width, height));
     }
   }
 
@@ -1184,12 +1184,12 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       selected.setX(selected.getX() + snappedDeltaX);
       selected.setY(selected.getY() + snappedDeltaY);
 
-      IEntity entity = Game.getEnvironment().get(selected.getId());
+      IEntity entity = Game.world().environment().get(selected.getId());
       if (entity != null) {
         entity.setX(selected.getLocation().getX());
         entity.setY(selected.getLocation().getY());
       } else {
-        Game.getEnvironment().reloadFromMap(selected.getId());
+        Game.world().environment().reloadFromMap(selected.getId());
       }
 
       if (selected.equals(this.getFocusedMapObject())) {
@@ -1200,7 +1200,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   }
 
   private void setCurrentZoom() {
-    Game.getCamera().setZoom(zooms[this.currentZoomIndex], 0);
+    Game.world().camera().setZoom(zooms[this.currentZoomIndex], 0);
   }
 
   private void setupKeyboardControls() {
@@ -1353,19 +1353,19 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    final Point2D currentFocus = Game.getCamera().getFocus();
+    final Point2D currentFocus = Game.world().camera().getFocus();
     // horizontal scrolling
     if (Input.keyboard().isPressed(KeyEvent.VK_CONTROL) && this.dragPoint == null) {
       if (e.getEvent().getWheelRotation() < 0) {
 
         Point2D newFocus = new Point2D.Double(currentFocus.getX() - this.scrollSpeed, currentFocus.getY());
-        Game.getCamera().setFocus(newFocus);
+        Game.world().camera().setFocus(newFocus);
       } else {
         Point2D newFocus = new Point2D.Double(currentFocus.getX() + this.scrollSpeed, currentFocus.getY());
-        Game.getCamera().setFocus(newFocus);
+        Game.world().camera().setFocus(newFocus);
       }
 
-      Program.getHorizontalScrollBar().setValue((int) Game.getCamera().getViewport().getCenterX());
+      Program.getHorizontalScrollBar().setValue((int) Game.world().camera().getViewport().getCenterX());
       return;
     }
 
@@ -1381,14 +1381,14 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
     if (e.getEvent().getWheelRotation() < 0) {
       Point2D newFocus = new Point2D.Double(currentFocus.getX(), currentFocus.getY() - this.scrollSpeed);
-      Game.getCamera().setFocus(newFocus);
+      Game.world().camera().setFocus(newFocus);
 
     } else {
       Point2D newFocus = new Point2D.Double(currentFocus.getX(), currentFocus.getY() + this.scrollSpeed);
-      Game.getCamera().setFocus(newFocus);
+      Game.world().camera().setFocus(newFocus);
     }
 
-    Program.getVerticalcrollBar().setValue((int) Game.getCamera().getViewport().getCenterY());
+    Program.getVerticalcrollBar().setValue((int) Game.world().camera().getViewport().getCenterY());
   }
 
   /***
@@ -1560,7 +1560,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       Rectangle2D rect = this.getCurrentMouseSelectionArea(false);
       boolean somethingIsFocused = false;
       boolean currentObjectFocused = false;
-      for (IMapObjectLayer layer : Game.getEnvironment().getMap().getMapObjectLayers()) {
+      for (IMapObjectLayer layer : Game.world().environment().getMap().getMapObjectLayers()) {
         if (layer == null || !EditorScreen.instance().getMapSelectionPanel().isVisibleMapObjectLayer(layer.getName())) {
           continue;
         }
@@ -1618,11 +1618,11 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   private float snapX(double x) {
     if (Program.getUserPreferences().isSnapGrid()) {
       double snapped = ((int) (x / this.getGridWidth()) * this.getGridWidth());
-      return (int) Math.round(Math.min(Math.max(snapped, 0), Game.getEnvironment().getMap().getSizeInPixels().getWidth()));
+      return (int) Math.round(Math.min(Math.max(snapped, 0), Game.world().environment().getMap().getSizeInPixels().getWidth()));
     }
 
     if (Program.getUserPreferences().isSnapPixels()) {
-      return MathUtilities.clamp((int) Math.round(x), 0, (int) Game.getEnvironment().getMap().getSizeInPixels().getWidth());
+      return MathUtilities.clamp((int) Math.round(x), 0, (int) Game.world().environment().getMap().getSizeInPixels().getWidth());
     }
 
     return MathUtilities.round((float) x, 2);
@@ -1631,11 +1631,11 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   private float snapY(double y) {
     if (Program.getUserPreferences().isSnapGrid()) {
       int snapped = (int) (y / this.getGridHeight()) * this.getGridHeight();
-      return (int) Math.round(Math.min(Math.max(snapped, 0), Game.getEnvironment().getMap().getSizeInPixels().getHeight()));
+      return (int) Math.round(Math.min(Math.max(snapped, 0), Game.world().environment().getMap().getSizeInPixels().getHeight()));
     }
 
     if (Program.getUserPreferences().isSnapPixels()) {
-      return MathUtilities.clamp((int) Math.round(y), 0, (int) Game.getEnvironment().getMap().getSizeInPixels().getHeight());
+      return MathUtilities.clamp((int) Math.round(y), 0, (int) Game.world().environment().getMap().getSizeInPixels().getHeight());
     }
 
     return MathUtilities.round((float) y, 2);
@@ -1657,7 +1657,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
   private void renderMapObjectBounds(Graphics2D g) {
     // render all entities
-    for (final IMapObjectLayer layer : Game.getEnvironment().getMap().getMapObjectLayers()) {
+    for (final IMapObjectLayer layer : Game.world().environment().getMap().getMapObjectLayers()) {
       if (layer == null) {
         continue;
       }
@@ -1679,7 +1679,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         }
 
         MapObjectType type = MapObjectType.get(mapObject.getType());
-        final BasicStroke shapeStroke = new BasicStroke(1f / Game.getCamera().getRenderScale());
+        final BasicStroke shapeStroke = new BasicStroke(1f / Game.world().camera().getRenderScale());
         // render spawn points
         if (type == MapObjectType.SPAWNPOINT) {
           g.setColor(COLOR_SPAWNPOINT);
@@ -1743,14 +1743,14 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
   private void renderGrid(Graphics2D g) {
     // render the grid
-    if (Program.getUserPreferences().isShowGrid() && Game.getCamera().getRenderScale() >= 1) {
+    if (Program.getUserPreferences().isShowGrid() && Game.world().camera().getRenderScale() >= 1) {
 
       g.setColor(this.getGridColor());
-      final Stroke stroke = new BasicStroke(this.getGridStrokeFactor() / Game.getCamera().getRenderScale());
-      for (int x = 0; x < Game.getEnvironment().getMap().getWidth(); x++) {
-        for (int y = 0; y < Game.getEnvironment().getMap().getHeight(); y++) {
-          Shape tile = Game.getEnvironment().getMap().getTileShape(x, y);
-          if (Game.getCamera().getViewport().intersects(tile.getBounds2D())) {
+      final Stroke stroke = new BasicStroke(this.getGridStrokeFactor() / Game.world().camera().getRenderScale());
+      for (int x = 0; x < Game.world().environment().getMap().getWidth(); x++) {
+        for (int y = 0; y < Game.world().environment().getMap().getHeight(); y++) {
+          Shape tile = Game.world().environment().getMap().getTileShape(x, y);
+          if (Game.world().camera().getViewport().intersects(tile.getBounds2D())) {
             Game.graphics().renderOutline(g, tile, stroke);
           }
         }
@@ -1793,19 +1793,19 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     final Rectangle2D focus = this.getFocus();
     final IMapObject focusedMapObject = this.getFocusedMapObject();
     if (focus != null && focusedMapObject != null) {
-      Stroke stroke = new BasicStroke(1 / Game.getCamera().getRenderScale(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 4, new float[] { 1f, 1f }, Game.loop().getTicks() / 15);
+      Stroke stroke = new BasicStroke(1 / Game.world().camera().getRenderScale(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 4, new float[] { 1f, 1f }, Game.loop().getTicks() / 15);
 
       g.setColor(Color.BLACK);
 
       Game.graphics().renderOutline(g, focus, stroke);
 
-      Stroke whiteStroke = new BasicStroke(1 / Game.getCamera().getRenderScale(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 4, new float[] { 1f, 1f }, Game.loop().getTicks() / 15 - 1f);
+      Stroke whiteStroke = new BasicStroke(1 / Game.world().camera().getRenderScale(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 4, new float[] { 1f, 1f }, Game.loop().getTicks() / 15 - 1f);
       g.setColor(Color.WHITE);
       Game.graphics().renderOutline(g, focus, whiteStroke);
 
       // render transform rects
       if (!Input.keyboard().isPressed(KeyEvent.VK_CONTROL)) {
-        Stroke transStroke = new BasicStroke(1 / Game.getCamera().getRenderScale());
+        Stroke transStroke = new BasicStroke(1 / Game.world().camera().getRenderScale());
         for (Rectangle2D trans : this.transformRects.values()) {
           g.setColor(COLOR_TRANSFORM_RECT_FILL);
           Game.graphics().renderShape(g, trans);
@@ -1816,7 +1816,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
       // render transform rects
       if (!Input.keyboard().isPressed(KeyEvent.VK_CONTROL)) {
-        Stroke transStroke = new BasicStroke(1 / Game.getCamera().getRenderScale());
+        Stroke transStroke = new BasicStroke(1 / Game.world().camera().getRenderScale());
         for (Rectangle2D trans : this.transformRects.values()) {
           g.setColor(COLOR_TRANSFORM_RECT_FILL);
           Game.graphics().renderShape(g, trans);
@@ -1827,11 +1827,11 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     }
 
     if (focusedMapObject != null) {
-      Point2D loc = Game.getCamera().getViewportLocation(new Point2D.Double(focusedMapObject.getX() + focusedMapObject.getWidth() / 2, focusedMapObject.getY()));
+      Point2D loc = Game.world().camera().getViewportLocation(new Point2D.Double(focusedMapObject.getX() + focusedMapObject.getWidth() / 2, focusedMapObject.getY()));
       g.setFont(Program.TEXT_FONT.deriveFont(Font.BOLD, 15f));
       g.setColor(Color.WHITE);
       String id = "#" + focusedMapObject.getId();
-      TextRenderer.render(g, id, loc.getX() * Game.getCamera().getRenderScale() - g.getFontMetrics().stringWidth(id) / 2.0, loc.getY() * Game.getCamera().getRenderScale() - (5 * this.currentTransformRectSize));
+      TextRenderer.render(g, id, loc.getX() * Game.world().camera().getRenderScale() - g.getFontMetrics().stringWidth(id) / 2.0, loc.getY() * Game.world().camera().getRenderScale() - (5 * this.currentTransformRectSize));
     }
   }
 
@@ -1841,7 +1841,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         continue;
       }
 
-      Stroke stroke = new BasicStroke(1 / Game.getCamera().getRenderScale());
+      Stroke stroke = new BasicStroke(1 / Game.world().camera().getRenderScale());
 
       g.setColor(colorSelectionBorder);
       Game.graphics().renderOutline(g, mapObject.getBoundingBox(), stroke);
@@ -1910,7 +1910,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       Game.graphics().renderShape(g, collisionBox);
       g.setColor(collision ? COLOR_COLLISION_BORDER : COLOR_NOCOLLISION_BORDER);
 
-      Stroke collisionStroke = collision ? shapeStroke : new BasicStroke(1 / Game.getCamera().getRenderScale(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_BEVEL, 0, new float[] { 1f }, 0);
+      Stroke collisionStroke = collision ? shapeStroke : new BasicStroke(1 / Game.world().camera().getRenderScale(), BasicStroke.CAP_ROUND, BasicStroke.JOIN_BEVEL, 0, new float[] { 1f }, 0);
       Game.graphics().renderOutline(g, collisionBox, collisionStroke);
     }
   }

--- a/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
@@ -286,9 +286,11 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   }
 
   public List<IMapObject> getSelectedMapObjects() {
-    final String map = Game.world().environment().getMap().getName();
-    if (Game.world().environment() != null && Game.world().environment().getMap() != null && this.selectedObjects.containsKey(map)) {
-      return this.selectedObjects.get(map);
+    if (Game.world().environment() != null && Game.world().environment().getMap() != null) {
+      final String map = Game.world().environment().getMap().getName();
+      if (this.selectedObjects.containsKey(map)) {
+        return this.selectedObjects.get(map);
+      }
     }
 
     return new ArrayList<>();
@@ -1656,8 +1658,13 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   }
 
   private void renderMapObjectBounds(Graphics2D g) {
+    if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
+      return;
+    }
+    
+    final List<IMapObjectLayer> layers = Game.world().environment().getMap().getMapObjectLayers();
     // render all entities
-    for (final IMapObjectLayer layer : Game.world().environment().getMap().getMapObjectLayers()) {
+    for (final IMapObjectLayer layer : layers) {
       if (layer == null) {
         continue;
       }
@@ -1743,13 +1750,18 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
   private void renderGrid(Graphics2D g) {
     // render the grid
-    if (Program.getUserPreferences().isShowGrid() && Game.world().camera().getRenderScale() >= 1) {
+    if (Program.getUserPreferences().isShowGrid() && Game.world().camera().getRenderScale() >= 1 && Game.world().environment() != null) {
+
+      final IMap map = Game.world().environment().getMap();
+      if (map == null) {
+        return;
+      }
 
       g.setColor(this.getGridColor());
       final Stroke stroke = new BasicStroke(this.getGridStrokeFactor() / Game.world().camera().getRenderScale());
-      for (int x = 0; x < Game.world().environment().getMap().getWidth(); x++) {
-        for (int y = 0; y < Game.world().environment().getMap().getHeight(); y++) {
-          Shape tile = Game.world().environment().getMap().getTileShape(x, y);
+      for (int x = 0; x < map.getWidth(); x++) {
+        for (int y = 0; y < map.getHeight(); y++) {
+          Shape tile = map.getTileShape(x, y);
           if (Game.world().camera().getViewport().intersects(tile.getBounds2D())) {
             Game.graphics().renderOutline(g, tile, stroke);
           }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/AssetPanelItem.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/AssetPanelItem.java
@@ -315,11 +315,11 @@ public class AssetPanelItem extends JPanel {
 
       MapObject mo = new MapObject();
       mo.setType(MapObjectType.PROP.name());
-      mo.setX((int) Game.getCamera().getFocus().getX() - info.getWidth() / 2);
-      mo.setY((int) Game.getCamera().getFocus().getY() - info.getHeight() / 2);
+      mo.setX((int) Game.world().camera().getFocus().getX() - info.getWidth() / 2);
+      mo.setY((int) Game.world().camera().getFocus().getY() - info.getHeight() / 2);
       mo.setWidth((int) info.getWidth());
       mo.setHeight((int) info.getHeight());
-      mo.setId(Game.getEnvironment().getNextMapId());
+      mo.setId(Game.world().environment().getNextMapId());
       mo.setName("");
       mo.setValue(MapObjectProperty.COLLISIONBOX_WIDTH, info.getWidth() * 0.4);
       mo.setValue(MapObjectProperty.COLLISIONBOX_HEIGHT, info.getHeight() * 0.4);
@@ -332,16 +332,16 @@ public class AssetPanelItem extends JPanel {
       return true;
     } else if (this.getOrigin() instanceof EmitterData) {
       MapObject newEmitter = (MapObject) EmitterMapObjectLoader.createMapObject((EmitterData) this.getOrigin());
-      newEmitter.setX((int) (Game.getCamera().getFocus().getX() - newEmitter.getWidth()));
-      newEmitter.setY((int) (Game.getCamera().getFocus().getY() - newEmitter.getHeight()));
-      newEmitter.setId(Game.getEnvironment().getNextMapId());
+      newEmitter.setX((int) (Game.world().camera().getFocus().getX() - newEmitter.getWidth()));
+      newEmitter.setY((int) (Game.world().camera().getFocus().getY() - newEmitter.getHeight()));
+      newEmitter.setId(Game.world().environment().getNextMapId());
       EditorScreen.instance().getMapComponent().add(newEmitter);
     } else if (this.getOrigin() instanceof Blueprint) {
       Blueprint blueprint = (Blueprint) this.getOrigin();
 
       UndoManager.instance().beginOperation();
       try {
-        List<IMapObject> newObjects = blueprint.build((int) Game.getCamera().getFocus().getX() - blueprint.getWidth() / 2, (int) Game.getCamera().getFocus().getY() - blueprint.getHeight() / 2);
+        List<IMapObject> newObjects = blueprint.build((int) Game.world().camera().getFocus().getX() - blueprint.getWidth() / 2, (int) Game.world().camera().getFocus().getY() - blueprint.getHeight() / 2);
         for (IMapObject newMapObject : newObjects) {
           EditorScreen.instance().getMapComponent().add(newMapObject);
         }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/IconTreeListRenderer.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/IconTreeListRenderer.java
@@ -75,7 +75,7 @@ public class IconTreeListRenderer implements TreeCellRenderer {
       return null;
     }
 
-    String cacheKey = Game.getEnvironment().getMap().getName() + "-" + prop.getSpritesheetName().toLowerCase() + "-tree";
+    String cacheKey = Game.world().environment().getMap().getName() + "-" + prop.getSpritesheetName().toLowerCase() + "-tree";
     BufferedImage propImag = Resources.images().get(cacheKey, () -> {
       final String name = Program.PROP_SPRITE_PREFIX + prop.getSpritesheetName().toLowerCase() + "-" + PropState.INTACT.toString().toLowerCase();
       final String fallbackName = Program.PROP_SPRITE_PREFIX + prop.getSpritesheetName().toLowerCase();
@@ -99,7 +99,7 @@ public class IconTreeListRenderer implements TreeCellRenderer {
   }
 
   private static Icon getIcon(Creature creature) {
-    String cacheKey = Game.getEnvironment().getMap().getName() + "-" + creature.getSpritePrefix() + "-" + creature.getMapId() + "-tree";
+    String cacheKey = Game.world().environment().getMap().getName() + "-" + creature.getSpritePrefix() + "-" + creature.getMapId() + "-tree";
     
     BufferedImage propImag = Resources.images().get(cacheKey, () -> {
       Collection<Spritesheet> sprites = Resources.spritesheets().get(s -> s.getName().equals(creature.getSpritePrefix() + CreatureAnimationController.IDLE) || s.getName().equals(creature.getSpritePrefix() + CreatureAnimationController.WALK)

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/TagPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/TagPanel.java
@@ -211,7 +211,7 @@ public class TagPanel extends JPanel {
       return null;
     }
 
-    Optional<String> found = Game.getEnvironment().getUsedTags().stream().filter(x -> x != null && !this.getTagStrings().contains(x) && x.startsWith(currentText.toLowerCase())).findFirst();
+    Optional<String> found = Game.world().environment().getUsedTags().stream().filter(x -> x != null && !this.getTagStrings().contains(x) && x.startsWith(currentText.toLowerCase())).findFirst();
     return found.isPresent() ? found.get() : null;
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/EmitterPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/EmitterPanel.java
@@ -103,7 +103,7 @@ public class EmitterPanel extends PropertyPanel {
 
   @Override
   protected void setControlValues(IMapObject mapObject) {
-    this.emitter = (CustomEmitter) Game.getEnvironment().getEmitter(mapObject.getId());
+    this.emitter = (CustomEmitter) Game.world().environment().getEmitter(mapObject.getId());
     if (emitter == null) {
       this.btnPause.setSelected(false);
       return;

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/LightSourcePanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/LightSourcePanel.java
@@ -188,39 +188,39 @@ public class LightSourcePanel extends PropertyPanel {
       this.spinnerBrightness.setValue(result.getAlpha());
       if (getDataSource() != null) {
         getDataSource().setValue(MapObjectProperty.LIGHT_COLOR, h);
-        Game.getEnvironment().reloadFromMap(getDataSource().getId());
-        Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+        Game.world().environment().reloadFromMap(getDataSource().getId());
+        Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
       }
     });
 
     this.spinnerBrightness.addChangeListener(new MapObjectPropertyChangeListener(m -> {
       m.setValue(MapObjectProperty.LIGHT_ALPHA, spinnerBrightness.getValue().toString());
-      Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
     }));
 
     this.spinnerIntensity.addChangeListener(new MapObjectPropertyChangeListener(m -> {
       m.setValue(MapObjectProperty.LIGHT_INTENSITY, spinnerIntensity.getValue().toString());
-      Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
     }));
 
     this.comboBoxLightShape.addActionListener(new MapObjectPropertyActionListener(m -> {
       m.setValue(MapObjectProperty.LIGHT_SHAPE, comboBoxLightShape.getSelectedItem().toString());
-      Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
     }));
 
     this.checkBoxIsActive.addActionListener(new MapObjectPropertyActionListener(m -> {
       m.setValue(MapObjectProperty.LIGHT_ACTIVE, checkBoxIsActive.isSelected());
-      Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
     }));
 
     this.sliderOffsetX.addChangeListener(new MapObjectPropertyChangeListener(m -> {
       m.setValue(MapObjectProperty.LIGHT_FOCUSOFFSETX, this.sliderOffsetX.getValue() / 100.0);
-      Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
     }));
 
     this.sliderOffsetY.addChangeListener(new MapObjectPropertyChangeListener(m -> {
       m.setValue(MapObjectProperty.LIGHT_FOCUSOFFSETY, this.sliderOffsetY.getValue() / 100.0);
-      Game.getEnvironment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
+      Game.world().environment().getAmbientLight().updateSection(getDataSource().getBoundingBox());
     }));
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/PropertyPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/PropertyPanel.java
@@ -165,9 +165,9 @@ public abstract class PropertyPanel extends JPanel {
   protected void updateEnvironment(final IMapObject before) {
     if (getDataSource() instanceof IMapObject) {
       IMapObject obj = getDataSource();
-      Game.getEnvironment().reloadFromMap(obj.getId());
+      Game.world().environment().reloadFromMap(obj.getId());
       if (MapObjectType.get(obj.getType()) == MapObjectType.LIGHTSOURCE) {
-        Game.getEnvironment().getAmbientLight().updateSection(MapObject.getBounds(before, obj));
+        Game.world().environment().getAmbientLight().updateSection(MapObject.getBounds(before, obj));
       }
     }
   }


### PR DESCRIPTION
This pull request solves the requests of feature request #196.
**API changes:**

- `Game.getEnvironment()` -> `Game.world().environment()`
- `Game.getCamera()` -> `Game.world().camera()`
- `Game.addEnvironmentLoadedListener(EnvironmentLoadedListener)` -> `Game.world().addLoadedListener(EnvironmentLoadedListener)`
- `Game.loadEnvironment(IEnvironment)` -> `Game.world().loadEnvironment(IEnvironment)`

**API additions:**

- `Game.world().addLoadedListener(String mapName, EnvironmentLoadedListener listener)`
- `Game.world().addUnloadedListener(String mapName, EnvironmentUnloadedListener listener)`
- `Game.world().addListener(String mapName, EnvironmentListener listener)`
- and the remove listener equivalents
- `Game.world().attach(String mapName, IUpdateable updateable)` 
- `Game.world().detach(String mapName, IUpdateable updateable)` 
- `Game.world().getEnvironments()` 
- `Game.world().getEnvironment(String mapName)`
- `Game.world().getEnvironment(IMap map)` 
- `Game.world().loadEnvironment(String mapName)` 
- `Game.world().loadEnvironment(IMap map)` 

It's now possible to attach game logic to different states of an `Environment` life cycle. This logic will be executed on a per-map basis:

- `Game.world().addLoadedListener("test-map", e -> { /* do stuff */ });`
- `Game.world().addUnloadedListener("test-map", e -> { /* do stuff */ });`
- `Game.world().attach("test-map", () -> { /* do stuff */ });`

Using the attach method allows to execute logic in the game's main loop if the map is currently active.

Also, it is now possible to access resources via an alias which can e.g. be used for maps since they have to have a globally unique name. A map that was originally loaded via:
`Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx")`
can be also accessed like:
`Resources.maps().get("test-map")`