### PR TITLE
Ignore .gradle folders in subprojects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.gradle/
+**/.gradle/
 /build/
 /bin/
 /config.properties


### PR DESCRIPTION
Some files are being generated in /utiliti/.gradle/buildOutputCleanup which aren't needed in the repository.

I've added the ignore to the main .gitignore instead of /utiliti/.gitignore just in case another subproject is ever added to the repository.