### PR TITLE
Improved GeometricUtilities

### DIFF
--- a/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -318,9 +318,16 @@ public class GeometricUtilities {
 
     return Math.sqrt(Math.pow(rect.getWidth(), 2) + Math.pow(rect.getHeight(), 2));
   }
+  
+  public static Point2D getMidPoint(Line2D line) {
+    return getMidPoint(line.getP1(), line.getP2());
+  }
 
   public static Point2D getMidPoint(final Point2D p1, final Point2D p2) {
     return getAveragePosition(p1, p2);
+  
+  public static Point2D getMidPoint(final double x1, final double y1, final double x2, final double y2) {
+    return new Point2D.Double((x1 + x2) / 2, (y1 + y2) / 2);
   }
 
   public static Ellipse2D getCircle(Point2D center, double radius) {

--- a/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -324,7 +324,8 @@ public class GeometricUtilities {
   }
 
   public static Point2D getMidPoint(final Point2D p1, final Point2D p2) {
-    return getAveragePosition(p1, p2);
+    return new Point2D.Double((p1.getX() + p2.getX()) / 2, (p1.getY() + p2.getY()) / 2);
+  }
   
   public static Point2D getMidPoint(final double x1, final double y1, final double x2, final double y2) {
     return new Point2D.Double((x1 + x2) / 2, (y1 + y2) / 2);

--- a/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -325,7 +325,7 @@ public class GeometricUtilities {
   }
 
   public static Point2D getCenter(final Point2D p1, final Point2D p2) {
-    return new Point2D.Double((p1.getX() + p2.getX()) / 2, (p1.getY() + p2.getY()) / 2);
+    return getCenter(p1.getX(), p2.getX(), p1.getY(),  p2.getY());
   }
   
   public static Point2D getCenter(final double x1, final double y1, final double x2, final double y2) {

--- a/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -11,6 +11,7 @@ import java.awt.geom.Path2D;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.geom.RectangularShape;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -329,6 +330,27 @@ public class GeometricUtilities {
   
   public static Point2D getMidPoint(final double x1, final double y1, final double x2, final double y2) {
     return new Point2D.Double((x1 + x2) / 2, (y1 + y2) / 2);
+  }
+  
+  /**
+   * Returns the center of a shape whose geometry is defined by a rectangular frame. 
+   * 
+   * Works for any subclass of RectuangularShape, including:<br>
+   * 
+   * <br>
+   * Arc2D<br>
+   * Ellipse2D<br>
+   * Rectangle2D<br>
+   * RoundRectangle2D<br>
+   * <br>
+   * 
+   * @param shape the shape to retrieve the center of
+   * @return a Point2D representing the center of the shape
+   * 
+   * @see java.awt.geom.RectangularShape
+   */
+  public static Point2D getMidPoint(RectangularShape shape) {
+    return new Point2D.Double(shape.getCenterX(), shape.getCenterY());
   }
 
   public static Ellipse2D getCircle(Point2D center, double radius) {

--- a/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -320,15 +320,15 @@ public class GeometricUtilities {
     return Math.sqrt(Math.pow(rect.getWidth(), 2) + Math.pow(rect.getHeight(), 2));
   }
   
-  public static Point2D getMidPoint(Line2D line) {
-    return getMidPoint(line.getP1(), line.getP2());
+  public static Point2D getCenter(Line2D line) {
+    return getCenter(line.getP1(), line.getP2());
   }
 
-  public static Point2D getMidPoint(final Point2D p1, final Point2D p2) {
+  public static Point2D getCenter(final Point2D p1, final Point2D p2) {
     return new Point2D.Double((p1.getX() + p2.getX()) / 2, (p1.getY() + p2.getY()) / 2);
   }
   
-  public static Point2D getMidPoint(final double x1, final double y1, final double x2, final double y2) {
+  public static Point2D getCenter(final double x1, final double y1, final double x2, final double y2) {
     return new Point2D.Double((x1 + x2) / 2, (y1 + y2) / 2);
   }
   
@@ -349,7 +349,7 @@ public class GeometricUtilities {
    * 
    * @see java.awt.geom.RectangularShape
    */
-  public static Point2D getMidPoint(RectangularShape shape) {
+  public static Point2D getCenter(RectangularShape shape) {
     return new Point2D.Double(shape.getCenterX(), shape.getCenterY());
   }
 

--- a/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -320,7 +320,7 @@ public class GeometricUtilities {
     return Math.sqrt(Math.pow(rect.getWidth(), 2) + Math.pow(rect.getHeight(), 2));
   }
   
-  public static Point2D getCenter(Line2D line) {
+  public static Point2D getCenter(final Line2D line) {
     return getCenter(line.getP1(), line.getP2());
   }
 
@@ -349,7 +349,7 @@ public class GeometricUtilities {
    * 
    * @see java.awt.geom.RectangularShape
    */
-  public static Point2D getCenter(RectangularShape shape) {
+  public static Point2D getCenter(final RectangularShape shape) {
     return new Point2D.Double(shape.getCenterX(), shape.getCenterY());
   }
 

--- a/tests/de/gurkenlabs/litiengine/util/geom/GeometricUtilitiesTests.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/GeometricUtilitiesTests.java
@@ -68,10 +68,6 @@ public class GeometricUtilitiesTests {
     Rectangle2D rectangle9 = new Rectangle2D.Double(-5, -5, 10, 10);
     Point2D mid9 = GeometricUtilities.getMidPoint(rectangle9);
     
-    for(int i = 0; i < 10; i++) {
-      System.err.println(mid3);
-    }
-    
     assertEquals(new Point2D.Double(0, 0.5), mid);
     assertEquals(new Point2D.Double(0, 0.5), mid2);
     assertEquals(new Point2D.Double(0.5, 0.5), mid3);

--- a/tests/de/gurkenlabs/litiengine/util/geom/GeometricUtilitiesTests.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/GeometricUtilitiesTests.java
@@ -54,19 +54,19 @@ public class GeometricUtilitiesTests {
 
   @Test
   public void testGetMidPoint() {
-    Point2D mid = GeometricUtilities.getMidPoint(new Point2D.Double(0, 0), new Point2D.Double(0, 1));
-    Point2D mid2 = GeometricUtilities.getMidPoint(new Line2D.Double(new Point2D.Double(0,0), new Point2D.Double(0,1)));
-    Point2D mid3 = GeometricUtilities.getMidPoint(0, 0, 1, 1);
-    Point2D mid4 = GeometricUtilities.getMidPoint(GeometricUtilities.getCircle(new Point2D.Double(0.5d, 0.5d), 0.5d));
-    Point2D mid5 = GeometricUtilities.getMidPoint(new Ellipse2D.Double(0, 0, 1, 1));
-    Point2D mid6 = GeometricUtilities.getMidPoint(new Rectangle2D.Double(0, 0, 1, 1));
-    Point2D mid7 = GeometricUtilities.getMidPoint(new Arc2D.Double(0, 0, 1, 1, 1, 1, Arc2D.OPEN));
+    Point2D mid = GeometricUtilities.getCenter(new Point2D.Double(0, 0), new Point2D.Double(0, 1));
+    Point2D mid2 = GeometricUtilities.getCenter(new Line2D.Double(new Point2D.Double(0,0), new Point2D.Double(0,1)));
+    Point2D mid3 = GeometricUtilities.getCenter(0, 0, 1, 1);
+    Point2D mid4 = GeometricUtilities.getCenter(GeometricUtilities.getCircle(new Point2D.Double(0.5d, 0.5d), 0.5d));
+    Point2D mid5 = GeometricUtilities.getCenter(new Ellipse2D.Double(0, 0, 1, 1));
+    Point2D mid6 = GeometricUtilities.getCenter(new Rectangle2D.Double(0, 0, 1, 1));
+    Point2D mid7 = GeometricUtilities.getCenter(new Arc2D.Double(0, 0, 1, 1, 1, 1, Arc2D.OPEN));
     
     Rectangle2D rectangle8 = new Rectangle2D.Double(5, 5, 10, 10);
-    Point2D mid8 = GeometricUtilities.getMidPoint(rectangle8);
+    Point2D mid8 = GeometricUtilities.getCenter(rectangle8);
     
     Rectangle2D rectangle9 = new Rectangle2D.Double(-5, -5, 10, 10);
-    Point2D mid9 = GeometricUtilities.getMidPoint(rectangle9);
+    Point2D mid9 = GeometricUtilities.getCenter(rectangle9);
     
     assertEquals(new Point2D.Double(0, 0.5), mid);
     assertEquals(new Point2D.Double(0, 0.5), mid2);

--- a/tests/de/gurkenlabs/litiengine/util/geom/GeometricUtilitiesTests.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/GeometricUtilitiesTests.java
@@ -3,10 +3,12 @@ package de.gurkenlabs.litiengine.util.geom;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.awt.geom.Arc2D;
 import java.awt.geom.Dimension2D;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
-
 import org.junit.jupiter.api.Test;
 
 public class GeometricUtilitiesTests {
@@ -53,8 +55,32 @@ public class GeometricUtilitiesTests {
   @Test
   public void testGetMidPoint() {
     Point2D mid = GeometricUtilities.getMidPoint(new Point2D.Double(0, 0), new Point2D.Double(0, 1));
-
+    Point2D mid2 = GeometricUtilities.getMidPoint(new Line2D.Double(new Point2D.Double(0,0), new Point2D.Double(0,1)));
+    Point2D mid3 = GeometricUtilities.getMidPoint(0, 0, 1, 1);
+    Point2D mid4 = GeometricUtilities.getMidPoint(GeometricUtilities.getCircle(new Point2D.Double(0.5d, 0.5d), 0.5d));
+    Point2D mid5 = GeometricUtilities.getMidPoint(new Ellipse2D.Double(0, 0, 1, 1));
+    Point2D mid6 = GeometricUtilities.getMidPoint(new Rectangle2D.Double(0, 0, 1, 1));
+    Point2D mid7 = GeometricUtilities.getMidPoint(new Arc2D.Double(0, 0, 1, 1, 1, 1, Arc2D.OPEN));
+    
+    Rectangle2D rectangle8 = new Rectangle2D.Double(5, 5, 10, 10);
+    Point2D mid8 = GeometricUtilities.getMidPoint(rectangle8);
+    
+    Rectangle2D rectangle9 = new Rectangle2D.Double(-5, -5, 10, 10);
+    Point2D mid9 = GeometricUtilities.getMidPoint(rectangle9);
+    
+    for(int i = 0; i < 10; i++) {
+      System.err.println(mid3);
+    }
+    
     assertEquals(new Point2D.Double(0, 0.5), mid);
+    assertEquals(new Point2D.Double(0, 0.5), mid2);
+    assertEquals(new Point2D.Double(0.5, 0.5), mid3);
+    assertEquals(new Point2D.Double(0.5, 0.5), mid4);
+    assertEquals(new Point2D.Double(0.5, 0.5), mid5);
+    assertEquals(new Point2D.Double(0.5, 0.5), mid6);
+    assertEquals(new Point2D.Double(0.5, 0.5), mid7);
+    assertEquals(new Point2D.Double(10, 10), mid8);
+    assertEquals(new Point2D.Double(0, 0), mid9);
   }
 
   @Test


### PR DESCRIPTION
- Added `getMidPoint(Line2D)`
- Optimized `getMidpoint(Point2D, Point2D)`
- Added `getMidPoint(double x1, double y1, double x2, double y2)`
- Added `getMidPoint(RectangularShape)`
- Added unit tests for the above methods

`getMidPoint(Point2D, Point2D)` is more optimized now because it no longer calls `getAveragePosition(Point2D...)`. This is faster because an array is no longer created or iterated, and there are no unnecessary calls to `Point2D[].length`