### PR TITLE
Fix importing map with nested tile layers

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/GroupLayer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/GroupLayer.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 
@@ -123,6 +124,16 @@ public class GroupLayer extends Layer implements IGroupLayer {
   @Override
   public List<IGroupLayer> getGroupLayers() {
     return this.groupLayers;
+  }
+
+  @Override
+  protected void afterUnmarshal(Unmarshaller u, Object parent) {
+    super.afterUnmarshal(u, parent);
+    if (getMap() != null) {
+      for (ILayer layer : layers) {
+        ((Layer) layer).setMap((TmxMap) getMap());
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
The parentMap variable in Layer is only set if the immediate parent of the layer is the TmxMap. Children of GroupLayers would never have parentMap set. TileLayer::finish assumes parentMap is set when setting up its tiles.