### PR TITLE
Add copy constructor to `MapImage`

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/IMapImage.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/IMapImage.java
@@ -57,4 +57,14 @@ public interface IMapImage extends ICustomPropertyProvider {
    * @return The hash code for this map image
    */
   public int hashCode();
+
+  public void setTransparentColor(Color color);
+
+  public void setSource(String source);
+
+  public void setAbsoluteSourcePath(String absolutePath);
+
+  public void setWidth(int width);
+
+  public void setHeight(int height);
 }

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
@@ -48,8 +48,6 @@ public class MapImage extends CustomPropertyProvider implements IMapImage {
    *
    * @param original
    *          the original we want to copy
-   *
-   * @see CustomPropertyProvider()
    */
   public MapImage(MapImage original) {
     super(original);

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
@@ -39,6 +39,37 @@ public class MapImage extends CustomPropertyProvider implements IMapImage {
   @XmlTransient
   private String absolutePath;
 
+  public MapImage(){
+    super();
+  }
+
+  /**
+   * Copy Constructor for copying instances of MapImage.
+   *
+   * @param original
+   *          the original we want to copy
+   *
+   * @see CustomPropertyProvider()
+   */
+  public MapImage(MapImage original) {
+    super(original);
+
+    if(original == null){
+      return;
+    }
+
+    this.source = original.source;
+    if (original.transparentcolor != null){
+      this.transparentcolor = new Color(original.transparentcolor.getRed(),
+              original.transparentcolor.getGreen(),
+              original.transparentcolor.getBlue(),
+              original.transparentcolor.getAlpha());
+    }
+    this.width = original.width;
+    this.height = original.height;
+    this.absolutePath = original.absolutePath;
+  }
+
   @Override
   public String getAbsoluteSourcePath() {
     return this.absolutePath;
@@ -84,6 +115,31 @@ public class MapImage extends CustomPropertyProvider implements IMapImage {
 
   public void setAbsolutePath(final String mapPath) {
     this.absolutePath = FileUtilities.combine(mapPath, this.getSource());
+  }
+
+  @Override
+  public void setTransparentColor(Color color) {
+    this.transparentcolor = color;
+  }
+
+  @Override
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  @Override
+  public void setAbsoluteSourcePath(String absolutePath) {
+    this.absolutePath = absolutePath;
+  }
+
+  @Override
+  public void setWidth(int width) {
+    this.width = width;
+  }
+
+  @Override
+  public void setHeight(int height) {
+    this.height = height;
   }
 
   @Override

--- a/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImageTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImageTests.java
@@ -1,0 +1,53 @@
+package de.gurkenlabs.litiengine.environment.tilemap.xml;
+
+import org.junit.jupiter.api.Test;
+import java.awt.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MapImageTests {
+
+    /**
+     * Tests the copy constructor and verifies that there are no side effects.
+     */
+    @Test
+    public void testCopyConstructor() {
+        MapImage original = new MapImage();
+        MapImage copy = new MapImage(original);
+
+        verifyUnmodified(copy);
+
+        // Change original, verify it does not affect the copy
+        original.setSource("source1");
+        original.setAbsoluteSourcePath("abs1");
+        original.setTransparentColor(Color.GREEN);
+        original.setHeight(10);
+        original.setWidth(10);
+
+        verifyUnmodified(copy);
+
+        // Change the copy, verify it does not affect the original
+        copy.setSource("source2");
+        copy.setAbsoluteSourcePath("abs2");
+        copy.setTransparentColor(Color.RED);
+        copy.setHeight(20);
+        copy.setWidth(20);
+
+        assertEquals("source1", original.getSource());
+        assertEquals("abs1", original.getAbsoluteSourcePath());
+        assertEquals(Color.GREEN, original.getTransparentColor());
+        assertEquals(10, original.getWidth());
+        assertEquals(10, original.getHeight());
+    }
+
+    /**
+     * Helper method to verify that a newly created map image is valid.
+     */
+    public static void verifyUnmodified(MapImage image){
+        assertNull(image.getSource());
+        assertNull(image.getAbsoluteSourcePath());
+        assertNull(image.getTransparentColor());
+        assertEquals(0, image.getWidth());
+        assertEquals(0, image.getHeight());
+    }
+}


### PR DESCRIPTION
Copies a MapImage, as detailed in #154. Verified with tests.