### PR TITLE
Use URL fragments for external resources

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
@@ -6,10 +6,12 @@ import java.awt.geom.Rectangle2D;
 import java.net.URL;
 import java.util.List;
 
+import de.gurkenlabs.litiengine.resources.Resource;
+
 /**
  * The Interface IMap.
  */
-public interface IMap extends ILayerList {
+public interface IMap extends ILayerList, Resource {
 
   /**
    * Gets the tilesets.
@@ -106,16 +108,6 @@ public interface IMap extends ILayerList {
   public double getVersion();
 
   public String getTiledVersion();
-
-  /**
-   * Sets the name.
-   *
-   * @param name
-   *          the new name
-   */
-  public void setName(String name);
-
-  public String getName();
 
   public int getNextObjectId();
   

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
@@ -3,7 +3,6 @@ package de.gurkenlabs.litiengine.environment.tilemap;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.geom.Rectangle2D;
-import java.net.URL;
 import java.util.List;
 
 import de.gurkenlabs.litiengine.resources.Resource;
@@ -28,8 +27,6 @@ public interface IMap extends ILayerList, Resource {
    * @return the orientation
    */
   public IMapOrientation getOrientation();
-
-  public URL getPath();
 
   /**
    * Gets the renderorder.

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/MapRenderer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/MapRenderer.java
@@ -10,7 +10,6 @@ import java.awt.image.BufferedImage;
 import de.gurkenlabs.litiengine.environment.Environment;
 import de.gurkenlabs.litiengine.graphics.ImageRenderer;
 import de.gurkenlabs.litiengine.graphics.RenderType;
-import de.gurkenlabs.litiengine.graphics.Spritesheet;
 import de.gurkenlabs.litiengine.resources.Resources;
 
 public class MapRenderer {
@@ -114,19 +113,18 @@ public class MapRenderer {
   }
 
   protected static void renderImageLayer(Graphics2D g, IImageLayer layer, Rectangle2D viewport, float opacity) {
-    Spritesheet sprite = Resources.spritesheets().get(layer.getImage().getSource());
+    BufferedImage sprite = Resources.images().get(layer.getImage().getAbsoluteSourcePath());
     if (sprite == null) {
       return;
     }
 
     final Composite oldComp = g.getComposite();
-    final AlphaComposite ac = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity);
-    g.setComposite(ac);
+    g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));
 
     final double viewportOffsetX = layer.getOffset().x - viewport.getX();
     final double viewportOffsetY = layer.getOffset().y - viewport.getY();
 
-    ImageRenderer.render(g, sprite.getImage(), viewportOffsetX, viewportOffsetY);
+    ImageRenderer.render(g, sprite, viewportOffsetX, viewportOffsetY);
     g.setComposite(oldComp);
   }
 

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
@@ -42,7 +42,7 @@ import de.gurkenlabs.litiengine.util.io.FileUtilities;
 
 @XmlRootElement(name = "map")
 @XmlAccessorType(XmlAccessType.FIELD)
-public final class TmxMap extends CustomPropertyProvider implements IMap, Comparable<TmxMap> {
+public final class TmxMap extends CustomPropertyProvider implements IMap {
   public static final String FILE_EXTENSION = "tmx";
 
   private static final Logger log = Logger.getLogger(TmxMap.class.getName());
@@ -405,19 +405,6 @@ public final class TmxMap extends CustomPropertyProvider implements IMap, Compar
   @XmlTransient
   public void setWidth(int width) {
     this.width = width;
-  }
-
-  @Override
-  public int compareTo(TmxMap o) {
-    if (this.name == null) {
-      return o.name == null ? 0 : -1;
-    }
-
-    if (o.name == null) {
-      return 1;
-    }
-
-    return this.name.compareTo(o.name);
   }
 
   @Override

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
@@ -112,9 +112,6 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
   })
   private List<ILayer> layers;
 
-  @XmlTransient
-  private URL path;
-
   private transient List<ITileLayer> rawTileLayers = new CopyOnWriteArrayList<>();
   private transient List<IMapObjectLayer> rawMapObjectLayers = new CopyOnWriteArrayList<>();
   private transient List<IImageLayer> rawImageLayers = new CopyOnWriteArrayList<>();
@@ -157,12 +154,6 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
       this.mapOrientation = MapOrientations.forName(this.orientation);
     }
     return this.mapOrientation;
-  }
-
-  @Override
-  @XmlTransient
-  public URL getPath() {
-    return this.path;
   }
 
   @Override
@@ -276,17 +267,12 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.staggerindex;
   }
 
-  public void setPath(final URL path) {
-    this.path = path;
-  }
-
   @Override
   public void finish(URL location) throws TmxException {
     super.finish(location);
     if (this.name == null) {
       this.name = FileUtilities.getFileName(location);
     }
-    this.path = location;
     // tilesets must be post-processed before layers; otherwise external tilesets may not be loaded
     for (ITileset tileset : this.tilesets) {
       if (tileset instanceof Tileset) {

--- a/src/de/gurkenlabs/litiengine/resources/Resource.java
+++ b/src/de/gurkenlabs/litiengine/resources/Resource.java
@@ -1,7 +1,10 @@
 package de.gurkenlabs.litiengine.resources;
 
-public interface Resource extends Comparable<Resource> {
-  
+import java.util.Comparator;
+
+public interface Resource {
+  public static final Comparator<Resource> BY_NAME = Comparator.nullsFirst(Comparator.comparing(Resource::getName, Comparator.nullsFirst(Comparator.naturalOrder())));
+
   /**
    * Gets the name.
    *
@@ -10,25 +13,4 @@ public interface Resource extends Comparable<Resource> {
   public String getName();
 
   public void setName(String name);
-  
-  @Override
-  public default int compareTo(Resource obj) {
-    if (obj == null) {
-      return 1;
-    }
-
-    if (this.getName() == null) {
-      if (obj.getName() == null) {
-        return 0;
-      }
-
-      return -1;
-    }
-
-    if (obj.getName() == null) {
-      return 1;
-    }
-
-    return this.getName().compareTo(obj.getName());
-  }
 }

--- a/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -225,7 +225,8 @@ public class ResourceBundle implements Serializable {
     }
   }
 
-  void beforeMarshal(Marshaller m) {
+  @SuppressWarnings("unused")
+  private void beforeMarshal(Marshaller m) {
     List<SpritesheetResource> distinctList = new ArrayList<>();
     for (SpritesheetResource sprite : this.getSpriteSheets()) {
       if (distinctList.stream().anyMatch(x -> x.getName().equals(sprite.getName()) && x.getImage().equals(sprite.getImage()))) {

--- a/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -156,12 +156,12 @@ public class ResourceBundle implements Serializable {
       }
     }
 
-    Collections.sort(this.getMaps());
-    Collections.sort(this.getSpriteSheets());
-    Collections.sort(this.getTilesets());
-    Collections.sort(this.getEmitters());
-    Collections.sort(this.getBluePrints());
-    Collections.sort(this.getSounds());
+    Collections.sort(this.getMaps(), Resource.BY_NAME);
+    Collections.sort(this.getSpriteSheets(), Resource.BY_NAME);
+    Collections.sort(this.getTilesets(), Resource.BY_NAME);
+    Collections.sort(this.getEmitters(), Resource.BY_NAME);
+    Collections.sort(this.getBluePrints(), Resource.BY_NAME);
+    Collections.sort(this.getSounds(), Resource.BY_NAME);
 
     try (FileOutputStream fileOut = new FileOutputStream(newFile, false)) {
       final JAXBContext jaxbContext = XmlUtilities.getContext(ResourceBundle.class);

--- a/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -232,7 +232,7 @@ public class ResourceBundle implements Serializable {
       // TODO: come the beta release, this can be removed
       @Override
       public URL unmarshal(String v) throws MalformedURLException {
-        if (v.indexOf('/') == -1 && v.indexOf('\\') == -1 && v.indexOf('.') == -1 && !v.startsWith("#")) {
+        if (v.indexOf('/') == -1 && v.indexOf('\\') == -1 && !v.startsWith("#")) {
           log.warning("Could not safely determine whether the reference \"" + v + "\" was referring to another resource in the bundle or a separate file.\nPrepend \"./\" or \"#\" to clear this ambiguity.");
           v = '#' + v;
         }

--- a/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -174,6 +174,7 @@ public class ResourceBundle implements Serializable {
       final Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
       // output pretty printed
       jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, false);
+      jaxbMarshaller.setAdapter(new URLAdapter(newFile.toURI().toURL()));
 
       if (compress) {
         final GZIPOutputStream stream = new GZIPOutputStream(fileOut);

--- a/src/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
@@ -276,6 +276,9 @@ public abstract class ResourcesContainer<T> {
 
       return resource;
     } else {
+      if (resourceName.getRef() != null && !this.contains(resourceName)) {
+        ResourceBundle.load(resourceName);
+      }
       return this.resources.computeIfAbsent(resourceName, this::loadResource);
     }
   }

--- a/src/de/gurkenlabs/litiengine/resources/Sounds.java
+++ b/src/de/gurkenlabs/litiengine/resources/Sounds.java
@@ -43,7 +43,6 @@ public final class Sounds extends ResourcesContainer<Sound> {
     Sound sound;
     try {
       sound = new Sound(input, resource.getName());
-      this.add(resource.getName(), sound);
       return sound;
     } catch (IOException | UnsupportedAudioFileException e) {
       log.log(Level.SEVERE, "The audio file {0} could not be loaded.", new Object[] { resource.getName() });

--- a/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/MapTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/MapTests.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 
 import java.awt.Color;
 import java.awt.geom.Rectangle2D;
-import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -45,7 +44,6 @@ public class MapTests {
     assertEquals(1, map.getNextObjectId());
 
     assertEquals("test-map", map.getName());
-    assertEquals((new File("tests/de/gurkenlabs/litiengine/environment/tilemap/xml/test-map.tmx")).toURI().toURL(), map.getPath());
     assertEquals(new Color(0xaa3df675, true), map.getBackgroundColor());
     assertEquals(new Rectangle2D.Double(0, 0, 256, 256), map.getBounds());
     assertEquals(2, map.getTilesets().size());

--- a/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
@@ -51,6 +51,7 @@ import de.gurkenlabs.litiengine.gui.ComponentMouseWheelEvent;
 import de.gurkenlabs.litiengine.gui.GuiComponent;
 import de.gurkenlabs.litiengine.input.Input;
 import de.gurkenlabs.litiengine.physics.Collision;
+import de.gurkenlabs.litiengine.resources.Resource;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.resources.SpritesheetResource;
 import de.gurkenlabs.litiengine.util.MathUtilities;
@@ -226,7 +227,7 @@ public class MapComponent extends GuiComponent {
     this.setFocus(null, true);
     this.getMaps().clear();
 
-    Collections.sort(maps);
+    Collections.sort(maps, Resource.BY_NAME);
 
     this.getMaps().addAll(maps);
     UI.getMapController().bind(this.getMaps(), true);
@@ -724,7 +725,7 @@ public class MapComponent extends GuiComponent {
       }
 
       this.getMaps().add(map);
-      Collections.sort(this.getMaps());
+      Collections.sort(this.getMaps(), Resource.BY_NAME);
 
       for (IImageLayer imageLayer : map.getImageLayers()) {
         BufferedImage img = Resources.images().get(imageLayer.getImage().getAbsoluteSourcePath(), true);

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/AssetPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/AssetPanel.java
@@ -14,6 +14,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.xml.MapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
 import de.gurkenlabs.litiengine.graphics.Spritesheet;
 import de.gurkenlabs.litiengine.graphics.emitters.xml.EmitterData;
+import de.gurkenlabs.litiengine.resources.Resource;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.resources.SoundResource;
 import de.gurkenlabs.litiengine.resources.SpritesheetResource;
@@ -39,7 +40,7 @@ public class AssetPanel extends JPanel {
 
   public void loadSprites(List<SpritesheetResource> infos) {
     this.load(infos, () -> {
-      Collections.sort(infos);
+      Collections.sort(infos, Resource.BY_NAME);
       for (SpritesheetResource info : infos) {
         Icon icon;
         Spritesheet opt = Resources.spritesheets().get(info.getName());
@@ -59,7 +60,7 @@ public class AssetPanel extends JPanel {
 
   public void loadTilesets(List<Tileset> tilesets) {
     this.load(tilesets, () -> {
-      Collections.sort(tilesets);
+      Collections.sort(tilesets, Resource.BY_NAME);
       for (Tileset tileset : tilesets) {
         AssetPanelItem panelItem = new AssetPanelItem(Icons.DOC_TILESET, tileset.getName(), tileset);
         this.add(panelItem);
@@ -70,7 +71,7 @@ public class AssetPanel extends JPanel {
 
   public void loadEmitters(List<EmitterData> emitters) {
     this.load(emitters, () -> {
-      Collections.sort(emitters);
+      Collections.sort(emitters, Resource.BY_NAME);
       for (EmitterData emitter : emitters) {
         AssetPanelItem panelItem = new AssetPanelItem(Icons.DOC_EMITTER, emitter.getName(), emitter);
         this.add(panelItem);
@@ -81,7 +82,7 @@ public class AssetPanel extends JPanel {
 
   public void loadBlueprints(List<Blueprint> blueprints) {
     this.load(blueprints, () -> {
-      Collections.sort(blueprints);
+      Collections.sort(blueprints, Resource.BY_NAME);
       for (MapObject blueprint : blueprints) {
         AssetPanelItem panelItem = new AssetPanelItem(Icons.DOC_BLUEPRINT, blueprint.getName(), blueprint);
         this.add(panelItem);
@@ -92,7 +93,7 @@ public class AssetPanel extends JPanel {
 
   public void loadSounds(List<SoundResource> sounds) {
     this.load(sounds, () -> {
-      Collections.sort(sounds);
+      Collections.sort(sounds, Resource.BY_NAME);
       for (SoundResource sound : sounds) {
         AssetPanelItem panelItem = new AssetPanelItem(Icons.DOC_SOUND, sound.getName(), sound);
         this.add(panelItem);


### PR DESCRIPTION
This is an addition to #272.

This pull request aims to resolve what would otherwise become an edit war on image layer rendering. Among other things, it changes the implementation of `ResourceBundle`s to use URL fragments to reference internal images. It's somewhat backwards-compatible, but older bundles may experience problems.

Additionally, this pull request removes the unused `path` property from maps, and the improper `Comparable` implementation from resources. The `Comparable` implementation has been moved to a `Comparator` in the same interface called `BY_NAME`.