### PR TITLE
Fix for silent startup exception in utiliti when last game file was e…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 /build/
 /bin/
 /config.properties
-/.DS_Store
+.DS_Store
 crash.txt
+game.log
 /.idea
 /out/production/classes/de/gurkenlabs/litiengine
 /out/test/classes/de/gurkenlabs/litiengine

--- a/utiliti/src/de/gurkenlabs/utiliti/UserPreferences.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/UserPreferences.java
@@ -51,6 +51,7 @@ public class UserPreferences extends ConfigurationGroup {
     this.snapToGrid = true;
     this.renderBoundingBoxes = true;
     this.renderNames = true;
+    this.lastGameFile = "";
     this.lastOpenedFiles = new String[10];
     this.compressFile = false;
     this.gridLineWidth = 1.0f;


### PR DESCRIPTION
…mpty.

The utilLITY editor would throw an exception (NullPointer) on line 45, where it gets its preferences and tries to `trim` the last game file. Fix involves setting a default empty string for the last game file in the constructor. Exception was being written to game.log.

Also added game.log to .gitignore, and changed the pattern for .DS_Store, since the original one didn't catch all such files.