### PR TITLE
Fix swing tests

### DIFF
--- a/tests/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
+++ b/tests/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
@@ -9,11 +9,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.awt.event.MouseEvent;
 
 import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class GuiComponentTests {
 
+  @BeforeEach
+  public void assertOnSwingThread() {
+    assertTrue(SwingUtilities.isEventDispatchThread());
+  }
+  
   @Test
   public void testInitializaion() {
     TestComponent component = new TestComponent(10, 20, 100, 50);

--- a/tests/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
+++ b/tests/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
@@ -13,7 +13,9 @@ import javax.swing.SwingUtilities;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(SwingTestSuite.class)
 public class GuiComponentTests {
 
   @BeforeEach

--- a/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
+++ b/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.gurkenlabs.litiengine.Game;
@@ -20,6 +23,11 @@ class ListFieldTest {
       { "P", "Q", "R", "S", "T", "U", "V" },
       { "W", "X", "Y", "Z" }
   };
+  
+  @BeforeEach
+  public void assertOnSwingThread() {
+    assertTrue(SwingUtilities.isEventDispatchThread());
+  }
 
   @Test
   void testInitialization() {

--- a/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
+++ b/tests/de/gurkenlabs/litiengine/gui/ListFieldTest.java
@@ -9,9 +9,11 @@ import javax.swing.SwingUtilities;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import de.gurkenlabs.litiengine.Game;
 
+@ExtendWith(SwingTestSuite.class)
 class ListFieldTest {
 
   private final String[] content_1D = new String[] {

--- a/tests/de/gurkenlabs/litiengine/gui/SwingTestSuite.java
+++ b/tests/de/gurkenlabs/litiengine/gui/SwingTestSuite.java
@@ -1,0 +1,78 @@
+package de.gurkenlabs.litiengine.gui;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionException;
+
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+public class SwingTestSuite implements InvocationInterceptor {
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T interceptTestClassConstructor(Invocation<T> invocation, ReflectiveInvocationContext<Constructor<T>> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    final Object[] ret = new Object[1];
+    SwingUtilities.invokeAndWait(() -> {ret[0] = proceed(invocation);});
+    return (T) ret[0];
+  }
+  
+  @Override
+  public void interceptBeforeAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+  
+  @Override
+  public void interceptBeforeEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+  
+  @Override
+  public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extendsionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+  
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T interceptTestFactoryMethod(Invocation<T> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    final Object[] ret = new Object[1];
+    SwingUtilities.invokeAndWait(() -> {ret[0] = proceed(invocation);});
+    return (T) ret[0];
+  }
+  
+  @Override
+  public void interceptTestTemplateMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+  
+  @Override
+  public void interceptDynamicTest(Invocation<Void> invocation, ExtensionContext extensionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+  
+  @Override
+  public void interceptAfterEachMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+  
+  @Override
+  public void interceptAfterAllMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
+    proceedAndWait(invocation);
+  }
+   
+  private void proceedAndWait(Invocation<Void> invocation) throws Throwable {
+    SwingUtilities.invokeAndWait(() -> {proceed(invocation);});
+  }
+
+  private <T> T proceed(Invocation<T> invocation) {
+    try {
+      return invocation.proceed();
+    } catch (Throwable e) {
+      throw new CompletionException(e);
+    }
+  }
+  
+}

--- a/utiliti/build.gradle
+++ b/utiliti/build.gradle
@@ -38,10 +38,10 @@ dependencies {
   implementation 'com.formdev:svgSalamander:1.1.2.1'
   implementation 'com.fifesoft:rsyntaxtextarea:3.1.1'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.+'
-  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.+'
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.+'
-  testImplementation 'org.mockito:mockito-core:2.25.+'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.0'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+  testImplementation 'org.mockito:mockito-core:3.3.3'
 }
 
 test {

--- a/utiliti/build.gradle
+++ b/utiliti/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   implementation 'com.formdev:svgSalamander:1.1.2.1'
   implementation 'com.fifesoft:rsyntaxtextarea:3.1.1'
 
+  testImplementation project(':').sourceSets.test.output //needed for swing tests
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.0'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'

--- a/utiliti/src/de/gurkenlabs/utiliti/swing/LogHandler.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/LogHandler.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 public class LogHandler extends java.util.logging.Handler {
-    private final JTextPane textPane;
+    final JTextPane textPane;
 
     public LogHandler(final JTextPane textPane) {
         this.textPane = textPane;

--- a/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
+++ b/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
@@ -1,6 +1,10 @@
 package de.gurkenlabs.utiliti.swing;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import de.gurkenlabs.litiengine.gui.SwingTestSuite;
 
 import javax.swing.*;
 import javax.swing.text.*;
@@ -10,8 +14,14 @@ import java.util.logging.LogRecord;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(SwingTestSuite.class)
 public class LogHandlerTest {
 
+    @BeforeEach
+    public void assertOnSwingThread() {
+      assertTrue(SwingUtilities.isEventDispatchThread());
+    }
+  
     @Test
     public void publish() {
         JTextPane textPane = new JTextPane();

--- a/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
+++ b/utiliti/tests/de/gurkenlabs/utiliti/swing/LogHandlerTest.java
@@ -1,0 +1,82 @@
+package de.gurkenlabs.utiliti.swing;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.*;
+import javax.swing.text.*;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LogHandlerTest {
+
+    @Test
+    public void publish() {
+        JTextPane textPane = new JTextPane();
+        LogHandler logHandler = new LogHandler(textPane);
+
+        StyledDocument styledDocument = textPane.getStyledDocument();
+
+        assertEquals(0, styledDocument.getLength());
+        assertEquals(0, textPane.getCaretPosition());
+
+        logHandler.publish(new LogRecord(Level.INFO, "Hello World"));
+        logHandler.publish(new LogRecord(Level.SEVERE, "This is a severe test!"));
+
+        assertEquals(55, styledDocument.getLength());
+        assertEquals(55, textPane.getCaretPosition());
+    }
+
+    @Test
+    public void flush() {
+        JTextPane textPane = new JTextPane();
+        LogHandler logHandler = new LogHandler(textPane);
+
+        logHandler.publish(new LogRecord(Level.INFO, "Hello World"));
+        logHandler.publish(new LogRecord(Level.INFO, "This is a test"));
+
+        StyledDocument styledDocument = textPane.getStyledDocument();
+
+        assertEquals(47, styledDocument.getLength());
+        assertEquals(47, textPane.getCaretPosition());
+
+        logHandler.flush();
+
+        assertEquals(0, styledDocument.getLength());
+        assertEquals(0, textPane.getCaretPosition());
+    }
+
+    @Test
+    public void scrollToLast() {
+        JTextPane textPane = new JTextPane();
+        textPane.setBounds(5, 5, 200, 10);
+        LogHandler logHandler = new LogHandler(textPane);
+
+        logHandler.publish(new LogRecord(Level.INFO, "Hello World"));
+        logHandler.publish(new LogRecord(Level.INFO, "This is a test"));
+
+        StyledDocument styledDocument = textPane.getStyledDocument();
+        textPane.setCaretPosition(0);
+
+        assertEquals(47, styledDocument.getLength());
+        assertEquals(0, textPane.getCaretPosition());
+
+        try {
+          System.out.println(logHandler != null);
+          if(logHandler != null) {
+            System.out.println("TextPane = " + logHandler.textPane);
+            System.out.println("doc = " + logHandler.textPane.getStyledDocument());
+          }
+          logHandler.scrollToLast();
+        }
+        catch(Throwable t) {
+          t.printStackTrace();
+          throw t;
+        }
+
+        assertEquals(47, styledDocument.getLength());
+        assertEquals(47, textPane.getCaretPosition());
+    }
+}


### PR DESCRIPTION
This pull request fixes a threading issue in the testing environment, which was discovered in https://github.com/gurkenlabs/litiengine/pull/362.

It is unsafe to perform operations on swing components outside of the event dispatcher thread. Junit by default completes tests on a thread which is not the event dispatch thread.

I've created `SwingTestSuite.class`, which is a test suite that executes all tests in the event dispatcher thread. 

Any class in the testing environment which performs operations on swing components should be annotated with `@ExtendWith(SwingTestSuite.class)` so the tests will be executed in the swing test suite.