### PR TITLE
Improve coverage by 100% in vector2D

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    testLogging.showStandardStreams = true
+	testLogging {
+    events "passed", "skipped", "failed"
+    exceptionFormat "full" }
 }
 
 jacocoTestReport {

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -86,4 +86,21 @@ public class Vector2DTest {
         assertEquals(result.getX(), expectedX);
         assertEquals(result.getY(), expectedY);   
     }
+
+    /**
+     * Test scale vector
+     */
+    @Test
+    public void testVector2DScale(){
+        double xValue = 5.0;
+        double yValue = 0.0;
+        double scalefactor = 3.0;
+        double expectedX = 15.0;
+        double expectedY = 0.0;
+        Vector2D vector = new Vector2D(xValue, yValue);
+        Vector2D result  = vector.scale(scalefactor);
+
+        assertEquals(result.getX(), expectedX);
+        assertEquals(result.getY(), expectedY);
+    }
 }

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -34,4 +34,25 @@ public class Vector2DTest {
         assertEquals(vectorResult1.dY, vectorResult1.getY());
 
     }
+
+    /**
+     * Test unitVector-function in Vector2D class
+     */
+    @Test
+    public void testVector2DUnit(){
+        double xValue = 0.0;
+        double yValue = 5.0;
+
+        Vector2D vectorDouble = new Vector2D(xValue, yValue);
+        Vector2D unitVector = vectorDouble.unitVector();
+        assertEquals(unitVector.getY(), 1.0);
+        assertEquals(unitVector.getX(), 0.0);
+
+        yValue = 0.0;
+        Vector2D zeroLengthVector = new Vector2D(xValue,yValue);
+        unitVector = zeroLengthVector.unitVector();
+        assertEquals(unitVector.getX(), 0.0);
+        assertEquals(unitVector.getY(), 0.0);
+
+    }
 }

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -119,6 +119,25 @@ public class Vector2DTest {
         Vector2D vector2 = new Vector2D(xValue2, yValue2);
         double result = vector1.dotProduct(vector2);
         assertEquals(result, expected);
+    }
+    
+    /**
+     * Test sub
+     */
+    @Test
+    public void testVector2DSub(){
+        double xValue1 = 5.0;
+        double yValue1 = 10.0;
+        double xValue2 = 3.0;
+        double yValue2 = 2.0;
+        double expectedX = 2.0;
+        double expectedY = 8.0;
 
+        Vector2D vector1 = new Vector2D(xValue1, yValue1);
+        Vector2D vector2 = new Vector2D(xValue2, yValue2);
+        Vector2D result = vector1.sub(vector2);
+
+        assertEquals(result.getX(), expectedX);
+        assertEquals(result.getY(), expectedY);
     }
 }

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -56,6 +56,9 @@ public class Vector2DTest {
 
     }
 
+    /**
+     * Test toString method
+     */
     @Test
     public void testVector2DToString(){
         double xValue = 10.0;
@@ -65,7 +68,22 @@ public class Vector2DTest {
         Vector2D vectorDouble = new Vector2D(xValue, yValue);
 
         assertEquals(expected, vectorDouble.toString());
+    }
 
+    /**
+     * Test normal vector
+     */
+    @Test
+    public void testVector2DNormal(){
+        double xValue = 5.0;
+        double yValue = 0.0;
+        double expectedX = 0.0;
+        double expectedY = -5.0;
 
+        Vector2D vector= new Vector2D(xValue, yValue);
+        Vector2D result = vector.normalVector();
+
+        assertEquals(result.getX(), expectedX);
+        assertEquals(result.getY(), expectedY);   
     }
 }

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -103,4 +103,22 @@ public class Vector2DTest {
         assertEquals(result.getX(), expectedX);
         assertEquals(result.getY(), expectedY);
     }
+
+    /**
+     * Test dot product
+     */
+    @Test
+    public void testVector2DDot(){
+        double xValue1 = 5.0;
+        double yValue1 = 10.0;
+        double xValue2 = 3.0;
+        double yValue2 = 2.0;
+        double expected = 35.0;
+
+        Vector2D vector1 = new Vector2D(xValue1, yValue1);
+        Vector2D vector2 = new Vector2D(xValue2, yValue2);
+        double result = vector1.dotProduct(vector2);
+        assertEquals(result, expected);
+
+    }
 }

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -1,0 +1,37 @@
+package de.gurkenlabs.litiengine.util.geom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.geom.Point2D;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class Vector2DTest {
+
+    /**
+     * Test add-function in Vector2D class
+     */
+    @Test
+    public void testVector2D() {
+        double xValue = 10.0;
+        double yValue = 5.0;
+        Point2D point1 = new Point2D.Double(0, 0);;
+        Point2D point2 = new Point2D.Double(xValue, yValue);;
+
+        Vector2D vectorStandard = new Vector2D();
+        Vector2D vectorDouble = new Vector2D(xValue, yValue);
+        Vector2D vectorPoint2D = new Vector2D(point1, point2);
+
+        Vector2D vectorResult1 = vectorStandard.add(vectorDouble);
+        Vector2D vectorResult2 = vectorStandard.add(vectorPoint2D);
+
+        assertEquals(vectorResult1.dX, xValue);
+        assertEquals(vectorResult1.dY, yValue);
+        assertEquals(vectorResult2.dX, xValue);
+        assertEquals(vectorResult2.dY, yValue);
+        assertEquals(vectorResult1.dX, vectorResult1.getX());
+        assertEquals(vectorResult1.dY, vectorResult1.getY());
+
+    }
+}

--- a/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
+++ b/tests/de/gurkenlabs/litiengine/util/geom/Vector2DTest.java
@@ -55,4 +55,17 @@ public class Vector2DTest {
         assertEquals(unitVector.getY(), 0.0);
 
     }
+
+    @Test
+    public void testVector2DToString(){
+        double xValue = 10.0;
+        double yValue = 5.0;
+        String expected = "Vector2D(10.0, 5.0)";
+
+        Vector2D vectorDouble = new Vector2D(xValue, yValue);
+
+        assertEquals(expected, vectorDouble.toString());
+
+
+    }
 }


### PR DESCRIPTION
This adds tests for the vector2D-class (litiengine.util.geom.vector2D), improving the branch and instructions cover by 100%

Before:
![vector2DBeforeTest](https://user-images.githubusercontent.com/45625500/109347131-f1025980-7872-11eb-824e-b1287106dbea.png)
After:
![vector2DFinal](https://user-images.githubusercontent.com/45625500/109347264-2e66e700-7873-11eb-9ede-728dd877f67d.png)

