### PR TITLE
Add .gitignore for JVM crash logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 crash.txt
 game.log*
+hs_err_pid*.log
 /.idea
 /out/production/classes/de/gurkenlabs/litiengine
 /out/test/classes/de/gurkenlabs/litiengine


### PR DESCRIPTION
If the JVM crashes, a log file titled hs_err_pid####.log is generated.
These shouldn't be pushed to the repo.