### PR TITLE
Rename the Map implementation.

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/GroupLayer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/GroupLayer.java
@@ -49,7 +49,7 @@ public class GroupLayer extends Layer implements IGroupLayer {
     this.layers.add(layer);
     this.layerAdded(layer);
     if (layer instanceof Layer) {
-      ((Layer) layer).setMap((Map) this.getMap());
+      ((Layer) layer).setMap((TmxMap) this.getMap());
     }
   }
 
@@ -58,7 +58,7 @@ public class GroupLayer extends Layer implements IGroupLayer {
     this.layers.add(index, layer);
     this.layerAdded(layer);
     if (layer instanceof Layer) {
-      ((Layer) layer).setMap((Map) this.getMap());
+      ((Layer) layer).setMap((TmxMap) this.getMap());
     }
   }
 

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/ImageLayer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/ImageLayer.java
@@ -32,7 +32,7 @@ public class ImageLayer extends Layer implements IImageLayer {
   @Override
   public int getOffsetX() {
     if (this.isInfiniteMap()) {
-      Map map = (Map) this.getMap();
+      TmxMap map = (TmxMap) this.getMap();
       return super.getOffsetX() - map.getChunkOffsetX() * map.getTileWidth();
     }
 
@@ -42,7 +42,7 @@ public class ImageLayer extends Layer implements IImageLayer {
   @Override
   public int getOffsetY() {
     if (this.isInfiniteMap()) {
-      Map map = (Map) this.getMap();
+      TmxMap map = (TmxMap) this.getMap();
       return super.getOffsetX() - map.getChunkOffsetY() * map.getTileHeight();
     }
 
@@ -50,7 +50,7 @@ public class ImageLayer extends Layer implements IImageLayer {
   }
 
   private boolean isInfiniteMap() {
-    return this.getMap() != null && this.getMap().isInfinite() && this.getMap() instanceof Map;
+    return this.getMap() != null && this.getMap().isInfinite() && this.getMap() instanceof TmxMap;
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
@@ -48,7 +48,7 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer {
   @XmlAttribute
   private Integer offsety;
 
-  private transient Map parentMap;
+  private transient TmxMap parentMap;
   private transient RenderType renderType;
   private transient boolean renderTypeLoaded;
 
@@ -215,13 +215,13 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer {
     this.visible = visible ? 1 : 0;
   }
 
-  protected void setMap(Map map) {
+  protected void setMap(TmxMap map) {
     this.parentMap = map;
   }
 
   protected void afterUnmarshal(Unmarshaller u, Object parent) {
-    if (parent instanceof Map) {
-      this.parentMap = (Map) parent;
+    if (parent instanceof TmxMap) {
+      this.parentMap = (TmxMap) parent;
     }
 
     if (this.offsetx != null && this.offsetx.intValue() == 0) {

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
@@ -246,7 +246,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   @XmlTransient
   public void setX(float x) {
     if (this.isInfiniteMap()) {
-      Map map = (Map) this.getLayer().getMap();
+      TmxMap map = (TmxMap) this.getLayer().getMap();
       this.x = x + map.getChunkOffsetX() * map.getTileWidth();
       return;
     }
@@ -258,7 +258,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   @XmlTransient
   public void setY(float y) {
     if (this.isInfiniteMap()) {
-      Map map = (Map) this.getLayer().getMap();
+      TmxMap map = (TmxMap) this.getLayer().getMap();
       this.y = y + map.getChunkOffsetY() * map.getTileHeight();
       return;
     }
@@ -297,7 +297,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   @Override
   public float getX() {
     if (this.isInfiniteMap()) {
-      Map map = (Map) this.getLayer().getMap();
+      TmxMap map = (TmxMap) this.getLayer().getMap();
       return this.x - map.getChunkOffsetX() * map.getTileWidth();
     }
 
@@ -307,7 +307,7 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   @Override
   public float getY() {
     if (this.isInfiniteMap()) {
-      Map map = (Map) this.getLayer().getMap();
+      TmxMap map = (TmxMap) this.getLayer().getMap();
       return this.y - map.getChunkOffsetY() * map.getTileHeight();
     }
 
@@ -379,6 +379,6 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
   }
 
   private boolean isInfiniteMap() {
-    return this.getLayer() != null && this.getLayer().getMap() != null && this.getLayer().getMap().isInfinite() && this.getLayer().getMap() instanceof Map;
+    return this.getLayer() != null && this.getLayer().getMap() != null && this.getLayer().getMap().isInfinite() && this.getLayer().getMap() instanceof TmxMap;
   }
 }

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
@@ -41,10 +41,10 @@ import de.gurkenlabs.litiengine.util.io.FileUtilities;
 
 @XmlRootElement(name = "map")
 @XmlAccessorType(XmlAccessType.FIELD)
-public final class Map extends CustomPropertyProvider implements IMap, Comparable<Map> {
+public final class TmxMap extends CustomPropertyProvider implements IMap, Comparable<TmxMap> {
   public static final String FILE_EXTENSION = "tmx";
 
-  private static final Logger log = Logger.getLogger(Map.class.getName());
+  private static final Logger log = Logger.getLogger(TmxMap.class.getName());
   private static final int[] MAX_SUPPORTED_VERSION = { 1, 2 };
 
   @XmlAttribute
@@ -396,7 +396,7 @@ public final class Map extends CustomPropertyProvider implements IMap, Comparabl
   }
 
   @Override
-  public int compareTo(Map o) {
+  public int compareTo(TmxMap o) {
     if (this.name == null) {
       return o.name == null ? 0 : -1;
     }
@@ -413,10 +413,10 @@ public final class Map extends CustomPropertyProvider implements IMap, Comparabl
     if (this == anObject) {
       return true;
     }
-    if (!(anObject instanceof Map)) {
+    if (!(anObject instanceof TmxMap)) {
       return false;
     }
-    return Objects.equals(this.name, ((Map) anObject).name);
+    return Objects.equals(this.name, ((TmxMap) anObject).name);
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/resources/Maps.java
+++ b/src/de/gurkenlabs/litiengine/resources/Maps.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import javax.xml.bind.JAXBException;
 
 import de.gurkenlabs.litiengine.environment.tilemap.IMap;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxException;
 import de.gurkenlabs.litiengine.util.io.FileUtilities;
 import de.gurkenlabs.litiengine.util.io.XmlUtilities;
@@ -17,14 +17,14 @@ public final class Maps extends ResourcesContainer<IMap> {
 
   public static boolean isSupported(String fileName) {
     String extension = FileUtilities.getExtension(fileName);
-    return extension != null && !extension.isEmpty() && extension.equalsIgnoreCase(Map.FILE_EXTENSION);
+    return extension != null && !extension.isEmpty() && extension.equalsIgnoreCase(TmxMap.FILE_EXTENSION);
   }
 
   @Override
   protected IMap load(URL resourceName) throws TmxException {
-    Map map;
+    TmxMap map;
     try {
-      map = XmlUtilities.readFromFile(Map.class, resourceName);
+      map = XmlUtilities.readFromFile(TmxMap.class, resourceName);
     } catch (JAXBException e) {
       throw new TmxException("could not parse xml data", e);
     }

--- a/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -30,7 +30,7 @@ import javax.xml.bind.annotation.XmlTransient;
 
 import de.gurkenlabs.litiengine.environment.tilemap.ITileset;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Blueprint;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
 import de.gurkenlabs.litiengine.graphics.emitters.xml.EmitterData;
 import de.gurkenlabs.litiengine.util.io.XmlUtilities;
@@ -48,7 +48,7 @@ public class ResourceBundle implements Serializable {
 
   @XmlElementWrapper(name = "maps")
   @XmlElement(name = "map")
-  private List<Map> maps;
+  private List<TmxMap> maps;
 
   @XmlElementWrapper(name = "spriteSheets")
   @XmlElement(name = "sprite")
@@ -94,7 +94,7 @@ public class ResourceBundle implements Serializable {
         tileset.finish(file);
       }
 
-      for (Map map : gameFile.getMaps()) {
+      for (TmxMap map : gameFile.getMaps()) {
         for (final ITileset tileset : map.getTilesets()) {
           if (tileset instanceof Tileset) {
             ((Tileset)tileset).load(gameFile.getTilesets());
@@ -112,7 +112,7 @@ public class ResourceBundle implements Serializable {
   }
 
   @XmlTransient
-  public List<Map> getMaps() {
+  public List<TmxMap> getMaps() {
     return this.maps;
   }
 

--- a/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/MapTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/MapTests.java
@@ -47,7 +47,7 @@ public class MapTests {
     assertEquals(new Color(0xaa3df675, true), map.getBackgroundColor());
     assertEquals(new Rectangle2D.Double(0, 0, 256, 256), map.getBounds());
     assertEquals(2, map.getTilesets().size());
-    assertEquals(1, ((Map) map).getExternalTilesets().size());
+    assertEquals(1, ((TmxMap) map).getExternalTilesets().size());
     assertEquals("external-tileset", map.getTilesets().get(1).getName());
     assertEquals(1, map.getTileLayers().size());
     assertEquals(16, map.getTileLayers().get(0).getSizeInTiles().width);
@@ -70,7 +70,7 @@ public class MapTests {
 
   @Test
   public void testSettingProperties() {
-    Map map = (Map) Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx");
+    TmxMap map = (TmxMap) Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx");
     map.setOrientation(MapOrientations.ISOMETRIC_STAGGERED);
     map.setTiledVersion("0.0.0");
     map.setVersion(2.0);
@@ -145,7 +145,7 @@ public class MapTests {
 
   @Test
   public void testInfiniteMap() {
-    Map map = (Map) Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-infinite-map.tmx");
+    TmxMap map = (TmxMap) Resources.maps().get("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-infinite-map.tmx");
 
     assertTrue(map.isInfinite());
     assertEquals(64, map.getWidth());

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -67,7 +67,7 @@ import de.gurkenlabs.litiengine.GameListener;
 import de.gurkenlabs.litiengine.configuration.Quality;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectType;
 import de.gurkenlabs.litiengine.environment.tilemap.MapProperty;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.graphics.ImageFormat;
 import de.gurkenlabs.litiengine.input.Input;
 import de.gurkenlabs.litiengine.resources.Resources;
@@ -621,7 +621,7 @@ public class Program {
 
         UndoManager.instance().recordChanges();
         EditorScreen.instance().getMapComponent().loadMaps(EditorScreen.instance().getGameFile().getMaps());
-        EditorScreen.instance().getMapComponent().loadEnvironment((Map) Game.world().environment().getMap());
+        EditorScreen.instance().getMapComponent().loadEnvironment((TmxMap) Game.world().environment().getMap());
       }
     });
 

--- a/utiliti/src/de/gurkenlabs/utiliti/components/EditorScreen.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/EditorScreen.java
@@ -37,7 +37,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.environment.tilemap.ITileset;
 import de.gurkenlabs.litiengine.environment.tilemap.MapRenderer;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Blueprint;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxException;
 import de.gurkenlabs.litiengine.graphics.ImageFormat;
@@ -240,7 +240,7 @@ public class EditorScreen extends Screen {
       this.gameFile = new ResourceBundle();
 
       // add sprite sheets by tile sets of all maps in the project director
-      for (Map map : this.mapComponent.getMaps()) {
+      for (TmxMap map : this.mapComponent.getMaps()) {
         this.loadSpriteSheets(map);
       }
 
@@ -324,7 +324,7 @@ public class EditorScreen extends Screen {
       log.log(Level.INFO, "{0} blueprints loaded from {1}", new Object[] { this.getGameFile().getBluePrints().size(), this.currentResourceFile });
       log.log(Level.INFO, "{0} sounds loaded from {1}", new Object[] { this.getGameFile().getSounds().size(), this.currentResourceFile });
 
-      for (Map map : this.mapComponent.getMaps()) {
+      for (TmxMap map : this.mapComponent.getMaps()) {
         this.loadSpriteSheets(map);
       }
 
@@ -627,7 +627,7 @@ public class EditorScreen extends Screen {
     return currentStatus;
   }
 
-  public List<Map> getChangedMaps() {
+  public List<TmxMap> getChangedMaps() {
     return this.getMapComponent().getMaps().stream().filter(UndoManager::hasChanges).distinct().collect(Collectors.toList());
   }
 
@@ -638,7 +638,7 @@ public class EditorScreen extends Screen {
 
   public void updateGameFileMaps() {
     this.getGameFile().getMaps().clear();
-    for (Map map : this.mapComponent.getMaps()) {
+    for (TmxMap map : this.mapComponent.getMaps()) {
       this.getGameFile().getMaps().add(map);
     }
 
@@ -664,10 +664,10 @@ public class EditorScreen extends Screen {
   }
 
   private void saveMaps() {
-    for (Map map : this.getChangedMaps()) {
+    for (TmxMap map : this.getChangedMaps()) {
       UndoManager.save(map);
-      for (String file : FileUtilities.findFilesByExtension(new ArrayList<>(), Paths.get(FileUtilities.combine(this.getProjectPath(), "maps")), map.getName() + "." + Map.FILE_EXTENSION)) {
-        File newFile = XmlUtilities.save(map, file, Map.FILE_EXTENSION);
+      for (String file : FileUtilities.findFilesByExtension(new ArrayList<>(), Paths.get(FileUtilities.combine(this.getProjectPath(), "maps")), map.getName() + "." + TmxMap.FILE_EXTENSION)) {
+        File newFile = XmlUtilities.save(map, file, TmxMap.FILE_EXTENSION);
         log.log(Level.INFO, "synchronized map {0}", new Object[] { newFile });
       }
     }
@@ -679,7 +679,7 @@ public class EditorScreen extends Screen {
     }
   }
 
-  private void loadSpriteSheets(Map map) {
+  private void loadSpriteSheets(TmxMap map) {
     List<SpritesheetResource> infos = new ArrayList<>();
     int cnt = 0;
     for (ITileset tileSet : map.getTilesets()) {

--- a/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
@@ -48,7 +48,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.MapObjectProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectType;
 import de.gurkenlabs.litiengine.environment.tilemap.MapUtilities;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Blueprint;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.MapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.MapObjectLayer;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
@@ -97,7 +97,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   private final List<Consumer<Integer>> editModeChangedConsumer;
   private final List<Consumer<IMapObject>> focusChangedConsumer;
   private final List<Consumer<List<IMapObject>>> selectionChangedConsumer;
-  private final List<Consumer<Map>> mapLoadedConsumer;
+  private final List<Consumer<TmxMap>> mapLoadedConsumer;
 
   private final java.util.Map<String, Integer> selectedLayers;
   private final java.util.Map<String, Point2D> cameraFocus;
@@ -111,7 +111,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
   private int currentZoomIndex = 7;
 
-  private final List<Map> maps;
+  private final List<TmxMap> maps;
 
   private float scrollSpeed = BASE_SCROLL_SPEED;
 
@@ -169,7 +169,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     this.selectionChangedConsumer.add(cons);
   }
 
-  public void onMapLoaded(Consumer<Map> cons) {
+  public void onMapLoaded(Consumer<TmxMap> cons) {
     this.mapLoadedConsumer.add(cons);
   }
 
@@ -206,9 +206,9 @@ public class MapComponent extends EditorComponent implements IUpdateable {
   public void loadMaps(String projectPath) {
     final List<String> files = FileUtilities.findFilesByExtension(new ArrayList<>(), Paths.get(projectPath), "tmx");
     log.log(Level.INFO, "{0} maps found in folder {1}", new Object[] { files.size(), projectPath });
-    final List<Map> loadedMaps = new ArrayList<>();
+    final List<TmxMap> loadedMaps = new ArrayList<>();
     for (final String mapFile : files) {
-      Map map = (Map) Resources.maps().get(mapFile);
+      TmxMap map = (TmxMap) Resources.maps().get(mapFile);
       if (map != null) { // if an error occurred or it's not in the expected
                          // format
         loadedMaps.add(map);
@@ -219,7 +219,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     this.loadMaps(loadedMaps);
   }
 
-  public void loadMaps(List<Map> maps) {
+  public void loadMaps(List<TmxMap> maps) {
     if (maps == null) {
       return;
     }
@@ -233,7 +233,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     EditorScreen.instance().getMapSelectionPanel().bind(this.getMaps(), true);
   }
 
-  public List<Map> getMaps() {
+  public List<TmxMap> getMaps() {
     return this.maps;
   }
 
@@ -285,7 +285,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     super.prepare();
   }
 
-  public void loadEnvironment(Map map) {
+  public void loadEnvironment(TmxMap map) {
     if (map == null) {
       return;
     }
@@ -328,7 +328,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
       EditorScreen.instance().getMapObjectPanel().bind(this.getFocusedMapObject());
 
-      for (Consumer<Map> cons : this.mapLoadedConsumer) {
+      for (Consumer<TmxMap> cons : this.mapLoadedConsumer) {
         cons.accept(map);
       }
 
@@ -342,7 +342,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    this.loadEnvironment((Map) Game.world().environment().getMap());
+    this.loadEnvironment((TmxMap) Game.world().environment().getMap());
   }
 
   public void add(IMapObject mapObject) {
@@ -668,7 +668,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
 
     XmlImportDialog.importXml("Tilemap", file -> {
       String mapPath = file.toURI().toString();
-      Map map = (Map) Resources.maps().get(mapPath);
+      TmxMap map = (TmxMap) Resources.maps().get(mapPath);
       if (map == null) {
         log.log(Level.WARNING, "could not load map from file {0}", new Object[] { mapPath });
         return;
@@ -683,7 +683,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
         map.addLayer(layer);
       }
 
-      Optional<Map> current = this.maps.stream().filter(x -> x.getName().equals(map.getName())).findFirst();
+      Optional<TmxMap> current = this.maps.stream().filter(x -> x.getName().equals(map.getName())).findFirst();
       if (current.isPresent()) {
         int n = JOptionPane.showConfirmDialog(Game.window().getRenderComponent(), Resources.strings().get("input_replace_map", map.getName()), Resources.strings().get("input_replace_map_title"), JOptionPane.YES_NO_OPTION);
 
@@ -727,7 +727,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       EditorScreen.instance().getMapSelectionPanel().bind(this.getMaps(), true);
       this.loadEnvironment(map);
       log.log(Level.INFO, "imported map {0}", new Object[] { map.getName() });
-    }, Map.FILE_EXTENSION);
+    }, TmxMap.FILE_EXTENSION);
   }
 
   public void loadTileset(ITileset tileset, boolean embedded) {
@@ -753,7 +753,7 @@ public class MapComponent extends EditorComponent implements IUpdateable {
       return;
     }
 
-    Map map = (Map) Game.world().environment().getMap();
+    TmxMap map = (TmxMap) Game.world().environment().getMap();
     if (map == null) {
       return;
     }
@@ -761,8 +761,8 @@ public class MapComponent extends EditorComponent implements IUpdateable {
     this.exportMap(map);
   }
 
-  public void exportMap(Map map) {
-    XmlExportDialog.export(map, "Map", map.getName(), Map.FILE_EXTENSION, dir -> {
+  public void exportMap(TmxMap map) {
+    XmlExportDialog.export(map, "Map", map.getName(), TmxMap.FILE_EXTENSION, dir -> {
       for (ITileset tileSet : map.getTilesets()) {
         ImageFormat format = ImageFormat.get(FileUtilities.getExtension(tileSet.getImage().getSource()));
         ImageSerializer.saveImage(Paths.get(dir, tileSet.getImage().getSource()).toString(), Resources.spritesheets().get(tileSet.getImage().getSource()).getImage(), format);

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/AssetTree.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/AssetTree.java
@@ -10,7 +10,7 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 
 import de.gurkenlabs.litiengine.environment.tilemap.ITileset;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
 import de.gurkenlabs.litiengine.graphics.animation.PropAnimationController;
 import de.gurkenlabs.litiengine.resources.ResourceBundle;
@@ -105,7 +105,7 @@ public class AssetTree extends JTree {
       ArrayList<Tileset> allTilesets = new ArrayList<>();
       allTilesets.addAll(gameFile.getTilesets().stream().filter(x -> x.getName() != null).collect(Collectors.toList()));
 
-      for (Map map : gameFile.getMaps()) {
+      for (TmxMap map : gameFile.getMaps()) {
         for (ITileset tileset : map.getTilesets()) {
           if (allTilesets.stream().anyMatch(x -> x.getName() != null && x.getName().equals(tileset.getName()))) {
             continue;

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/MapSelectionPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/MapSelectionPanel.java
@@ -53,7 +53,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObjectLayer;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectType;
-import de.gurkenlabs.litiengine.environment.tilemap.xml.Map;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.MapObjectLayer;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.util.ColorHelper;
@@ -139,7 +139,7 @@ public class MapSelectionPanel extends JSplitPane {
       }
 
       if (this.mapList.getSelectedIndex() < EditorScreen.instance().getMapComponent().getMaps().size() && this.mapList.getSelectedIndex() >= 0) {
-        Map map = EditorScreen.instance().getMapComponent().getMaps().get(this.mapList.getSelectedIndex());
+        TmxMap map = EditorScreen.instance().getMapComponent().getMaps().get(this.mapList.getSelectedIndex());
         if (Game.world().environment() != null && Game.world().environment().getMap().equals(map)) {
           return;
         }
@@ -519,16 +519,16 @@ public class MapSelectionPanel extends JSplitPane {
     UndoManager.onUndoStackChanged(manager -> this.bind(EditorScreen.instance().getMapComponent().getMaps()));
   }
 
-  public synchronized void bind(List<Map> maps) {
+  public synchronized void bind(List<TmxMap> maps) {
     this.bind(maps, false);
   }
 
-  public synchronized void bind(List<Map> maps, boolean clear) {
+  public synchronized void bind(List<TmxMap> maps, boolean clear) {
     if (clear) {
       this.model.clear();
     }
 
-    for (Map map : maps) {
+    for (TmxMap map : maps) {
       String name = map.getName();
       if (UndoManager.hasChanges(map)) {
         name += " *";
@@ -597,7 +597,7 @@ public class MapSelectionPanel extends JSplitPane {
       return;
     }
 
-    Map map = EditorScreen.instance().getMapComponent().getMaps().get(mapList.getSelectedIndex());
+    TmxMap map = EditorScreen.instance().getMapComponent().getMaps().get(mapList.getSelectedIndex());
     int lastSelection = listObjectLayers.getSelectedIndex();
     this.saveLayerVisibility();
     this.layerModel.clear();
@@ -625,7 +625,7 @@ public class MapSelectionPanel extends JSplitPane {
       }
       newBox.setSelected(layer.isVisible());
       newBox.addItemListener(sel -> {
-        Map currentMap = EditorScreen.instance().getMapComponent().getMaps().get(mapList.getSelectedIndex());
+        TmxMap currentMap = EditorScreen.instance().getMapComponent().getMaps().get(mapList.getSelectedIndex());
         int boxIndex = this.layerModel.indexOf(newBox);
         currentMap.getMapObjectLayers().get(boxIndex).setVisible(newBox.isSelected());
         UndoManager.instance().recordChanges();


### PR DESCRIPTION
Fairly simple request, but it does cause incompatible changes. This pull request renames the `Map` class to `TmxMap` to avoid collisions with `java.util.Map`.