### PR TITLE
Tiledata serialization

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TileData.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TileData.java
@@ -19,10 +19,31 @@ import javax.xml.bind.annotation.XmlTransient;
 import de.gurkenlabs.litiengine.util.ArrayUtilities;
 
 public class TileData {
-  protected static final String ENCODING_BASE64 = "base64";
-  protected static final String ENCODING_CSV = "csv";
-  protected static final String COMPRESSION_GZIP = "gzip";
-  protected static final String COMPRESSION_ZLIB = "zlib";
+  public static class Encoding {
+    public static final String BASE64 = "base64";
+    public static final String CSV = "csv";
+
+    private Encoding() {
+    }
+
+    public static boolean isValid(String encoding) {
+      return encoding != null && !encoding.isEmpty() && (encoding.equals(BASE64) || encoding.equals(CSV));
+    }
+  }
+
+  public static class Compression {
+    public static final String GZIP = "gzip";
+    public static final String ZLIB = "zlib";
+    public static final String NONE = null;
+
+    private Compression() {
+    }
+
+    public static boolean isValid(String compression) {
+      // null equals no compression which is an accepted value
+      return compression == null || !compression.isEmpty() && (compression.equals(GZIP) || compression.equals(ZLIB));
+    }
+  }
 
   @XmlAttribute
   private String encoding;
@@ -65,23 +86,35 @@ public class TileData {
     // keep for serialization
   }
 
-  public TileData(List<Tile> tiles) {
+  public TileData(List<Tile> tiles, int width, int height, String encoding, String compression) throws TmxException {
+    if (!Encoding.isValid(encoding)) {
+      throw new TmxException("Invalid tile data encoding '" + encoding + "'. Supported encodings are " + Encoding.CSV + " and " + Encoding.BASE64 + ".");
+    }
+
+    if (!Compression.isValid(compression)) {
+      throw new TmxException("Invalid tile data compression '" + compression + "'. Supported compressions are " + Compression.GZIP + " and " + Compression.ZLIB + ".");
+    }
+
     this.tiles = tiles;
+    this.encoding = encoding;
+    this.compression = compression;
+    this.width = width;
+    this.height = height;
   }
 
   @XmlTransient
   public String getEncoding() {
-    return encoding;
+    return this.encoding;
   }
 
   @XmlTransient
   public String getCompression() {
-    return compression;
+    return this.compression;
   }
 
   @XmlTransient
   public String getValue() {
-    return value;
+    return this.value;
   }
 
   public void setEncoding(String encoding) {
@@ -112,6 +145,25 @@ public class TileData {
     }
 
     return this.tiles;
+  }
+
+  public static String encode(TileData data) throws InvalidTileLayerException {
+    StringBuilder sb = new StringBuilder();
+
+    for (int i = 0; i < data.getTiles().size(); i++) {
+      sb.append(data.getTiles().get(i).getGridId());
+
+      if (i < data.getTiles().size() - 1) {
+        sb.append(',');
+
+        if (i != 0 && (i + 1) % data.getWidth() == 0) {
+          sb.append('\n');
+        }
+      }
+    }
+
+    String csv = sb.toString();
+    return csv;
   }
 
   protected void setMinChunkOffsets(int x, int y) {
@@ -162,9 +214,9 @@ public class TileData {
 
       if (compression == null || compression.isEmpty()) {
         is = bais;
-      } else if (compression.equals(COMPRESSION_GZIP)) {
+      } else if (compression.equals(Compression.GZIP)) {
         is = new GZIPInputStream(bais, dec.length);
-      } else if (compression.equals(COMPRESSION_ZLIB)) {
+      } else if (compression.equals(Compression.ZLIB)) {
         is = new InflaterInputStream(bais);
       } else {
         throw new IllegalArgumentException("Unsupported tile layer compression method " + compression);
@@ -316,12 +368,12 @@ public class TileData {
     // first fill a two-dimensional array with all the information of the chunks
     Tile[][] tileArr = new Tile[this.getHeight()][this.getWidth()];
 
-    if (this.getEncoding().equals(ENCODING_BASE64)) {
+    if (this.getEncoding().equals(Encoding.BASE64)) {
       for (TileChunk chunk : this.chunks) {
         List<Tile> chunkTiles = parseBase64Data(chunk.getValue(), this.compression);
         this.addTiles(tileArr, chunk, chunkTiles);
       }
-    } else if (this.getEncoding().equals(ENCODING_CSV)) {
+    } else if (this.getEncoding().equals(Encoding.CSV)) {
       for (TileChunk chunk : this.chunks) {
         List<Tile> chunkTiles = parseCsvData(chunk.getValue());
         this.addTiles(tileArr, chunk, chunkTiles);
@@ -358,9 +410,9 @@ public class TileData {
 
   private List<Tile> parseData() throws InvalidTileLayerException {
     List<Tile> tiles;
-    if (this.getEncoding().equals(ENCODING_BASE64)) {
+    if (this.getEncoding().equals(Encoding.BASE64)) {
       tiles = parseBase64Data(this.value, this.compression);
-    } else if (this.getEncoding().equals(ENCODING_CSV)) {
+    } else if (this.getEncoding().equals(Encoding.CSV)) {
       tiles = parseCsvData(this.value);
     } else {
       throw new IllegalArgumentException("Unsupported tile layer encoding " + this.getEncoding());

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
@@ -93,6 +93,7 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
   }
 
   public Tileset(Tileset source) {
+    this.source = Resources.getLocation(source.getName() + "." + FILE_EXTENSION);
     this.sourceTileset = source;
     this.firstgid = 1;
   }

--- a/src/de/gurkenlabs/litiengine/resources/Blueprints.java
+++ b/src/de/gurkenlabs/litiengine/resources/Blueprints.java
@@ -1,6 +1,7 @@
 package de.gurkenlabs.litiengine.resources;
 
 import java.net.URL;
+
 import javax.xml.bind.JAXBException;
 
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Blueprint;

--- a/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/TileDataTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/TileDataTests.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +18,7 @@ public class TileDataTests {
 
     TileData data = new TileData();
     data.setValue(uncompressedBase64);
-    data.setEncoding(TileData.ENCODING_BASE64);
+    data.setEncoding(TileData.Encoding.BASE64);
     List<Tile> tiles = data.getTiles();
     assertEquals(500, tiles.size());
     assertEquals(1, tiles.get(0).getGridId());
@@ -34,8 +36,8 @@ public class TileDataTests {
 
     TileData data = new TileData();
     data.setValue(gzipBase64);
-    data.setEncoding(TileData.ENCODING_BASE64);
-    data.setCompression(TileData.COMPRESSION_GZIP);
+    data.setEncoding(TileData.Encoding.BASE64);
+    data.setCompression(TileData.Compression.GZIP);
     List<Tile> tiles = data.getTiles();
     assertEquals(500, tiles.size());
     assertEquals(1, tiles.get(0).getGridId());
@@ -49,8 +51,8 @@ public class TileDataTests {
 
     TileData data = new TileData();
     data.setValue(zlibBase64);
-    data.setEncoding(TileData.ENCODING_BASE64);
-    data.setCompression(TileData.COMPRESSION_ZLIB);
+    data.setEncoding(TileData.Encoding.BASE64);
+    data.setCompression(TileData.Compression.ZLIB);
     List<Tile> tiles = data.getTiles();
     assertEquals(500, tiles.size());
     assertEquals(1, tiles.get(0).getGridId());
@@ -89,7 +91,7 @@ public class TileDataTests {
 
     TileData data = new TileData();
     data.setValue(csv);
-    data.setEncoding(TileData.ENCODING_CSV);
+    data.setEncoding(TileData.Encoding.CSV);
     List<Tile> tiles = data.getTiles();
     assertEquals(500, tiles.size());
     assertEquals(1, tiles.get(0).getGridId());
@@ -99,5 +101,25 @@ public class TileDataTests {
     assertTrue(tiles.get(127).isFlippedVertically());
     assertFalse(tiles.get(127).isFlippedDiagonally());
     assertEquals(18, tiles.get(127).getGridId());
+  }
+  
+  @Test
+  public void testEncodeTileData() throws TmxException{
+    String csv = String.join("\n"
+        , "1,1,1,0,0,0,1,1,1,"
+        , "1,1,1,0,2,0,1,1,1,"
+        , "1,1,1,0,1,0,1,1,1");
+    
+    Tile[] tiles = new Tile[] {
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(0), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(2), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(1), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+    };
+     
+    TileData data = new TileData(Arrays.asList(tiles), 9, 3, TileData.Encoding.CSV, TileData.Compression.NONE);
+    
+    String encoded = TileData.encode(data);
+    
+    assertEquals(csv, encoded);
   }
 }

--- a/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/TileDataTests.java
+++ b/tests/de/gurkenlabs/litiengine/environment/tilemap/xml/TileDataTests.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -102,24 +102,74 @@ public class TileDataTests {
     assertFalse(tiles.get(127).isFlippedDiagonally());
     assertEquals(18, tiles.get(127).getGridId());
   }
-  
+
   @Test
-  public void testEncodeTileData() throws TmxException{
-    String csv = String.join("\n"
-        , "1,1,1,0,0,0,1,1,1,"
-        , "1,1,1,0,2,0,1,1,1,"
-        , "1,1,1,0,1,0,1,1,1");
-    
+  public void testEncodeBase64() throws IOException {
+    String uncompressed = "AQAAAAEAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAAAAAAIAAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAAAAAAEAAAAAAAAAAQAAAAEAAAABAAAA";
+
     Tile[] tiles = new Tile[] {
         new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(0), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
         new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(2), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
         new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(1), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
     };
-     
-    TileData data = new TileData(Arrays.asList(tiles), 9, 3, TileData.Encoding.CSV, TileData.Compression.NONE);
-    
+    TileData data = new TileData(Arrays.asList(tiles), 9, 3, TileData.Encoding.BASE64, TileData.Compression.NONE);
+
     String encoded = TileData.encode(data);
-    
+
+    assertEquals(uncompressed, encoded);
+  }
+
+  @Test
+  public void testEncodeBase64Gzip() throws IOException {
+    String compressed = "H4sIAAAAAAAAAGNkYGBghGJkwIgDgwATEWoYsagBAFsJTlBsAAAA";
+
+    Tile[] tiles = new Tile[] {
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(0), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(2), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(1), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+    };
+    TileData data = new TileData(Arrays.asList(tiles), 9, 3, TileData.Encoding.BASE64, TileData.Compression.GZIP);
+
+    String encoded = TileData.encode(data);
+
+    assertEquals(compressed, encoded);
+  }
+
+  @Test
+  public void testEncodeBase64Zlib() throws IOException {
+    String compressed = "eJxjZGBgYIRiZMCIA4MAExFqGLGoAQAE4AAW";
+
+    Tile[] tiles = new Tile[] {
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(0), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(2), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(1), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+    };
+    TileData data = new TileData(Arrays.asList(tiles), 9, 3, TileData.Encoding.BASE64, TileData.Compression.ZLIB);
+
+    String encoded = TileData.encode(data);
+
+    assertEquals(compressed, encoded);
+  }
+
+  @Test
+  public void testEncodeCsv() throws IOException {
+    String csv = String.join("\n", 
+        "",
+        "1,1,1,0,0,0,1,1,1,", 
+        "1,1,1,0,2,0,1,1,1,", 
+        "1,1,1,0,1,0,1,1,1", 
+        "");
+
+    Tile[] tiles = new Tile[] {
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(0), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(2), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+        new Tile(1), new Tile(1), new Tile(1), new Tile(0), new Tile(1), new Tile(0), new Tile(1), new Tile(1), new Tile(1),
+    };
+
+    TileData data = new TileData(Arrays.asList(tiles), 9, 3, TileData.Encoding.CSV, TileData.Compression.NONE);
+
+    String encoded = TileData.encode(data);
+
     assertEquals(csv, encoded);
   }
 }


### PR DESCRIPTION
Implement a way to serialize `TileData` that originates from a list of `Tiles`. Until now the engine was only able to deserialize that information.

This is useful e.g. to generate `Maps` from code (Issue #139)