### PR TITLE
Add divisions to grid's snap tool

### DIFF
--- a/utiliti/localization/strings.properties
+++ b/utiliti/localization/strings.properties
@@ -38,6 +38,7 @@ menu_view_gridHeight=grid height (px)
 menu_view_gridStroke=grid line thickness
 menu_view_gridColor=grid color
 panel_selectGridColor=Select grid color
+menu_view_snapDivision=snap division
 menu_view_gridSettings=Grid properties...
 menu_view_zoomIn=Zoom in
 menu_view_zoomOut=Zoom out

--- a/utiliti/src/de/gurkenlabs/utiliti/UserPreferences.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/UserPreferences.java
@@ -33,7 +33,7 @@ public class UserPreferences extends ConfigurationGroup {
 
   private float gridLineWidth;
   private String gridColor;
-  private double snapDivision;
+  private int snapDivision;
 
   private String lastGameFile;
   private String[] lastOpenedFiles;
@@ -51,7 +51,7 @@ public class UserPreferences extends ConfigurationGroup {
     this.compressFile = false;
     this.gridLineWidth = 1.0f;
     this.gridColor = ColorHelper.encode(Style.COLOR_DEFAULT_GRID);
-    this.snapDivision = 1.0;
+    this.snapDivision = 1;
     this.setUiScale(1.0f);
   }
 
@@ -188,7 +188,7 @@ public class UserPreferences extends ConfigurationGroup {
     return ColorHelper.decode(this.gridColor);
   }
   
-  public double getSnapDivision() {
+  public int getSnapDivision() {
     return this.snapDivision;
   }
 
@@ -200,7 +200,7 @@ public class UserPreferences extends ConfigurationGroup {
     this.gridColor = gridColor;
   }
   
-  public void setSnapDivision(double snapDivision) {
+  public void setSnapDivision(int snapDivision) {
     this.snapDivision = snapDivision;
   }
 

--- a/utiliti/src/de/gurkenlabs/utiliti/UserPreferences.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/UserPreferences.java
@@ -33,6 +33,7 @@ public class UserPreferences extends ConfigurationGroup {
 
   private float gridLineWidth;
   private String gridColor;
+  private double snapDivision;
 
   private String lastGameFile;
   private String[] lastOpenedFiles;
@@ -50,6 +51,7 @@ public class UserPreferences extends ConfigurationGroup {
     this.compressFile = false;
     this.gridLineWidth = 1.0f;
     this.gridColor = ColorHelper.encode(Style.COLOR_DEFAULT_GRID);
+    this.snapDivision = 1.0;
     this.setUiScale(1.0f);
   }
 
@@ -185,6 +187,10 @@ public class UserPreferences extends ConfigurationGroup {
   public Color getGridColor() {
     return ColorHelper.decode(this.gridColor);
   }
+  
+  public double getSnapDivision() {
+    return this.snapDivision;
+  }
 
   public void setGridLineWidth(float gridLineWidth) {
     this.gridLineWidth = gridLineWidth;
@@ -192,6 +198,10 @@ public class UserPreferences extends ConfigurationGroup {
 
   public void setGridColor(String gridColor) {
     this.gridColor = gridColor;
+  }
+  
+  public void setSnapDivision(double snapDivision) {
+    this.snapDivision = snapDivision;
   }
 
   public boolean syncMaps() {

--- a/utiliti/src/de/gurkenlabs/utiliti/handlers/Snap.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/handlers/Snap.java
@@ -47,8 +47,9 @@ public class Snap {
     return (int) Math.round(value);
   }
 
-  private static int snapToGrid(double value, int gridSize) {
-    long snapped = (Math.round((value / gridSize)) * gridSize);
-    return (int) snapped;
+  private static double snapToGrid(double value, int gridSize) {
+    double gridSizeDivided = gridSize / Editor.preferences().getSnapDivision();
+    double snapped = Math.round(value / gridSizeDivided) * gridSizeDivided;
+    return snapped;
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/handlers/Snap.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/handlers/Snap.java
@@ -48,7 +48,7 @@ public class Snap {
   }
 
   private static double snapToGrid(double value, int gridSize) {
-    double gridSizeDivided = gridSize / Editor.preferences().getSnapDivision();
+    double gridSizeDivided = gridSize / (double) Editor.preferences().getSnapDivision();
     double snapped = Math.round(value / gridSizeDivided) * gridSizeDivided;
     return snapped;
   }

--- a/utiliti/src/de/gurkenlabs/utiliti/handlers/Transform.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/handlers/Transform.java
@@ -201,9 +201,6 @@ public class Transform {
     // calculate the actual delta that all the map objects need to be moved by
     float deltaX = newX - drag.minX;
     float deltaY = newY - drag.minY;
-    if (deltaX == 0 && deltaY == 0) {
-      return;
-    }
 
     final Rectangle2D beforeBounds = MapObject.getBounds(selectedMapObjects);
 

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/dialogs/GridEditPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/dialogs/GridEditPanel.java
@@ -101,6 +101,6 @@ public class GridEditPanel extends JPanel {
   }
   
   public int getSnapDivision() {
-    return Integer.parseInt(this.snapDivisionSpinner.getValue().toString());
+    return (int) Math.round(Double.parseDouble(this.snapDivisionSpinner.getValue().toString()));
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/dialogs/GridEditPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/dialogs/GridEditPanel.java
@@ -26,7 +26,7 @@ public class GridEditPanel extends JPanel {
   private Color gridColor;
   private JSpinner snapDivisionSpinner;
 
-  public GridEditPanel(float strokeWidth, Color strokeColor, double snapDivision) {
+  public GridEditPanel(float strokeWidth, Color strokeColor, int snapDivision) {
 
     this.strokeSpinner = new JSpinner();
     this.strokeSpinner.setModel(new SpinnerNumberModel(strokeWidth, 1f, 5f, 0.1f));
@@ -100,7 +100,7 @@ public class GridEditPanel extends JPanel {
     return ((Double) this.strokeSpinner.getValue()).floatValue();
   }
   
-  public double getSnapDivision() {
-    return Double.parseDouble(this.snapDivisionSpinner.getValue().toString());
+  public int getSnapDivision() {
+    return Integer.parseInt(this.snapDivisionSpinner.getValue().toString());
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/dialogs/GridEditPanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/dialogs/GridEditPanel.java
@@ -24,13 +24,12 @@ public class GridEditPanel extends JPanel {
   private JSpinner strokeSpinner;
   private JButton buttonSetColor;
   private Color gridColor;
+  private JSpinner snapDivisionSpinner;
 
-  public GridEditPanel(float strokeWidth, Color strokeColor) {
-
-    JLabel lblStroke = new JLabel(Resources.strings().get("menu_view_gridStroke"));
+  public GridEditPanel(float strokeWidth, Color strokeColor, double snapDivision) {
 
     this.strokeSpinner = new JSpinner();
-    strokeSpinner.setModel(new SpinnerNumberModel(strokeWidth, 1f, 5f, 0.1f));
+    this.strokeSpinner.setModel(new SpinnerNumberModel(strokeWidth, 1f, 5f, 0.1f));
 
     this.gridColor = strokeColor;
     this.buttonSetColor = new JButton("");
@@ -39,8 +38,13 @@ public class GridEditPanel extends JPanel {
       Color newColor = JColorChooser.showDialog(null, Resources.strings().get("panel_selectLayerColor"), strokeColor);
       this.gridColor = newColor == null ? strokeColor : newColor;
     });
+    
+    this.snapDivisionSpinner = new JSpinner();
+    this.snapDivisionSpinner.setModel(new SpinnerNumberModel(snapDivision, 1.0, 10.0, 1.0));
 
+    JLabel lblStroke = new JLabel(Resources.strings().get("menu_view_gridStroke"));
     JLabel lblColor = new JLabel(Resources.strings().get("menu_view_gridColor"));
+    JLabel lblSnapDivision = new JLabel(Resources.strings().get("menu_view_snapDivision"));
 
     GroupLayout groupLayout = new GroupLayout(this);
     groupLayout.setHorizontalGroup(
@@ -51,11 +55,15 @@ public class GridEditPanel extends JPanel {
             .addGroup(groupLayout.createSequentialGroup()
               .addComponent(lblStroke)
               .addGap(18)
-              .addComponent(strokeSpinner, GroupLayout.DEFAULT_SIZE, 34, Short.MAX_VALUE))
+              .addComponent(this.strokeSpinner, GroupLayout.DEFAULT_SIZE, 34, Short.MAX_VALUE))
             .addGroup(groupLayout.createSequentialGroup()
               .addComponent(lblColor)
               .addGap(58)
-              .addComponent(buttonSetColor, GroupLayout.DEFAULT_SIZE, 34, Short.MAX_VALUE)))
+              .addComponent(this.buttonSetColor, GroupLayout.DEFAULT_SIZE, 34, Short.MAX_VALUE))
+            .addGroup(groupLayout.createSequentialGroup()
+              .addComponent(lblSnapDivision)
+              .addGap(18)
+              .addComponent(this.snapDivisionSpinner, GroupLayout.DEFAULT_SIZE, 34, Short.MAX_VALUE)))
           .addContainerGap())
     );
     groupLayout.setVerticalGroup(
@@ -64,11 +72,15 @@ public class GridEditPanel extends JPanel {
           .addContainerGap()
           .addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
             .addComponent(lblStroke)
-            .addComponent(strokeSpinner, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+            .addComponent(this.strokeSpinner, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
           .addPreferredGap(ComponentPlacement.RELATED)
           .addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
             .addComponent(lblColor)
-            .addComponent(buttonSetColor, GroupLayout.PREFERRED_SIZE, 24, GroupLayout.PREFERRED_SIZE))
+            .addComponent(this.buttonSetColor, GroupLayout.PREFERRED_SIZE, 24, GroupLayout.PREFERRED_SIZE))
+          .addPreferredGap(ComponentPlacement.UNRELATED)
+          .addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+              .addComponent(lblSnapDivision)
+              .addComponent(this.snapDivisionSpinner, GroupLayout.PREFERRED_SIZE, 24, GroupLayout.PREFERRED_SIZE))
           .addGap(171))
     );
 
@@ -86,5 +98,9 @@ public class GridEditPanel extends JPanel {
       log.log(Level.WARNING, "Your edits in the grid line thickness spinner could not be parsed as Float.");
     }
     return ((Double) this.strokeSpinner.getValue()).floatValue();
+  }
+  
+  public double getSnapDivision() {
+    return Double.parseDouble(this.snapDivisionSpinner.getValue().toString());
   }
 }

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/menus/ViewMenu.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/menus/ViewMenu.java
@@ -65,11 +65,12 @@ public final class ViewMenu extends JMenu {
 
     JMenuItem setGrid = new JMenuItem(Resources.strings().get("menu_view_gridSettings"));
     setGrid.addActionListener(a -> {
-      GridEditPanel panel = new GridEditPanel(Editor.preferences().getGridLineWidth(), Editor.preferences().getGridColor());
+      GridEditPanel panel = new GridEditPanel(Editor.preferences().getGridLineWidth(), Editor.preferences().getGridColor(), Editor.preferences().getSnapDivision());
       int option = JOptionPane.showConfirmDialog(Game.window().getRenderComponent(), panel, Resources.strings().get("menu_view_gridSettings"), JOptionPane.PLAIN_MESSAGE);
       if (option == JOptionPane.OK_OPTION) {
         Editor.preferences().setGridColor(ColorHelper.encode(panel.getGridColor()));
         Editor.preferences().setGridLineWidth(panel.getStrokeWidth());
+        Editor.preferences().setSnapDivision(panel.getSnapDivision());
       }
     });
 

--- a/utiliti/tests/de/gurkenlabs/utiliti/handlers/SnapTests.java
+++ b/utiliti/tests/de/gurkenlabs/utiliti/handlers/SnapTests.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import de.gurkenlabs.litiengine.util.MathUtilities;
+import de.gurkenlabs.utiliti.components.Editor;
+
 public class SnapTests {
   @Test
   public void testPixelSnapping() {
@@ -28,5 +31,56 @@ public class SnapTests {
 
     assertEquals(0, Snap.y(7, 16, true, true));
     assertEquals(16, Snap.y(9.91, 16, true, true));
+  }
+  
+  @Test
+  public void testGridSnappingDivision() {
+    float aThird = (float) MathUtilities.round(16.0/3.0, 2);
+    float twoThirds = (float) MathUtilities.round((16.0/3.0)*2.0, 2);
+
+    Editor.preferences().setSnapDivision(3);
+
+    assertEquals(0, Snap.x(1.1, 16, true, false));
+    assertEquals(aThird, Snap.x(6, 16, true, false));
+    assertEquals(twoThirds, Snap.x(11.1, 16, true, false));
+    assertEquals(16, Snap.x(14, 16, true, false));
+
+    assertEquals(0, Snap.y(2, 16, true, false));
+    assertEquals(aThird, Snap.y(7.99, 16, true, false));
+    assertEquals(twoThirds, Snap.y(9.91, 16, true, false));
+    assertEquals(16, Snap.y(15, 16, true, false));
+
+    // enabling pixel snapping while grid snapping is active should not make any difference
+    assertEquals(0, Snap.x(1.1, 16, true, true));
+    assertEquals(aThird, Snap.x(6, 16, true, true));
+    assertEquals(twoThirds, Snap.x(11.1, 16, true, true));
+    assertEquals(16, Snap.x(14, 16, true, true));
+
+    assertEquals(0, Snap.y(2, 16, true, true));
+    assertEquals(aThird, Snap.y(7.99, 16, true, true));
+    assertEquals(twoThirds, Snap.y(9.91, 16, true, true));
+    assertEquals(16, Snap.y(14, 16, true, true));
+
+    Editor.preferences().setSnapDivision(2);
+
+    assertEquals(0, Snap.x(1.1, 16, true, false));
+    assertEquals(16/2, Snap.x(11.99, 16, true, false));
+    assertEquals(16, Snap.x(14, 16, true, false));
+
+    assertEquals(0, Snap.y(3.99, 16, true, false));
+    assertEquals(16/2, Snap.y(9.91, 16, true, false));
+    assertEquals(16, Snap.y(12, 16, true, false));
+
+    // enabling pixel snapping while grid snapping is active should not make any difference
+    assertEquals(0, Snap.x(1.1, 16, true, true));
+    assertEquals(16/2, Snap.x(11.99, 16, true, true));
+    assertEquals(16, Snap.x(14, 16, true, true));
+
+    assertEquals(0, Snap.y(3.99, 16, true, true));
+    assertEquals(16/2, Snap.y(9.91, 16, true, true));
+    assertEquals(16, Snap.y(12, 16, true, true));
+
+    // reset to no divisions
+    Editor.preferences().setSnapDivision(1);
   }
 }


### PR DESCRIPTION
The user can decide to bring more precision to the snapping tool when "Snap to grid" is checked by changing the value of "snap division" in "View -> Grid properties...".

Closes #248