### PR TITLE
Use ./gradlew test instead of ./gradlew fullbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
     token:
       secure: G0KkiaIo+eBOrLgnvH5R6OLxhp7KWXEhP4VYuIo+yF0to4ZI3xLpmWL8ILQy9y//1QY6srbvTD6plpir3j7pToquko0GSpJwrcbQYjs+8WisH8f3WHFNGZoi3Y0BGwk3ozlcAwsxjpFvx/b1LPx5uPQpKNPaV35ag+IajholPXSwRi86/LvL12IxI5UgNfpEXwLiEquUJp9IGLGWFNT4Nb6TsZdD5EBerjkRJGyVV3MZvASiTLZLnV8CswFucbz5+SUBRmqNfSHzzryXnTwgFS7CNp3TRyNHWh5xBE2bbAvkgy3G/xSECQ3qUglxNleZ/AYqYyAbQfCX2q9WEwYD3OvZOZ3qyjzxdJ3NBa50KnKduiSF6GQDmmrUS6n6pu6R77NVz1fzkD4oz0Uny5BeiB5fkhn4rEVk9QmCOnfAFOj6MjSgFVTMGV3nmh6bHJlKhbHXPiYJAp7dwPWczOj2jevnJ4WO5yoNaAxHQWUMqkaukDjPkQGqF9/GPBElriOBM4CdQ/CGClpa82HexYuiGL+TCChZgcEWgBNLzt5BqMuckdVzmRB6AYXIJQZ0ZdTbDVIAioU6l08oDXM5Y3wd0yDTqKieIyof6lWqGc+hPdyN9wlY6BNGCR2g9wpUTBNPHXULVEixfnaeEUotd87hx26HC0wryuh+ZzY4GTCufQs=
 script: 
-- ./gradlew fullbuild
+- ./gradlew test
 - if [ $TRAVIS_PULL_REQUEST = 'false' ]; then 
     sonar-scanner; 
   fi


### PR DESCRIPTION
From what I can tell, the Travis CI is supposed to be making sure that the code works. It doesn't need to do a full build of the engine. `./gradlew test` will try to compile the code, assemble the dependencies, and run the unit tests and die if any of those tasks fail just like `./gradlew fullbuild`; it just doesn't try to produce a JAR, which we don't need it to do anyway.