### PR TITLE
Travis builds will now fail if not compatible with java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - chmod +x gradlew
   - sudo apt-get -y install at-spi2-core
 
-jdk: openjdk11
+jdk: openjdk8
 
 git:
   depth: false


### PR DESCRIPTION
The travis build will now fail if the source code is incompatible with java 8.

See https://github.com/Gamebuster19901/litiengine/tree/thisBranchShouldFail for an example failure.