### PR TITLE
Add some helper methods to TextRenderer

### DIFF
--- a/src/de/gurkenlabs/litiengine/graphics/TextRenderer.java
+++ b/src/de/gurkenlabs/litiengine/graphics/TextRenderer.java
@@ -13,6 +13,7 @@ import java.awt.font.TextAttribute;
 import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
 
@@ -266,6 +267,50 @@ public final class TextRenderer {
 
   public static void renderWithOutline(final Graphics2D g, final String text, Point2D location, final Color outlineColor, final boolean antiAliasing) {
     renderWithOutline(g, text, location.getX(), location.getY(), outlineColor, antiAliasing);
+  }
+  
+  /**
+   * Retrieve the bounds of some text if it was to be drawn on the specified Graphics2D
+   * 
+   * @param g
+   *          The Graphics2D object to be drawn on
+   * @param text
+   *          The string to calculate the bounds of
+   *          
+   * @return The bounds of the specified String in the specified Graphics context.
+   * 
+   * @see java.awt.FontMetrics#getStringBounds(String str, Graphics context)
+   */
+  public static Rectangle2D getBounds(final Graphics2D g, final String text) {
+    return g.getFontMetrics().getStringBounds(text, g);
+  }
+  
+  /**
+   * Retrieve the width of some text if it was to be drawn on the specified Graphics2D
+   * 
+   * @param g
+   *          The Graphics2D object to be drawn on
+   * @param text
+   *          The string to retrieve the width of
+   * @return
+   *          The width of the specified text
+   */
+  public static double getWidth(final Graphics2D g, final String text) {
+    return getBounds(g, text).getWidth();
+  }
+  
+  /**
+   * Retrieve the height of some text if it was to be drawn on the specified Graphics2D
+   * 
+   * @param g
+   *          The Graphics2D object to be drawn on
+   * @param text
+   *          The string to retrieve the height of
+   * @return
+   *          The height of the specified text
+   */
+  public static double getHeight(final Graphics2D g, final String text) {
+    return getBounds(g, text).getHeight();
   }
   
   private static void enableAntiAliasing(final Graphics2D g) {


### PR DESCRIPTION
These methods will make it easier to center text along a point, among other things.

Before to have text centered onto the screen properly you had to do the following:

```java
String text = "Test text";
Rectangle2D textSize = g.getFontMetrics().getStringBounds(text, g);
TextRenderer.render(g, text,  g.getClipBounds().getCenterX() - textSize.getWidth() / 2, g.getClipBounds().getCenterY() - textSize.getWidth() / 2);
```

Now it can be simplified to 

```java
String text = "Test text";
TextRenderer.render(g, text, g.getClipBounds.getCenterX() - TextRenderer.getWidth(text) / 2, g.getClipBounds.getCenterY() - TextRenderer.getHeight(text) / 2);
```