### PR TITLE
Add missing dependency for dark theme

### DIFF
--- a/utiliti/build.gradle
+++ b/utiliti/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
   implementation project(':')
   implementation 'com.github.weisj:darklaf-core:2.0.2'
+  implementation 'com.github.weisj:darklaf-theme:2.0.2'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.+'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.+'


### PR DESCRIPTION
Fixes build error in https://github.com/gurkenlabs/litiengine/pull/340.