### PR TITLE
Fix null pointer check in TmxMap

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
@@ -420,7 +420,7 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
 
   @Override
   public String toString() {
-    return (this.getName().isEmpty() || this.getName() == null) ? super.toString() : this.getName();
+    return (this.getName() == null || this.getName().isEmpty()) ? super.toString() : this.getName();
   }
 
   @Override


### PR DESCRIPTION
The null pointer was checked after already trying to call a method on the object.