### PR TITLE
Update getIntersection() to handle multiple intersections

### DIFF
--- a/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/src/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -393,25 +393,33 @@ public final class PhysicsEngine implements IUpdateable {
     return entity.canCollideWith(otherEntity);
   }
 
-  // TODO: I think the issue with this method is that it only reflects the intersection with the first collision box it 
-  // finds which results in the physics only accounting for one collision box at a time when resolving collision.
-  // We need to aggregate the delta X and delta Y for all collision boxes that the entity is colliding with.
+  /**
+   * Returns a Rectangle2D representing the union of intersections between the targeted position and all collision boxes 
+   * that the entity would be colliding with at that targeted position.
+   * 
+   * @param entity
+   * @param entityCollisionBox
+   * @return Rectangle2D
+   */
   private Rectangle2D getIntersection(final ICollisionEntity entity, final Rectangle2D entityCollisionBox) {
+    Rectangle2D result = null;
     for (final ICollisionEntity collisionBox : this.getCollisionEntities()) {
       if (!canCollide(entity, collisionBox)) {
         continue;
       }
 
-      if (collisionBox.getCollisionBox().contains(entityCollisionBox)) {
-        return collisionBox.getCollisionBox();
-      }
-
       if (GeometricUtilities.intersects(collisionBox.getCollisionBox(), entityCollisionBox)) {
-        return collisionBox.getCollisionBox().createIntersection(entityCollisionBox);
+        Rectangle2D tmpIntersection = collisionBox.getCollisionBox().createIntersection(entityCollisionBox);
+        if (result != null) {
+          result = tmpIntersection.createUnion(result);
+        }
+        else {
+          result = tmpIntersection;
+        }
       }
     }
 
-    return null;
+    return result;
   }
 
   private boolean collides(final ICollisionEntity entity, Collision type, Predicate<ICollisionEntity> check) {

--- a/tests/de/gurkenlabs/litiengine/physics/CollisionResolvingTests.java
+++ b/tests/de/gurkenlabs/litiengine/physics/CollisionResolvingTests.java
@@ -165,8 +165,54 @@ public class CollisionResolvingTests {
     assertEquals(59.0, ent.getX(), EPSILON);
   }
 
+  // TODO
   @Test
-  public void testCollisiionWithMapBounds() {
+  public void testMultipleIntersection() {
+    Creature ent = getNewCreature();
+
+    PhysicsEngine engine = new PhysicsEngine();
+    engine.add(ent);
+
+    // thin rectangle at the bottom of the entity
+    engine.add(new CollisionBox(0, 25, 50, 10));
+
+    // small square to top the right corner of the thin rectangle
+    engine.add(new CollisionBox(50, 20, 5, 5));
+
+    // large rectangle at the right of the square
+    engine.add(new CollisionBox(55, 0, 50, 100));
+
+    // first relocate the entity
+    ent.setLocation(45, 10);
+
+    // move 10 px down
+    engine.move(ent, 0, 10);
+
+    // the movement should have been denied
+    assertEquals(45.0, ent.getX(), EPSILON);
+    assertEquals(10.0, ent.getY(), EPSILON);
+
+    // move along the square to the left
+    engine.move(ent, -90, 10);
+
+    assertEquals(35.0, ent.getX(), EPSILON);
+    assertEquals(10.0, ent.getY(), EPSILON);
+
+    // move along the square downwards
+    engine.move(ent, 0, 10);
+
+    assertEquals(35.0, ent.getX(), EPSILON);
+    assertEquals(15.0, ent.getY(), EPSILON);
+
+    // move along the thin rectangle to the right
+    engine.move(ent, 90, 15);
+
+    assertEquals(40.0, ent.getX(), EPSILON);
+    assertEquals(15.0, ent.getY(), EPSILON);
+  }
+
+  @Test
+  public void testCollisionWithMapBounds() {
     Creature ent = getNewCreature();
     ent.setWidth(30);
     ent.setHeight(30);


### PR DESCRIPTION
- "getIntersection()" now returns a Rectangle2D representing the union of intersections between the targeted position and all collision boxes that the entity would be colliding with at that targeted position.
- Add tests in CollisionResolvingTests.java for multiple intersections when moving.