### PR TITLE
Fix wrong argument in setSpriteHeight()

### DIFF
--- a/src/de/gurkenlabs/litiengine/graphics/Spritesheet.java
+++ b/src/de/gurkenlabs/litiengine/graphics/Spritesheet.java
@@ -167,7 +167,7 @@ public final class Spritesheet {
   }
 
   public void setSpriteHeight(final int spriteHeight) {
-    this.checkHeight(spriteWidth);
+    this.checkHeight(spriteHeight);
 
     this.spriteHeight = spriteHeight;
     this.updateRowsAndCols();


### PR DESCRIPTION
This was checking height with the class width variable.
It didn't seem like it was intentional, so I changed it to check the local height variable passed over when its method is called.