### PR TITLE
Remove Serializable tag

### DIFF
--- a/src/de/gurkenlabs/litiengine/GameInfo.java
+++ b/src/de/gurkenlabs/litiengine/GameInfo.java
@@ -26,7 +26,6 @@ import de.gurkenlabs.litiengine.environment.tilemap.xml.CustomPropertyProvider;
 @XmlRootElement(name = "gameinfo")
 public class GameInfo extends CustomPropertyProvider {
   private static final Logger log = Logger.getLogger(GameInfo.class.getName());
-  private static final long serialVersionUID = 3340166298303962177L;
 
   @XmlElement
   private String name;

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Blueprint.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Blueprint.java
@@ -23,7 +23,6 @@ public class Blueprint extends MapObject {
    * Blueprint in this format support multiple map objects as children (extended template XML).
    */
   public static final String BLUEPRINT_FILE_EXTENSION = "xtx";
-  private static final long serialVersionUID = -7235380251249427834L;
 
   @XmlElement(name = "object")
   private List<MapObject> items = new ArrayList<>();

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProvider.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProvider.java
@@ -1,7 +1,6 @@
 package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
 import java.awt.Color;
-import java.io.Serializable;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -15,9 +14,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.ICustomProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.ICustomPropertyProvider;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-public class CustomPropertyProvider implements ICustomPropertyProvider, Serializable {
-  private static final long serialVersionUID = 5564165255132042594L;
-
+public class CustomPropertyProvider implements ICustomPropertyProvider {
   @XmlElement
   @XmlJavaTypeAdapter(CustomPropertyAdapter.class)
   private Map<String, ICustomProperty> properties;

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
@@ -18,7 +18,6 @@ import de.gurkenlabs.litiengine.util.io.FileUtilities;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class MapImage extends CustomPropertyProvider implements IMapImage {
-  private static final long serialVersionUID = -3571362172734426098L;
 
   /** The source. */
   @XmlAttribute

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
@@ -20,8 +20,6 @@ import de.gurkenlabs.litiengine.environment.tilemap.IMapObjectLayer;
  * The Class MapObject.
  */
 public class MapObject extends CustomPropertyProvider implements IMapObject {
-  private static final long serialVersionUID = -6001981756772928868L;
-
   @XmlAttribute
   private int id;
 

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Terrain.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Terrain.java
@@ -9,7 +9,6 @@ import de.gurkenlabs.litiengine.environment.tilemap.ITerrain;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Terrain extends CustomPropertyProvider implements ITerrain {
   public static final int NONE = -1;
-  private static final long serialVersionUID = 2890727446376641648L;
 
   @XmlAttribute
   private String name;

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TileOffset.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TileOffset.java
@@ -9,8 +9,6 @@ import de.gurkenlabs.litiengine.environment.tilemap.ITileOffset;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TileOffset extends CustomPropertyProvider implements ITileOffset {
 
-  private static final long serialVersionUID = 8543461379051662633L;
-
   @XmlAttribute
   private int x;
 

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
@@ -30,7 +30,6 @@ import de.gurkenlabs.litiengine.util.io.XmlUtilities;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Tileset extends CustomPropertyProvider implements ITileset {
   public static final String FILE_EXTENSION = "tsx";
-  private static final long serialVersionUID = 1711536300667154031L;
 
   @XmlAttribute
   private int firstgid;

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TilesetEntry.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TilesetEntry.java
@@ -15,8 +15,6 @@ import de.gurkenlabs.litiengine.util.ArrayUtilities;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TilesetEntry extends CustomPropertyProvider implements ITilesetEntry {
 
-  private static final long serialVersionUID = -3356859779159630943L;
-
   private transient ITerrain[] terrains;
 
   @XmlAttribute

--- a/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProviderTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProviderTests.java
@@ -14,7 +14,6 @@ public class CustomPropertyProviderTests {
 
   @Test
   public void testSetCustomProperty() {
-    @SuppressWarnings("serial")
     CustomPropertyProvider propProvider = new CustomPropertyProvider() {};
     propProvider.setValue("test", "testvalue");
 


### PR DESCRIPTION
The `Serializable` interface indicates that a class is intended to be
serialized through the Java Serialization API, AKA the `ObjectInputStream`
and `ObjectOutputStream` classes. If they're not supposed to be serialized
using those classes, they shouldn't implement `Serializable`.