### PR TITLE
Update ListField to create 2D list fields

### DIFF
--- a/src/de/gurkenlabs/litiengine/gui/DropdownListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/DropdownListField.java
@@ -63,7 +63,7 @@ public class DropdownListField extends GuiComponent {
   }
 
   public List<ImageComponent> getListEntries() {
-    return this.getContentList().getListEntries();
+    return this.getContentList().getListEntry(0);
   }
 
   public int getNumberOfShownElements() {
@@ -71,7 +71,7 @@ public class DropdownListField extends GuiComponent {
   }
 
   public int getSelectedIndex() {
-    return this.getContentList().getSelection();
+    return this.getContentList().getSelectionRow();
   }
 
   public Object getSelectedObject() {
@@ -79,7 +79,7 @@ public class DropdownListField extends GuiComponent {
       return null;
     }
 
-    return this.getContentArray()[this.getContentList().getSelection()];
+    return this.getContentArray()[this.getContentList().getSelectionRow()];
   }
 
   public boolean isArrowKeyNavigation() {
@@ -146,7 +146,7 @@ public class DropdownListField extends GuiComponent {
       return;
     }
 
-    this.getContentList().setSelection(selectionIndex);
+    this.getContentList().setSelection(0, selectionIndex);
   }
 
   public void setSelection(final Object selectedObject) {
@@ -182,14 +182,14 @@ public class DropdownListField extends GuiComponent {
       if (this.isSuspended() || !this.isVisible() || !this.isArrowKeyNavigation() || !this.getChosenElementComponent().isHovered()) {
         return;
       }
-      this.getContentList().setSelection(this.getSelectedIndex() - 1);
+      this.getContentList().setSelection(0, this.getSelectedIndex() - 1);
     });
 
     Input.keyboard().onKeyTyped(KeyEvent.VK_DOWN, e -> {
       if (this.isSuspended() || !this.isVisible() || !this.isArrowKeyNavigation() || !this.getChosenElementComponent().isHovered()) {
         return;
       }
-      this.getContentList().setSelection(this.getSelectedIndex() + 1);
+      this.getContentList().setSelection(0, this.getSelectedIndex() + 1);
     });
 
     this.onMouseWheelScrolled(e -> {
@@ -197,9 +197,9 @@ public class DropdownListField extends GuiComponent {
         return;
       }
       if (e.getEvent().getWheelRotation() < 0) {
-        this.getContentList().setSelection(this.getSelectedIndex() - 1);
+        this.getContentList().setSelection(0, this.getSelectedIndex() - 1);
       } else {
-        this.getContentList().setSelection(this.getSelectedIndex() + 1);
+        this.getContentList().setSelection(0, this.getSelectedIndex() + 1);
       }
       return;
     });

--- a/src/de/gurkenlabs/litiengine/gui/DropdownListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/DropdownListField.java
@@ -113,7 +113,7 @@ public class DropdownListField extends GuiComponent {
     this.getContentList().suspend();
 
     if (!this.getListEntries().isEmpty()) {
-      this.chosenElementComponent.setText(this.getListEntries().get(this.getSelectedIndex()).getText());
+      this.chosenElementComponent.setText(this.getListEntries().get(0).getText());
     }
 
     this.dropDownButton.onClicked(e -> this.toggleDropDown());

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -34,6 +34,7 @@ public class ListField extends GuiComponent {
   private int selectionColumn;
   private int selectionRow;
 
+  private boolean selectEntireRow = false;
 
   private final int shownElements;
   private VerticalSlider slider;
@@ -222,7 +223,12 @@ public class ListField extends GuiComponent {
     super.render(g);
     if (this.selectedComponent != null) {
       Rectangle2D border;
+      if (this.selectEntireRow) {
+        border = new Rectangle2D.Double(this.getX() - 1, this.selectedComponent.getY() - 1, this.getWidth() + 2, this.selectedComponent.getHeight() + 2);
+      }
+      else {
         border = new Rectangle2D.Double(this.selectedComponent.getX() - 1, this.selectedComponent.getY() - 1, this.selectedComponent.getWidth() + 2, this.selectedComponent.getHeight() + 2);
+      }
       g.setColor(Color.WHITE);
       ShapeRenderer.renderOutline(g, border, 2);
     }
@@ -267,7 +273,10 @@ public class ListField extends GuiComponent {
     }
     this.getChangeConsumer().forEach(consumer -> consumer.accept(this.selectionRow));
     this.refresh();
+  }
 
+  public void setSelectEntireRow(boolean selectEntireRow) {
+    this.selectEntireRow = selectEntireRow;
   }
 
   private void initContentList() {

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -305,6 +305,10 @@ public class ListField extends GuiComponent {
     for (int column = 0; column < this.nbOfColumns; column++) {
       this.listEntries.add(new CopyOnWriteArrayList<ImageComponent>());
       for (int row = 0; row < this.getNumberOfShownElements(); row++) {
+        if (this.getContent()[column].length <= row) {
+          continue;
+        }
+
         ImageComponent entryComponent;
         if (this.getContent()[column][row] == null) {
           entryComponent = new ImageComponent(this.getX() + (columnWidth * column), this.getY() + ((this.getHeight() / this.getNumberOfShownElements()) * row), (this.getWidth() / this.nbOfColumns), this.getHeight() / this.getNumberOfShownElements(), this.entrySprite, "", null);

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -211,6 +211,17 @@ public class ListField extends GuiComponent {
     this.prepareInput();
   }
 
+  /**
+   * Resets the ListField's selection to {@code null}.
+   * <br>
+   * The ListField will then show no selection.
+   */
+  public void deselect() {
+    this.selectionColumn = -1;
+    this.selectionRow = -1;
+    this.selectedComponent = null;
+  }
+
   public Spritesheet getButtonSprite() {
     return this.buttonSprite;
   }
@@ -278,6 +289,9 @@ public class ListField extends GuiComponent {
   }
 
   public Object getSelectedObject() {
+    if (this.getSelectedComponent() == null) {
+      return null;
+    }
     return this.getContent()[this.selectionColumn][this.selectionRow];
   }
 

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Rectangle2D;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.IntConsumer;
@@ -157,7 +158,7 @@ public class ListField extends GuiComponent {
    * @see #ListField(double, double, double, double, Object[][], int, int, boolean, Spritesheet, Spritesheet)
    */
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownRows, final int shownColumns, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
-    this(x, y, width, height, new Object[][] {content}, shownRows, shownColumns, false, entrySprite, buttonSprite);
+    this(x, y, width, height, content, shownRows, shownColumns, false, entrySprite, buttonSprite);
   }
 
   /**
@@ -199,6 +200,7 @@ public class ListField extends GuiComponent {
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownRows, final int shownColumns, final boolean sliderInside, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     super(x, y, width, height);
     this.changeConsumer = new CopyOnWriteArrayList<>();
+    System.out.println(Arrays.deepToString(content));
     this.content = content;
     this.nbOfColumns = this.content.length;
     this.listEntries = new CopyOnWriteArrayList<>();

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -43,7 +43,6 @@ public class ListField extends GuiComponent {
 
   private VerticalSlider verticalSlider;
   private HorizontalSlider horizontalSlider;
-  private final double sliderSize = 100.0;
   private boolean sliderInside = false;
 
   /**
@@ -517,13 +516,14 @@ public class ListField extends GuiComponent {
   }
   
   private void initSliders() {
+    final double sliderSize = this.getHeight() / 5;
     final int maxNbOfRows = this.getMaxRows() - this.getNumberOfShownRows();
     if (this.getNumberOfShownColumns() < this.getContent().length) {
       if (this.isSliderInside()) {
-        this.horizontalSlider = new HorizontalSlider(this.getX(), this.getY() + this.getHeight() - this.sliderSize, this.getWidth() - this.sliderSize, this.sliderSize, 0, this.nbOfColumns - this.getNumberOfShownColumns(), 1);
+        this.horizontalSlider = new HorizontalSlider(this.getX(), this.getY() + this.getHeight() - sliderSize, this.getWidth() - sliderSize, sliderSize, 0, this.nbOfColumns - this.getNumberOfShownColumns(), 1);
       }
       else {
-        this.horizontalSlider = new HorizontalSlider(this.getX(), this.getY() + this.getHeight(), this.getWidth(), this.sliderSize, 0, this.nbOfColumns - this.getNumberOfShownColumns(), 1);
+        this.horizontalSlider = new HorizontalSlider(this.getX(), this.getY() + this.getHeight(), this.getWidth(), sliderSize, 0, this.nbOfColumns - this.getNumberOfShownColumns(), 1);
       }
       this.getHorizontalSlider().setCurrentValue(this.getHorizontalLowerBound());
       this.getComponents().add(this.getHorizontalSlider());
@@ -532,14 +532,14 @@ public class ListField extends GuiComponent {
     if (maxNbOfRows > 0) {
       if (this.isSliderInside()) {
         if (this.getHorizontalSlider() != null) {
-          this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - this.sliderSize, this.getY(), this.sliderSize, this.getHeight() - this.sliderSize, 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
+          this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - sliderSize, this.getY(), sliderSize, this.getHeight() - sliderSize, 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
         }
         else {
-          this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - this.sliderSize, this.getY(), this.sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
+          this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - sliderSize, this.getY(), sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
         }
       }
       else {
-        this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth(), this.getY(), this.sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
+        this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth(), this.getY(), sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
       }
       this.getVerticalSlider().setCurrentValue(this.getVerticalLowerBound());
       this.getComponents().add(this.getVerticalSlider());

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -61,27 +61,63 @@ public class ListField extends GuiComponent {
    * </blockquote>
    * 
    * @param x
-   * the x
+   * The x-coordinate of the ListField.
    * @param y
-   * the y
+   * The y-coordinate of the ListField.
    * @param width
-   * the width
+   * The width of the ListField.
    * @param height
-   * the height
+   * The height of the ListField.
    * @param content
-   * the 1D content
-   * @param shownElements
-   * the number of rows/elements to 
-   * display before the user needs to scroll for more possible rows/elements
+   * The 1 dimension array to show in the ListField.
+   * @param shownRows
+   * The number of rows/elements to 
+   * display before the user needs to scroll for more possible rows/elements.
    * @param entrySprite
-   * the entrySprite
+   * The entrySprite.
    * @param buttonSprite
-   * the buttonSprite
+   * The buttonSprite.
+   * @see #ListField(double, double, double, double, Object[], int, boolean, Spritesheet, Spritesheet)
    */
   public ListField(final double x, final double y, final double width, final double height, final Object[] content, final int shownRows, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     this(x, y, width, height, new Object[][] {content}, shownRows, 1, false, entrySprite, buttonSprite);
   }
 
+  /**
+   * Creates a vertical list field.
+   * <br><br>
+   * The <b>content</b> of this list field can only be accessed through the first column (column 0).
+   * <br>
+   * Examples:
+   * <blockquote>
+   * content[0][0] - ok<br>
+   * content[0][1] - ok<br>
+   * content[0][8] - ok<br>
+   * content[1][5] - NOK<br>
+   * content[2][0] - NOK<br>
+   * </blockquote>
+   * 
+   * @param x
+   * The x-coordinate of the ListField.
+   * @param y
+   * The y-coordinate of the ListField.
+   * @param width
+   * The width of the ListField.
+   * @param height
+   * The height of the ListField.
+   * @param content
+   * The 1 dimension array to show in the ListField.
+   * @param shownRows
+   * The number of rows/elements to 
+   * display before the user needs to scroll for more possible rows/elements.
+   * @param sliderInside
+   * If set to true, sliders will show inside the ListField. 
+   * This can be used, for example, if the ListField's width matches the screen's width.
+   * @param entrySprite
+   * The entrySprite.
+   * @param buttonSprite
+   * The buttonSprite.
+   */
   public ListField(final double x, final double y, final double width, final double height, final Object[] content, final int shownRows, final boolean sliderInside, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     this(x, y, width, height, new Object[][] {content}, shownRows, 1, sliderInside, entrySprite, buttonSprite);
   }
@@ -99,27 +135,67 @@ public class ListField extends GuiComponent {
    * </blockquote>
    * 
    * @param x
-   * the x
+   * The x-coordinate of the ListField.
    * @param y
-   * the y
+   * The y-coordinate of the ListField.
    * @param width
-   * the width
+   * The width of the ListField.
    * @param height
-   * the height
+   * The height of the ListField.
    * @param content
-   * the 2D content
-   * @param shownElements
-   * the number of rows/elements to 
-   * display before the user needs to scroll for more possible rows/elements
+   * The 2 dimension array to show in the ListField.
+   * @param shownRows
+   * The number of rows to 
+   * display before the user needs to scroll for more possible rows.
+   * @param shownColumns
+   * The number of columns to 
+   * display before the user needs to scroll for more possible columns.
    * @param entrySprite
-   * the entrySprite
+   * The entrySprite.
    * @param buttonSprite
-   * the buttonSprite
+   * The buttonSprite.
+   * @see #ListField(double, double, double, double, Object[][], int, int, boolean, Spritesheet, Spritesheet)
    */
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownRows, final int shownColumns, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     this(x, y, width, height, new Object[][] {content}, shownRows, shownColumns, false, entrySprite, buttonSprite);
   }
 
+  /**
+   * Creates a 2D vertical list field.
+   * <br><br>
+   * The given <b>content</b> should be arranged as columns of elements.
+   * <br>
+   * Examples:
+   * <blockquote>
+   * content[0][0] - column 0, row 0<br>
+   * content[0][1] - column 0, row 1<br>
+   * content[2][8] - column 2, row 8<br>
+   * </blockquote>
+   * 
+   * @param x
+   * The x-coordinate of the ListField.
+   * @param y
+   * The y-coordinate of the ListField.
+   * @param width
+   * The width of the ListField.
+   * @param height
+   * The height of the ListField.
+   * @param content
+   * The 2 dimension array to show in the ListField.
+   * @param shownRows
+   * The number of rows to 
+   * display before the user needs to scroll for more possible rows.
+   * @param shownColumns
+   * The number of columns to 
+   * display before the user needs to scroll for more possible columns.
+   * @param sliderInside
+   * If set to true, sliders will show inside the ListField. 
+   * This can be used, for example, if the ListField's width matches the screen's width.
+   * @param entrySprite
+   * The entrySprite.
+   * @param buttonSprite
+   * The buttonSprite.
+   */
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownRows, final int shownColumns, final boolean sliderInside, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     super(x, y, width, height);
     this.changeConsumer = new CopyOnWriteArrayList<>();
@@ -346,12 +422,12 @@ public class ListField extends GuiComponent {
 
   /**
    * If set to true, selecting a element will show a selection of 
-   * the entire row on which that element is on. Without taking 
-   * account of its column.
+   * the entire column on which that element is on. Without taking 
+   * account of its row.
    * <br><br>
    * Set to <b>false</b> as default.
    * 
-   * @param selectEntireRow
+   * @param selectEntireColumn
    * a boolean
    */
   public void setSelectEntireColumn(boolean selectEntireColumn) {
@@ -359,13 +435,13 @@ public class ListField extends GuiComponent {
   }
 
   /**
-   * If set to true, the slider will show inside the ListField.
-   * <br>
-   * This can be used, for example, if the ListField's width matches the screen's width.
+   * If set to true, selecting a element will show a selection of 
+   * the entire row on which that element is on. Without taking 
+   * account of its column.
    * <br><br>
    * Set to <b>false</b> as default.
    * 
-   * @param sliderInside
+   * @param selectEntireRow
    * a boolean
    */
   public void setSelectEntireRow(boolean selectEntireRow) {
@@ -456,6 +532,12 @@ public class ListField extends GuiComponent {
     }
   }
 
+  /**
+   * See {@link #setSelectEntireColumn(boolean)}
+   * 
+   * @return
+   * true if selection is set to select the entire column; false otherwise
+   */
   public boolean isEntireColumnSelected() {
     return this.selectEntireColumn;
   }

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -469,10 +469,12 @@ public class ListField extends GuiComponent {
         else {
           entryComponent = new ImageComponent(this.getX() + (columnWidth * column), this.getY() + (rowHeight * row), columnWidth, rowHeight, this.entrySprite, this.getContent()[column][row].toString(), null);
         }
-        if (this.isSliderInside()) {
+        if (this.isSliderInside() && this.getVerticalSlider() != null) {
           entryComponent.setX(this.getX() + ((columnWidth - (this.getVerticalSlider().getWidth() / this.getNumberOfShownColumns()))  * column));
-          entryComponent.setY(this.getY() + ((rowHeight - (this.getHorizontalSlider().getHeight() / this.getNumberOfShownRows())) * row));
           entryComponent.setWidth(entryComponent.getWidth() - (this.getVerticalSlider().getWidth() / this.getNumberOfShownColumns()));
+        }
+        if (this.isSliderInside() && this.getHorizontalSlider() != null) {
+          entryComponent.setY(this.getY() + ((rowHeight - (this.getHorizontalSlider().getHeight() / this.getNumberOfShownRows())) * row));
           entryComponent.setHeight(entryComponent.getHeight() - (this.getHorizontalSlider().getHeight() / this.getNumberOfShownRows()));
         }
         entryComponent.setTextAlign(Align.LEFT);
@@ -516,19 +518,31 @@ public class ListField extends GuiComponent {
   
   private void initSliders() {
     final int maxNbOfRows = this.getMaxRows() - this.getNumberOfShownRows();
-    if (maxNbOfRows > 0) {
+    if (this.getNumberOfShownColumns() < this.getContent().length) {
       if (this.isSliderInside()) {
-        this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - this.sliderSize, this.getY(), this.sliderSize, this.getHeight() - this.sliderSize, 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
         this.horizontalSlider = new HorizontalSlider(this.getX(), this.getY() + this.getHeight() - this.sliderSize, this.getWidth() - this.sliderSize, this.sliderSize, 0, this.nbOfColumns - this.getNumberOfShownColumns(), 1);
       }
       else {
-        this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth(), this.getY(), this.sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
         this.horizontalSlider = new HorizontalSlider(this.getX(), this.getY() + this.getHeight(), this.getWidth(), this.sliderSize, 0, this.nbOfColumns - this.getNumberOfShownColumns(), 1);
       }
-      this.getVerticalSlider().setCurrentValue(this.getVerticalLowerBound());
       this.getHorizontalSlider().setCurrentValue(this.getHorizontalLowerBound());
-      this.getComponents().add(this.getVerticalSlider());
       this.getComponents().add(this.getHorizontalSlider());
+    }
+
+    if (maxNbOfRows > 0) {
+      if (this.isSliderInside()) {
+        if (this.getHorizontalSlider() != null) {
+          this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - this.sliderSize, this.getY(), this.sliderSize, this.getHeight() - this.sliderSize, 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
+        }
+        else {
+          this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth() - this.sliderSize, this.getY(), this.sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
+        }
+      }
+      else {
+        this.verticalSlider = new VerticalSlider(this.getX() + this.getWidth(), this.getY(), this.sliderSize, this.getHeight(), 0, this.getMaxRows() - this.getNumberOfShownRows(), 1);
+      }
+      this.getVerticalSlider().setCurrentValue(this.getVerticalLowerBound());
+      this.getComponents().add(this.getVerticalSlider());
     }
   }
 

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -200,7 +200,6 @@ public class ListField extends GuiComponent {
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownRows, final int shownColumns, final boolean sliderInside, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     super(x, y, width, height);
     this.changeConsumer = new CopyOnWriteArrayList<>();
-    System.out.println(Arrays.deepToString(content));
     this.content = content;
     this.nbOfColumns = this.content.length;
     this.listEntries = new CopyOnWriteArrayList<>();

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -32,8 +32,8 @@ public class ListField extends GuiComponent {
 
   private ImageComponent selectedComponent;
 
-  private int selectionColumn;
-  private int selectionRow;
+  private int selectionColumn = -1;
+  private int selectionRow = -1;
 
   private boolean selectEntireColumn = false;
   private boolean selectEntireRow = false;
@@ -576,6 +576,30 @@ public class ListField extends GuiComponent {
     return this.sliderInside;
   }
 
+  /**
+   * Slides the ListField up by one row.
+   */
+  public void slideUp() {
+    if (this.getVerticalLowerBound() <= 0) {
+      return;
+    }
+
+    this.setVerticalLowerBound(this.getVerticalLowerBound() - 1);
+    this.refresh();
+  }
+
+  /**
+   * Slides the ListField down by one row.
+   */
+  public void slideDown() {
+    if (this.getVerticalLowerBound() >= this.getMaxRows() - this.getNumberOfShownRows()) {
+      return;
+    }
+
+    this.setVerticalLowerBound(this.getVerticalLowerBound() + 1);
+    this.refresh();
+  }
+
   private void prepareInput() {
     Input.keyboard().onKeyTyped(KeyEvent.VK_UP, e -> {
       if (this.isSuspended() || !this.isVisible() || !this.isArrowKeyNavigation()) {
@@ -611,9 +635,9 @@ public class ListField extends GuiComponent {
       }
       if (this.isHovered()) {
         if (e.getEvent().getWheelRotation() < 0) {
-          this.setSelection(this.getHorizontalLowerBound(), this.selectionRow - 1);
+          this.slideUp();
         } else {
-          this.setSelection(this.getHorizontalLowerBound(), this.selectionRow + 1);
+          this.slideDown();
         }
         return;
       }

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -45,25 +45,31 @@ public class ListField extends GuiComponent {
    * The <b>content</b> of this list field can only be accessed through the first column (column 0).
    * <br>
    * Examples:
-   * <code><blockquote>
-   * content[0][0] -> ok<br>
-   * content[0][1] -> ok<br>
-   * content[0][8] -> ok<br>
-   * content[1][5] -> NOK<br>
-   * content[2][0] -> NOK<br>
-   * </blockquote></code>
-   * The argument <b>shownElements</b> represents the number of rows/elements to 
-   * display before the user needs to scroll for more possible rows/elements.
-   * <br>
+   * <blockquote>
+   * content[0][0] - ok<br>
+   * content[0][1] - ok<br>
+   * content[0][8] - ok<br>
+   * content[1][5] - NOK<br>
+   * content[2][0] - NOK<br>
+   * </blockquote>
    * 
    * @param x
+   * the x
    * @param y
+   * the y
    * @param width
+   * the width
    * @param height
+   * the height
    * @param content
+   * the 1D content
    * @param shownElements
+   * the number of rows/elements to 
+   * display before the user needs to scroll for more possible rows/elements
    * @param entrySprite
+   * the entrySprite
    * @param buttonSprite
+   * the buttonSprite
    */
   public ListField(final double x, final double y, final double width, final double height, final Object[] content, final int shownElements, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     this(x, y, width, height, new Object[][] {content}, shownElements, entrySprite, buttonSprite);
@@ -75,23 +81,29 @@ public class ListField extends GuiComponent {
    * The given <b>content</b> should be arranged as columns of elements.
    * <br>
    * Examples:
-   * <code><blockquote>
-   * content[0][0] -> column 0, row 0<br>
-   * content[0][1] -> column 0, row 1<br>
-   * content[2][8] -> column 2, row 8<br>
-   * </blockquote></code>
-   * The argument <b>shownElements</b> represents the number of rows/elements to 
-   * display before the user needs to scroll for more possible rows/elements.
-   * <br>
+   * <blockquote>
+   * content[0][0] - column 0, row 0<br>
+   * content[0][1] - column 0, row 1<br>
+   * content[2][8] - column 2, row 8<br>
+   * </blockquote>
    * 
    * @param x
+   * the x
    * @param y
+   * the y
    * @param width
+   * the width
    * @param height
+   * the height
    * @param content
+   * the 2D content
    * @param shownElements
+   * the number of rows/elements to 
+   * display before the user needs to scroll for more possible rows/elements
    * @param entrySprite
+   * the entrySprite
    * @param buttonSprite
+   * the buttonSprite
    */
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownElements, final Spritesheet entrySprite, final Spritesheet buttonSprite) {
     super(x, y, width, height);
@@ -126,6 +138,7 @@ public class ListField extends GuiComponent {
    * Returns all list items of a specified column.
    *
    * @param column
+   * the column
    * @return a list of items
    */
   public List<ImageComponent> getListEntry(final int column) {
@@ -143,6 +156,7 @@ public class ListField extends GuiComponent {
    * Returns the number of rows of the tallest column.
    * 
    * @return
+   * int representing the length of the tallest column
    */
   public int getMaxRows() {
     int result = 0;

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.KeyEvent;
 import java.awt.geom.Rectangle2D;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.IntConsumer;

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -240,6 +240,15 @@ public class ListField extends GuiComponent {
     this.entrySprite = entrySprite;
   }
 
+  public void setForwardMouseEvents(final int column, final boolean forwardMouseEvents) {
+    if (column < 0 && column >= this.nbOfColumns) {
+      return;
+    }
+    for (ImageComponent comp : this.getListEntry(column)) {
+      comp.setForwardMouseEvents(forwardMouseEvents);
+    }
+  }
+
   public void setLowerBound(final int lowerBound) {
     this.lowerBound = lowerBound;
   }

--- a/src/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/src/de/gurkenlabs/litiengine/gui/ListField.java
@@ -555,7 +555,7 @@ public class ListField extends GuiComponent {
   }
 
   /**
-   * See {@link #setSliderInside(boolean)}
+   * Verify if sliders are set to be inside the ListField.
    * 
    * @return
    * true if slider is set to be inside the ListField; false otherwise

--- a/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
+++ b/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
@@ -1,0 +1,67 @@
+package de.gurkenlabs.litiengine.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import de.gurkenlabs.litiengine.Game;
+
+public class ListFieldTest {
+
+  private final String[] content_1D = new String[] {
+    "A", "B", "C", "D", "E", "F", "G"
+  };
+  private final String[][] content_2D = new String[][] {
+    {"A", "B", "C", "D", "E", "F", "G"},
+    {"H", "I", "J", "K", "L", "M", "N", "O"},
+    {"P", "Q", "R", "S", "T", "U", "V"},
+    {"W", "X", "Y", "Z"}
+  };
+
+  @Test
+  public void testInitialization() {
+    Game.init(Game.COMMADLINE_ARG_NOGUI);
+    
+    ListField listField_1D = new ListField(0, 0, 100, 50, this.content_1D, 4, null, null);
+    ListField listField_2D = new ListField(0, 0, 100, 50, this.content_2D, 7, null, null);
+
+    assertNotNull(listField_1D);
+    assertNotNull(listField_2D);
+
+    assertEquals(this.content_1D, listField_1D.getContent()[0]);
+    assertEquals(this.content_2D, listField_2D.getContent());
+
+    for (int i = 0; i < listField_1D.getListEntry(0).size(); i++) {
+      assertEquals(this.content_1D[i], listField_1D.getListEntry(0).get(i).getText());
+    }
+    for (int i = 0; i < listField_2D.getContent().length; i++) {
+      for (int j = 0; j < listField_2D.getListEntry(i).size(); j++) {
+        assertEquals(this.content_2D[i][j], listField_2D.getListEntry(i).get(j).getText());
+      }
+    }
+
+    assertEquals(7, listField_1D.getMaxRows());
+    assertEquals(8, listField_2D.getMaxRows());
+
+    listField_1D.prepare();
+    listField_2D.prepare();
+
+    assertTrue(listField_1D.isVisible());
+    assertTrue(listField_2D.isVisible());
+
+    assertTrue(listField_1D.isEnabled());
+    assertTrue(listField_2D.isEnabled());
+
+    assertFalse(listField_1D.isArrowKeyNavigation());
+    assertFalse(listField_2D.isArrowKeyNavigation());
+
+    assertFalse(listField_1D.isEntireRowSelected());
+    assertFalse(listField_2D.isEntireRowSelected());
+
+    assertFalse(listField_1D.isSliderInside());
+    assertFalse(listField_2D.isSliderInside());
+  }
+}

--- a/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
+++ b/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
@@ -26,7 +26,7 @@ public class ListFieldTest {
     Game.init(Game.COMMADLINE_ARG_NOGUI);
     
     ListField listField_1D = new ListField(0, 0, 100, 50, this.content_1D, 4, null, null);
-    ListField listField_2D = new ListField(0, 0, 100, 50, this.content_2D, 7, null, null);
+    ListField listField_2D = new ListField(0, 0, 100, 50, this.content_2D, 7, 3, null, null);
 
     assertNotNull(listField_1D);
     assertNotNull(listField_2D);
@@ -37,7 +37,7 @@ public class ListFieldTest {
     for (int i = 0; i < listField_1D.getListEntry(0).size(); i++) {
       assertEquals(this.content_1D[i], listField_1D.getListEntry(0).get(i).getText());
     }
-    for (int i = 0; i < listField_2D.getContent().length; i++) {
+    for (int i = 0; i < listField_2D.getNumberOfShownColumns(); i++) {
       for (int j = 0; j < listField_2D.getListEntry(i).size(); j++) {
         assertEquals(this.content_2D[i][j], listField_2D.getListEntry(i).get(j).getText());
       }


### PR DESCRIPTION
This updates the ListField class to allow users to create two dimensional ListFields.
Additional features added:

- foward (or not) mouse events over columns (used to only select elements from specific columns)
- select entire rows and/or columns
- horizontal slider (automatically hidden if not needed)
- set sliders inside ListFileds
- scrolling won't affect selection anymore (fixes a bug in DropdownListField's where scrolling would automatically select and close the dropdown menu)
- deselecting (i.e.: reset selection to nothing)

Javadocs were also added.