### PR TITLE
Add possibility to retrieve info on last collided entities

### DIFF
--- a/src/de/gurkenlabs/litiengine/entities/CollisionEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/CollisionEntity.java
@@ -2,6 +2,8 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.List;
 
 import de.gurkenlabs.litiengine.Align;
 import de.gurkenlabs.litiengine.Game;
@@ -37,7 +39,7 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
 
   private Rectangle2D collisionBox;
   
-  private ICollisionEntity collidedEntity;
+  private List<ICollisionEntity> collidedEntities;
 
   protected CollisionEntity() {
     super();
@@ -49,6 +51,7 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
     this.align = info.align();
     this.collisionType = info.collisionType();
     this.collisionBox = this.getCollisionBox(this.getLocation());
+    this.collidedEntities = new ArrayList<ICollisionEntity> ();
   }
 
   public static Rectangle2D getCollisionBox(final Point2D location, final double entityWidth, final double entityHeight, final double collisionBoxWidth, final double collisionBoxHeight, final Align align, final Valign valign) {
@@ -121,8 +124,8 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
    * {@inheritDoc}
    */
   @Override
-  public ICollisionEntity getLastCollidedEntity() {
-    return this.collidedEntity;
+  public List<ICollisionEntity> getLastCollidedEntities() {
+    return this.collidedEntities;
   }
 
   /**
@@ -214,7 +217,7 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
    * {@inheritDoc}
    */
   @Override
-  public void setLastCollidedEntity(ICollisionEntity entity) {
-    this.collidedEntity = entity;
+  public void addCollidedEntities(ICollisionEntity entity) {
+    this.collidedEntities.add(entity);
   }
 }

--- a/src/de/gurkenlabs/litiengine/entities/CollisionEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/CollisionEntity.java
@@ -121,7 +121,7 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
    * {@inheritDoc}
    */
   @Override
-  public ICollisionEntity getCollidedEntity() {
+  public ICollisionEntity getLastCollidedEntity() {
     return this.collidedEntity;
   }
 
@@ -214,7 +214,7 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
    * {@inheritDoc}
    */
   @Override
-  public void setCollidedEntity(ICollisionEntity entity) {
+  public void setLastCollidedEntity(ICollisionEntity entity) {
     this.collidedEntity = entity;
   }
 }

--- a/src/de/gurkenlabs/litiengine/entities/CollisionEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/CollisionEntity.java
@@ -36,6 +36,8 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
   private Collision collisionType;
 
   private Rectangle2D collisionBox;
+  
+  private ICollisionEntity collidedEntity;
 
   protected CollisionEntity() {
     super();
@@ -113,6 +115,14 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
   @Override
   public Collision getCollisionType() {
     return this.collisionType;
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public ICollisionEntity getCollidedEntity() {
+    return this.collidedEntity;
   }
 
   /**
@@ -198,5 +208,13 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
     } else {
       this.collisionType = type;
     }
+  }
+  
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setCollidedEntity(ICollisionEntity entity) {
+    this.collidedEntity = entity;
   }
 }

--- a/src/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
@@ -2,6 +2,7 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.List;
 
 import de.gurkenlabs.litiengine.Align;
 import de.gurkenlabs.litiengine.Valign;
@@ -44,11 +45,11 @@ public interface ICollisionEntity extends IEntity {
   public double getCollisionBoxWidth();
   
   /**
-   * Gets the last collided entity.
+   * Gets a list of all last collided entities.
    * 
-   * @return the last collided entity; null otherwise
+   * @return a list of all last collided entities; null otherwise
    */
-  public ICollisionEntity getLastCollidedEntity();
+  public List<ICollisionEntity> getLastCollidedEntities();
 
   /**
    * Checks for collision.
@@ -76,10 +77,10 @@ public interface ICollisionEntity extends IEntity {
   public void setCollisionType(Collision collisionType);
   
   /**
-   * Sets the last collided entity
+   * Adds a collided entity at the end of a list of collided entities.
    * 
    * @param entity
-   *          the last collided entity
+   *          a collided entity
    */
-  public void setLastCollidedEntity(ICollisionEntity entity);
+  public void addCollidedEntities(ICollisionEntity entity);
 }

--- a/src/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
@@ -42,6 +42,13 @@ public interface ICollisionEntity extends IEntity {
   public double getCollisionBoxHeight();
 
   public double getCollisionBoxWidth();
+  
+  /**
+   * Gets the first collided entity.
+   * 
+   * @return the first collided entity; null otherwise
+   */
+  public ICollisionEntity getCollidedEntity();
 
   /**
    * Checks for collision.
@@ -67,4 +74,12 @@ public interface ICollisionEntity extends IEntity {
   public void setCollisionBoxValign(final Valign valign);
   
   public void setCollisionType(Collision collisionType);
+  
+  /**
+   * Sets the first collided entity
+   * 
+   * @param entity
+   *          the first collided entity
+   */
+  public void setCollidedEntity(ICollisionEntity entity);
 }

--- a/src/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
+++ b/src/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
@@ -44,11 +44,11 @@ public interface ICollisionEntity extends IEntity {
   public double getCollisionBoxWidth();
   
   /**
-   * Gets the first collided entity.
+   * Gets the last collided entity.
    * 
-   * @return the first collided entity; null otherwise
+   * @return the last collided entity; null otherwise
    */
-  public ICollisionEntity getCollidedEntity();
+  public ICollisionEntity getLastCollidedEntity();
 
   /**
    * Checks for collision.
@@ -76,10 +76,10 @@ public interface ICollisionEntity extends IEntity {
   public void setCollisionType(Collision collisionType);
   
   /**
-   * Sets the first collided entity
+   * Sets the last collided entity
    * 
    * @param entity
-   *          the first collided entity
+   *          the last collided entity
    */
-  public void setCollidedEntity(ICollisionEntity entity);
+  public void setLastCollidedEntity(ICollisionEntity entity);
 }

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -422,8 +422,8 @@ public final class PhysicsEngine implements IUpdateable {
 
       if (check.test(otherEntity)) {
         if (entity != null) {
-          entity.setCollidedEntity(otherEntity);
-          otherEntity.setCollidedEntity(entity);
+          entity.setLastCollidedEntity(otherEntity);
+          otherEntity.setLastCollidedEntity(entity);
         }
         return true;
       }

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -415,21 +415,23 @@ public final class PhysicsEngine implements IUpdateable {
   }
 
   private boolean collides(final ICollisionEntity entity, Collision type, Predicate<ICollisionEntity> check) {
-    for (final ICollisionEntity otherEntity : this.getCollisionEntities(type)) {
-      if (!canCollide(entity, otherEntity)) {
-        continue;
-      }
+    boolean result = false;
 
-      if (check.test(otherEntity)) {
-        if (entity != null) {
-          entity.setLastCollidedEntity(otherEntity);
-          otherEntity.setLastCollidedEntity(entity);
+    if (entity != null) {
+      entity.getLastCollidedEntities().clear();
+      for (final ICollisionEntity otherEntity : this.getCollisionEntities(type)) {
+
+        if (canCollide(entity, otherEntity)  &&  check.test(otherEntity)) {
+          otherEntity.getLastCollidedEntities().clear();
+          otherEntity.addCollidedEntities(entity);
+          entity.addCollidedEntities(otherEntity);
+
+          result = true;
         }
-        return true;
       }
     }
 
-    return false;
+    return result;
   }
 
   /**

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -419,15 +419,21 @@ public final class PhysicsEngine implements IUpdateable {
 
     if (entity != null) {
       entity.getLastCollidedEntities().clear();
-      for (final ICollisionEntity otherEntity : this.getCollisionEntities(type)) {
+    }
 
-        if (canCollide(entity, otherEntity)  &&  check.test(otherEntity)) {
+    for (final ICollisionEntity otherEntity : this.getCollisionEntities(type)) {
+      if (!canCollide(entity, otherEntity)) {
+        continue;
+      }
+
+      if (check.test(otherEntity)) {
+        if (entity != null) {
           otherEntity.getLastCollidedEntities().clear();
           otherEntity.addCollidedEntities(entity);
           entity.addCollidedEntities(otherEntity);
-
-          result = true;
         }
+
+        result = true;
       }
     }
 

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -417,10 +417,6 @@ public final class PhysicsEngine implements IUpdateable {
   private boolean collides(final ICollisionEntity entity, Collision type, Predicate<ICollisionEntity> check) {
     boolean result = false;
 
-    if (entity != null) {
-      entity.getLastCollidedEntities().clear();
-    }
-
     for (final ICollisionEntity otherEntity : this.getCollisionEntities(type)) {
       if (!canCollide(entity, otherEntity)) {
         continue;
@@ -429,6 +425,7 @@ public final class PhysicsEngine implements IUpdateable {
       if (check.test(otherEntity)) {
         if (entity != null) {
           otherEntity.getLastCollidedEntities().clear();
+          entity.getLastCollidedEntities().clear();
           otherEntity.addCollidedEntities(entity);
           entity.addCollidedEntities(otherEntity);
         }

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -421,6 +421,7 @@ public final class PhysicsEngine implements IUpdateable {
       }
 
       if (check.test(otherEntity)) {
+        entity.setCollidedEntity(otherEntity);
         return true;
       }
     }

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -423,6 +423,7 @@ public final class PhysicsEngine implements IUpdateable {
       if (check.test(otherEntity)) {
         if (entity != null) {
           entity.setCollidedEntity(otherEntity);
+          otherEntity.setCollidedEntity(entity);
         }
         return true;
       }

--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -421,7 +421,9 @@ public final class PhysicsEngine implements IUpdateable {
       }
 
       if (check.test(otherEntity)) {
-        entity.setCollidedEntity(otherEntity);
+        if (entity != null) {
+          entity.setCollidedEntity(otherEntity);
+        }
         return true;
       }
     }


### PR DESCRIPTION
Saves the first collided entity while a move check.
The saved entity can then be accessed by the moving entity so it can get details on the entity it just collided with.