### PR TITLE
Utiliti will now crash and generate a crash log if it fails to initialize or encounters an Error

### DIFF
--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -17,40 +17,54 @@ import de.gurkenlabs.utiliti.swing.UI;
 
 public class Program {
   public static void main(String[] args) {
-    // setup basic settings
-    Game.info().setName("utiLITI");
-    Game.info().setSubTitle("LITIENGINE Creation Kit");
-    Game.info().setVersion("v0.5.1-beta");
-    Resources.strings().setEncoding(StandardCharsets.UTF_8);
-
-    // hook up configuration and initialize the game
-    Game.config().add(Editor.preferences());
-
-    Game.config().load();
     SwingUtilities.invokeLater(() -> {
-      UI.initLookAndFeel();
-      Game.init(args);
-      forceBasicEditorConfiguration();
-      Game.world().camera().onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
-
-      // the editor should never crash, even if an exception occurs
       Game.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(false));
+      try {
+        try {
+          // setup basic settings
+          Game.info().setName("utiLITI");
+          Game.info().setSubTitle("LITIENGINE Creation Kit");
+          Game.info().setVersion("v0.5.1-beta");
+          Resources.strings().setEncoding(StandardCharsets.UTF_8);
 
-      // prepare UI and start the game
-      UI.init();
-      Game.start();
+          // hook up configuration and initialize the game
+          Game.config().add(Editor.preferences());
 
-      // configure input settings
-      Input.mouse().setGrabMouse(false);
-      Input.keyboard().consumeAlt(true);
-
-      // load up previously opened project file or the one that is specified in
-      // the command line arguments
-      handleArgs(args);
-
-      String gameFile = Editor.preferences().getLastGameFile();
-      if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
-        Editor.instance().load(new File(gameFile.trim()), false);
+          Game.config().load();
+          
+          UI.initLookAndFeel();
+          Game.init(args);
+          forceBasicEditorConfiguration();
+          Game.world().camera().onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
+    
+          // prepare UI and start the game
+          UI.init();
+          Game.start();
+        }
+        catch(Throwable t) {
+          throw new UtiLITIInitializationError("UtiLITI failed to initialize, see the stacktrace below for more information", t);
+        }
+  
+        // configure input settings
+        Input.mouse().setGrabMouse(false);
+        Input.keyboard().consumeAlt(true);
+  
+        // load up previously opened project file or the one that is specified in
+        // the command line arguments
+        handleArgs(args);
+  
+        String gameFile = Editor.preferences().getLastGameFile();
+        if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
+          Editor.instance().load(new File(gameFile.trim()), false);
+        }
+      }
+      catch(Error e) { //the editor SHOULD crash if an Error occurs, as long as the Error !instanceof ThreadDeath
+        if(e instanceof ThreadDeath) {
+          throw e;
+        }
+        DefaultUncaughtExceptionHandler exceptionHandler = (DefaultUncaughtExceptionHandler) Thread.getDefaultUncaughtExceptionHandler();
+        exceptionHandler.setExitOnException(true);
+        throw e;
       }
     });
   }

--- a/utiliti/src/de/gurkenlabs/utiliti/UtiLITIInitializationError.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/UtiLITIInitializationError.java
@@ -1,0 +1,18 @@
+package de.gurkenlabs.utiliti;
+
+@SuppressWarnings("serial")
+class UtiLITIInitializationError extends Error {
+  
+  public UtiLITIInitializationError(String message, Throwable cause) {
+    super(message, cause);
+  }
+  
+  public UtiLITIInitializationError(Throwable cause) {
+    super(cause);
+  }
+  
+  public UtiLITIInitializationError(String message) {
+    super(message);
+  }
+  
+}


### PR DESCRIPTION
It is possible for utiliti to have an exception get thrown before the UI is initialized. If this happens, utiliti will now crash and generate a crash report, instead of hanging and sometimes not generating a crash report. (Exception previously could get thrown before the exception handler was set).

Utiliti will also crash and generate a crash report if a subclass of Error is thrown (excluding ThreadDeath).

The previous behavior has created issues with helping game devs debug issues they are experiencing with utiliti.

see:
 https://discord.com/channels/326074836508213258/804040170504192031/826994492245540884
https://discord.com/channels/326074836508213258/804040170504192031/826992432440410143