### PR TITLE
Remove several unnecessary casts

### DIFF
--- a/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/components/MapComponent.java
@@ -656,7 +656,7 @@ public class MapComponent extends GuiComponent {
 
     for (IMapObject mapObject : mapObjects) {
       if (!this.getSelectedMapObjects().contains(mapObject)) {
-        this.getSelectedMapObjects().add((MapObject) mapObject);
+        this.getSelectedMapObjects().add(mapObject);
       }
     }
 
@@ -1202,8 +1202,8 @@ public class MapComponent extends GuiComponent {
           this.setSelection(mapObject, false);
           continue;
         }
-        if (this.getSelectedMapObjects().contains((MapObject) mapObject)) {
-          this.getSelectedMapObjects().remove((MapObject) mapObject);
+        if (this.getSelectedMapObjects().contains(mapObject)) {
+          this.getSelectedMapObjects().remove(mapObject);
         } else {
           this.setFocus(mapObject, !Input.keyboard().isPressed(KeyEvent.VK_SHIFT));
           UI.getInspector().bind(mapObject);


### PR DESCRIPTION
There are a few casts from IMap to MapObject, when the
function already accepts an IMap.