### PR TITLE
Fix ArraIndexOutOfBoundsException

### DIFF
--- a/utiliti/src/de/gurkenlabs/utiliti/swing/panels/CreaturePanel.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/swing/panels/CreaturePanel.java
@@ -44,19 +44,19 @@ public class CreaturePanel extends PropertyPanel {
   public static String getCreatureSpriteName(String name) {
     for (CreatureAnimationState state : CreatureAnimationState.values()) {
       if (name.endsWith(state.spriteString())) {
-        return name.substring(0, name.length() - state.spriteString().length() - 1);
+        return name.substring(0, name.length() - state.spriteString().length());
       }
     }
 
     for (Direction dir : Direction.values()) {
       String idle = CreatureAnimationState.IDLE.spriteString() + "-" + dir.toString().toLowerCase();
       if (name.endsWith(idle)) {
-        return name.substring(0, name.length() - idle.length() - 1);
+        return name.substring(0, name.length() - idle.length());
       }
 
       String walk = CreatureAnimationState.WALK.spriteString() + "-" + dir.toString().toLowerCase();
       if (name.endsWith(walk)) {
-        return name.substring(0, name.length() - walk.length() - 1);
+        return name.substring(0, name.length() - walk.length());
       }
     }
 


### PR DESCRIPTION
From the discord:

https://discord.com/channels/326074836508213258/517120478557634580/814282223641296936

These return statements erroneously subtract 1 when they shouldn't which can cause the index to underflow.

Ex: If the name is 4 characters long then:
```java
return name.substring(0, name.length() - state.spriteString().length() - 1);
```
is actually 

```java
return name.substring(0, 4 - 4 - 1)
```

`4 - 4 - 1 = -1`  which is less than 0, and therefor invalid.

Test before merging.