### PR TITLE
Update get-litiengine.md to mention MacOS instead of iOS

### DIFF
--- a/docs/creating-a-project/get-litiengine.md
+++ b/docs/creating-a-project/get-litiengine.md
@@ -33,4 +33,4 @@ The LITIengine comes with an editor that supports you with creating game environ
 
 [utiLITI for Windows](https://github.com/gurkenlabs/litiengine/releases/download/v0.4.14-alpha/utiliti-v0.4.14-alpha-win.zip)
 
-[utiLITI for Linux / iOS](https://github.com/gurkenlabs/litiengine/releases/download/v0.4.14-alpha/utiliti-v0.4.14-alpha-linux-mac.zip)
+[utiLITI for Linux / MacOS](https://github.com/gurkenlabs/litiengine/releases/download/v0.4.14-alpha/utiliti-v0.4.14-alpha-linux-mac.zip)


### PR DESCRIPTION
Update get-litiengine.md to mention MacOS instead of iOS, as MacOS is the desktop operating system.