### PR TITLE
Remove named spritesheets

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/EmitterMapObjectLoader.java
+++ b/src/de/gurkenlabs/litiengine/environment/EmitterMapObjectLoader.java
@@ -106,6 +106,7 @@ public class EmitterMapObjectLoader extends MapObjectLoader {
     return data;
   }
 
+  @SuppressWarnings("deprecation")
   public static IMapObject createMapObject(EmitterData emitterData) {
     MapObject newMapObject = new MapObject();
     newMapObject.setType(MapObjectType.EMITTER.toString());

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/MapRenderer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/MapRenderer.java
@@ -96,6 +96,7 @@ public abstract class MapRenderer {
     return layer.isVisible() && layer.getOpacity() > 0f;
   }
 
+  @SuppressWarnings("deprecation")
   protected static void renderImageLayer(Graphics2D g, IImageLayer layer, Rectangle2D viewport) {
     Spritesheet sprite = Resources.spritesheets().get(layer.getImage().getSource());
     if (sprite == null) {
@@ -163,7 +164,7 @@ public abstract class MapRenderer {
       }
     }
 
-    BufferedImage tileImage = sprite.getSprite(index, tileset.getMargin(), tileset.getSpacing());
+    BufferedImage tileImage = sprite.getSprite(index);
     if (tile.isFlipped()) {
       if (tile.isFlippedDiagonally()) {
         tileImage = Imaging.rotate(tileImage, -Math.PI / 2);

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
@@ -137,6 +137,7 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     return this.spacing;
   }
 
+  @SuppressWarnings("deprecation")
   @Override
   @XmlTransient
   public Spritesheet getSpritesheet() {

--- a/src/de/gurkenlabs/litiengine/graphics/Spritesheet.java
+++ b/src/de/gurkenlabs/litiengine/graphics/Spritesheet.java
@@ -18,6 +18,7 @@ public final class Spritesheet {
   private final List<Integer> emptySprites = new CopyOnWriteArrayList<>();
 
   private final BufferedImage image;
+  @Deprecated
   private final String name;
   private final ImageFormat imageFormat;
 
@@ -27,7 +28,21 @@ public final class Spritesheet {
   private int spriteHeight;
   private int spriteWidth;
 
-  public Spritesheet(final BufferedImage image, final String path, final int spriteWidth, final int spriteHeight) {
+  public Spritesheet(BufferedImage image, int spriteWidth, int spriteHeight) {
+    this(image, null, spriteWidth, spriteHeight, 0, 0);
+  }
+
+  public Spritesheet(BufferedImage image, int spriteWidth, int spriteHeight, int margin, int spacing) {
+    this(image, null, spriteWidth, spriteHeight, margin, spacing);
+  }
+
+  @Deprecated
+  public Spritesheet(BufferedImage image, String path, int spriteWidth, int spriteHeight) {
+    this(image, path, spriteWidth, spriteHeight, 0, 0);
+  }
+
+  @Deprecated
+  public Spritesheet(final BufferedImage image, final String path, final int spriteWidth, final int spriteHeight, int margin, int spacing) {
     checkImage(image, path);
     this.image = image;
     this.checkHeight(spriteHeight);
@@ -93,6 +108,7 @@ public final class Spritesheet {
    *
    * @return The name of the spritesheet.
    */
+  @Deprecated
   public String getName() {
     return this.name;
   }
@@ -105,6 +121,10 @@ public final class Spritesheet {
     return this.getSprite(index, 0, 0);
   }
 
+  /**
+   * @deprecated Margin and spacing are to be changed to fields within the spritesheet.
+   */
+  @Deprecated
   public BufferedImage getSprite(final int index, final int margin, final int spacing) {
     if (this.emptySprites.contains(index) || this.sprites.length == 0) {
       return null;
@@ -162,6 +182,7 @@ public final class Spritesheet {
     return this.getRows() * this.getColumns();
   }
 
+  @Deprecated
   public boolean isLoaded() {
     return Resources.spritesheets().contains(this.getName());
   }

--- a/src/de/gurkenlabs/litiengine/graphics/animation/Animation.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/Animation.java
@@ -27,18 +27,22 @@ public class Animation implements IUpdateable, ILaunchable {
   private boolean playing;
   private Spritesheet spritesheet;
 
+  @Deprecated
   public Animation(final String spriteSheetName, final boolean loop, final boolean randomizeStart, final int... keyFrameDurations) {
     this(Resources.spritesheets().get(spriteSheetName), loop, randomizeStart, keyFrameDurations);
   }
 
+  @SuppressWarnings("deprecation")
   public Animation(final Spritesheet spritesheet, final boolean loop, final boolean randomizeStart, final int... keyFrameDurations) {
     this(spritesheet.getName(), spritesheet, loop, randomizeStart, keyFrameDurations);
   }
 
+  @SuppressWarnings("deprecation")
   public Animation(final Spritesheet spritesheet, final boolean loop, final int... keyFrameDurations) {
     this(spritesheet.getName(), spritesheet, loop, keyFrameDurations);
   }
 
+  @Deprecated
   public Animation(final String name, final Spritesheet spritesheet, final boolean loop, final boolean randomizeStart, final int... keyFrameDurations) {
     this(name, spritesheet, loop, keyFrameDurations);
 
@@ -47,6 +51,7 @@ public class Animation implements IUpdateable, ILaunchable {
     }
   }
 
+  @Deprecated
   public Animation(final String name, final Spritesheet spritesheet, final boolean loop, final int... keyFrameDurations) {
     this.name = name;
     this.spritesheet = spritesheet;
@@ -60,7 +65,7 @@ public class Animation implements IUpdateable, ILaunchable {
 
     this.initKeyFrames(keyFrameDurations);
     if (this.getKeyframes().isEmpty()) {
-      log.log(Level.WARNING, "No keyframes defined for animation " + this.getName() + " (spitesheet: {0})", spritesheet.getName());
+      log.log(Level.WARNING, "No keyframes defined for animation " + this.getName() + " (spritesheet: {0})", spritesheet.getName());
     }
   }
 
@@ -90,6 +95,7 @@ public class Animation implements IUpdateable, ILaunchable {
     return this.name;
   }
 
+  @SuppressWarnings("deprecation")
   public Spritesheet getSpritesheet() {
     // in case the previously sprite sheet was unloaded (removed from the loaded sprite sheets),
     // try to find an updated one by the name of the previously used sprite
@@ -195,6 +201,7 @@ public class Animation implements IUpdateable, ILaunchable {
     this.elapsedTicks = 0;
   }
 
+  @SuppressWarnings("deprecation")
   private void initKeyFrames(final int... keyFrames) {
     if (this.getSpritesheet() == null) {
       return;

--- a/src/de/gurkenlabs/litiengine/graphics/animation/AnimationController.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/AnimationController.java
@@ -42,6 +42,7 @@ public class AnimationController implements IAnimationController {
     this(sprite, true);
   }
 
+  @SuppressWarnings("deprecation")
   public AnimationController(final Spritesheet sprite, boolean loop) {
     this(new Animation(sprite, loop, Resources.spritesheets().getCustomKeyFrameDurations(sprite)));
   }

--- a/src/de/gurkenlabs/litiengine/graphics/animation/CreatureAnimationController.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/CreatureAnimationController.java
@@ -58,6 +58,7 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
 
   public Animation flipAnimation(Spritesheet spriteToFlip, String newSpriteName) {
     final BufferedImage leftIdleSprite = Imaging.flipSpritesHorizontally(spriteToFlip);
+    @SuppressWarnings("deprecation")
     Spritesheet leftIdleSpritesheet = Resources.spritesheets().load(leftIdleSprite, newSpriteName, spriteToFlip.getSpriteWidth(), spriteToFlip.getSpriteHeight());
     return new Animation(leftIdleSpritesheet, true);
   }
@@ -120,6 +121,7 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
     return null;
   }
 
+  @Deprecated
   private void initializeAvailableAnimations() {
     for (Direction dir : Direction.values()) {
       // initialize walking animations

--- a/src/de/gurkenlabs/litiengine/graphics/animation/EntityAnimationController.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/EntityAnimationController.java
@@ -41,6 +41,7 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
     this(entity, sprite, true);
   }
 
+  @SuppressWarnings("deprecation")
   public EntityAnimationController(final T entity, final Spritesheet sprite, boolean loop) {
     this(entity, new Animation(sprite, loop, Resources.spritesheets().getCustomKeyFrameDurations(sprite)));
   }

--- a/src/de/gurkenlabs/litiengine/graphics/animation/PropAnimationController.java
+++ b/src/de/gurkenlabs/litiengine/graphics/animation/PropAnimationController.java
@@ -97,15 +97,17 @@ public class PropAnimationController<T extends Prop> extends EntityAnimationCont
     return sb.toString();
   }
 
+  @SuppressWarnings("deprecation")
   private static Animation createAnimation(final Prop prop, final PropState state) {
     final Spritesheet spritesheet = findSpriteSheet(prop, state);
     if (spritesheet == null) {
       return null;
     }
 
-    return new Animation(state.name(), spritesheet, true, true, Resources.spritesheets().getCustomKeyFrameDurations(spritesheet.getName()));
+    return new Animation(spritesheet, true, true, Resources.spritesheets().getCustomKeyFrameDurations(spritesheet.getName()));
   }
 
+  @Deprecated
   private static Spritesheet findSpriteSheet(final Prop prop, final PropState state) {
     if (prop == null || prop.getSpritesheetName() == null || prop.getSpritesheetName().isEmpty()) {
       return null;

--- a/src/de/gurkenlabs/litiengine/graphics/emitters/xml/CustomEmitter.java
+++ b/src/de/gurkenlabs/litiengine/graphics/emitters/xml/CustomEmitter.java
@@ -113,6 +113,7 @@ public class CustomEmitter extends Emitter {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   protected Particle createNewParticle() {
     float x;
     float y;

--- a/src/de/gurkenlabs/litiengine/graphics/emitters/xml/EmitterData.java
+++ b/src/de/gurkenlabs/litiengine/graphics/emitters/xml/EmitterData.java
@@ -106,6 +106,7 @@ public class EmitterData implements Serializable, Resource {
   @XmlElement
   private boolean animateSprite;
 
+  @Deprecated
   @XmlElement
   private String spritesheet;
 
@@ -322,6 +323,7 @@ public class EmitterData implements Serializable, Resource {
     this.animateSprite = animateSprite;
   }
 
+  @Deprecated
   @XmlTransient
   public String getSpritesheet() {
     return spritesheet;

--- a/src/de/gurkenlabs/litiengine/gui/ImageComponent.java
+++ b/src/de/gurkenlabs/litiengine/gui/ImageComponent.java
@@ -66,6 +66,7 @@ public class ImageComponent extends GuiComponent {
     }
   }
 
+  @SuppressWarnings("deprecation")
   public Image getBackground() {
     if (this.getSpritesheet() == null) {
       return null;

--- a/src/de/gurkenlabs/litiengine/resources/Resources.java
+++ b/src/de/gurkenlabs/litiengine/resources/Resources.java
@@ -55,6 +55,7 @@ public final class Resources {
   private static Tilesets tilesets = new Tilesets();
   private static Strings strings = new Strings();
   private static Images images = new Images();
+  @Deprecated
   private static Spritesheets spritesheets = new Spritesheets();
 
   private Resources() {
@@ -135,6 +136,7 @@ public final class Resources {
    * 
    * @see Spritesheet
    */
+  @Deprecated
   public static Spritesheets spritesheets() {
     return spritesheets;
   }
@@ -146,6 +148,7 @@ public final class Resources {
    * @param gameResourceFile
    *          The file name of the game resource file
    */
+  @SuppressWarnings("deprecation")
   public static void load(final String gameResourceFile) {
     final long loadStart = System.nanoTime();
 

--- a/src/de/gurkenlabs/litiengine/resources/SpritesheetResource.java
+++ b/src/de/gurkenlabs/litiengine/resources/SpritesheetResource.java
@@ -13,6 +13,7 @@ import de.gurkenlabs.litiengine.graphics.Spritesheet;
 import de.gurkenlabs.litiengine.util.ArrayUtilities;
 import de.gurkenlabs.litiengine.util.io.Codec;
 
+@SuppressWarnings("deprecation")
 @XmlRootElement(name = "sprite")
 public class SpritesheetResource extends NamedResource implements Serializable {
   public static final String PLAIN_TEXT_FILE_EXTENSION = "info";

--- a/src/de/gurkenlabs/litiengine/resources/Spritesheets.java
+++ b/src/de/gurkenlabs/litiengine/resources/Spritesheets.java
@@ -18,6 +18,7 @@ import de.gurkenlabs.litiengine.graphics.Spritesheet;
 import de.gurkenlabs.litiengine.util.io.Codec;
 import de.gurkenlabs.litiengine.util.io.FileUtilities;
 
+@Deprecated
 public final class Spritesheets extends ResourcesContainer<Spritesheet> {
   private final Map<String, int[]> customKeyFrameDurations = new ConcurrentHashMap<>();
   private static final Logger log = Logger.getLogger(Spritesheet.class.getName());

--- a/tests/de/gurkenlabs/litiengine/graphics/AnimationEmitterTests.java
+++ b/tests/de/gurkenlabs/litiengine/graphics/AnimationEmitterTests.java
@@ -8,14 +8,13 @@ import org.junit.jupiter.api.Test;
 
 import de.gurkenlabs.litiengine.graphics.animation.Animation;
 import de.gurkenlabs.litiengine.graphics.emitters.AnimationEmitter;
-import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.util.Imaging;
 
 public class AnimationEmitterTests {
 
   @Test
   public void testInitialization() {
-    Spritesheet sheet = Resources.spritesheets().load(Imaging.getCompatibleImage(16, 16), "some-sprite", 16, 16);
+    Spritesheet sheet = new Spritesheet(Imaging.getCompatibleImage(16, 16), 16, 16);
     AnimationEmitter emitter = new AnimationEmitter(sheet, new Point2D.Double(0, 0));
 
     assertEquals(16, emitter.getWidth(), 0.0001);

--- a/tests/de/gurkenlabs/litiengine/resources/ResourcesTests.java
+++ b/tests/de/gurkenlabs/litiengine/resources/ResourcesTests.java
@@ -21,7 +21,6 @@ public class ResourcesTests {
     assertNotNull(Resources.images());
     assertNotNull(Resources.maps());
     assertNotNull(Resources.sounds());
-    assertNotNull(Resources.spritesheets());
     assertNotNull(Resources.strings());
   }
 

--- a/tests/de/gurkenlabs/litiengine/util/ImagingTests.java
+++ b/tests/de/gurkenlabs/litiengine/util/ImagingTests.java
@@ -189,7 +189,7 @@ public class ImagingTests {
   @Test
   public void testSpriteFlipHorizontally() {
     BufferedImage image = Resources.images().get("tests/de/gurkenlabs/litiengine/util/prop-flag.png");
-    Spritesheet sprite = new Spritesheet(image, "tests/de/gurkenlabs/litiengine/util/prop-flag.png", 15, 16);
+    Spritesheet sprite = new Spritesheet(image, 15, 16);
     BufferedImage imageFlippedHor = Resources.images().get("tests/de/gurkenlabs/litiengine/util/prop-flag-spriteflip-hor.png");
 
     int[] expectedPixels = ((DataBufferInt) imageFlippedHor.getData().getDataBuffer()).getData();
@@ -202,7 +202,7 @@ public class ImagingTests {
   @Test
   public void testSpriteFlipVertically() {
     BufferedImage image = Resources.images().get("tests/de/gurkenlabs/litiengine/util/prop-flag-2rows.png");
-    Spritesheet sprite = new Spritesheet(image, "tests/de/gurkenlabs/litiengine/util/prop-flag-2rows.png", 15, 16);
+    Spritesheet sprite = new Spritesheet(image, 15, 16);
     BufferedImage imageFlippedVer = Resources.images().get("tests/de/gurkenlabs/litiengine/util/prop-flag-spriteflip-ver.png");
 
     int[] expectedPixels = ((DataBufferInt) imageFlippedVer.getData().getDataBuffer()).getData();


### PR DESCRIPTION
This is something that has bugged me from the very beginning. Spritesheets should be just a convenient wrapper for collection of images sewn together, not named resources. If it's absolutely necessary, a `SpritesheetResource` should be used instead.

Unfortunately, this attitude towards them is far too pervasive within the engine for me to remove on my own, especially not without breaking anything. I'm requesting help, therefore, to remove named spritesheets from the code. Items marked `@Deprecated` are those that I intend to remove or change incompatibly by the time this project is finished.