### PR TITLE
Crash handling & debugging

### DIFF
--- a/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
+++ b/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
@@ -30,7 +30,8 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
    * Initializes a new instance of the {@code DefaultUncaughtExceptionHandler} class.
    *
    * @param exitOnException
-   *          A flag indicating whether the game should exit when an unexpected error occurs.
+   *          A flag indicating whether the game should exit when an unexpected exception occurs.
+   *          The game will still exit if it encounters an Error.
    */
   public DefaultUncaughtExceptionHandler(boolean exitOnException) {
     this.exitOnException = exitOnException;
@@ -51,13 +52,15 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
 
     log.log(Level.SEVERE, "Game crashed! :(", e);
 
-    if (this.exitOnException()) {
+    if (this.exitOnException() || e instanceof Error) {
       System.exit(Game.EXIT_GAME_CRASHED);
     }
   }
 
   /**
    * Indicates whether this hander currently exits the game upon an unhandled exception.
+   * 
+   * Note that this handler will still exit if it encounters an unhandled Error.
    * 
    * @return True if the game will exit upon an unhandled exception; otherwise false.
    */

--- a/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
+++ b/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
@@ -108,10 +108,10 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
   }
   
   /**
-   * Set whether the generated crash report will contain an additonal thread dump
+   * Set whether the generated crash report will contain an additional thread dump
    * 
-   * @param exit
-   *          The flag that defines whether the game will exit upon an unhandled exception.
+   * @param dumpThreads
+   *          The flag that defines whether crash report will contain a thread dump.
    */
   public void dumpThreads(boolean dumpThreads) {
     this.dumpThreads = dumpThreads;

--- a/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
+++ b/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
@@ -27,8 +27,8 @@ import de.gurkenlabs.litiengine.configuration.ClientConfiguration;
 public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler {
   private static final Logger log = Logger.getLogger(DefaultUncaughtExceptionHandler.class.getName());
 
-  private boolean exitOnException;
-  private boolean dumpThreads;
+  private volatile boolean exitOnException;
+  private volatile boolean dumpThreads;
 
   /**
    * Initializes a new instance of the {@code DefaultUncaughtExceptionHandler} class.

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -13,9 +13,12 @@ import de.gurkenlabs.litiengine.configuration.Quality;
 import de.gurkenlabs.litiengine.input.Input;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.utiliti.components.Editor;
+import de.gurkenlabs.utiliti.handlers.DebugCrasher;
 import de.gurkenlabs.utiliti.swing.UI;
 
 public class Program {
+  public static boolean debugCrash = false;
+  
   public static void main(String[] args) {
     SwingUtilities.invokeLater(() -> {
         try {
@@ -34,12 +37,19 @@ public class Program {
           Game.init(args);
           DefaultUncaughtExceptionHandler handler = new DefaultUncaughtExceptionHandler(false);
           Game.setUncaughtExceptionHandler(handler);
+          Game.loop().attach(() -> {
+            if(debugCrash) {
+              handler.dumpThreads(true);
+              throw new Error("Manually triggered debug crash"); //Press CTRL + SHIFT + ALT + C to generate debug crash report
+            }
+          });
           forceBasicEditorConfiguration();
           Game.world().camera().onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
     
           // prepare UI and start the game
           UI.init();
           Game.start();
+          Game.window().getHostControl().addKeyListener(new DebugCrasher());
         }
         catch(Throwable t) {
           throw new UtiLITIInitializationError("UtiLITI failed to initialize, see the stacktrace below for more information", t);

--- a/utiliti/src/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/Program.java
@@ -18,8 +18,6 @@ import de.gurkenlabs.utiliti.swing.UI;
 public class Program {
   public static void main(String[] args) {
     SwingUtilities.invokeLater(() -> {
-      Game.setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(false));
-      try {
         try {
           // setup basic settings
           Game.info().setName("utiLITI");
@@ -34,6 +32,8 @@ public class Program {
           
           UI.initLookAndFeel();
           Game.init(args);
+          DefaultUncaughtExceptionHandler handler = new DefaultUncaughtExceptionHandler(false);
+          Game.setUncaughtExceptionHandler(handler);
           forceBasicEditorConfiguration();
           Game.world().camera().onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
     
@@ -52,20 +52,10 @@ public class Program {
         // load up previously opened project file or the one that is specified in
         // the command line arguments
         handleArgs(args);
-  
         String gameFile = Editor.preferences().getLastGameFile();
         if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
           Editor.instance().load(new File(gameFile.trim()), false);
         }
-      }
-      catch(Error e) { //the editor SHOULD crash if an Error occurs, as long as the Error !instanceof ThreadDeath
-        if(e instanceof ThreadDeath) {
-          throw e;
-        }
-        DefaultUncaughtExceptionHandler exceptionHandler = (DefaultUncaughtExceptionHandler) Thread.getDefaultUncaughtExceptionHandler();
-        exceptionHandler.setExitOnException(true);
-        throw e;
-      }
     });
   }
 

--- a/utiliti/src/de/gurkenlabs/utiliti/handlers/DebugCrasher.java
+++ b/utiliti/src/de/gurkenlabs/utiliti/handlers/DebugCrasher.java
@@ -1,0 +1,14 @@
+package de.gurkenlabs.utiliti.handlers;
+
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import de.gurkenlabs.utiliti.Program;
+
+public class DebugCrasher extends KeyAdapter {
+
+  public void keyPressed(KeyEvent e) {
+    if(e.getKeyCode() == 67 && e.isControlDown() && e.isShiftDown() && e.isAltDown()) { //Press CTRL + SHIFT + ALT + C to generate debug crash report
+      Program.debugCrash = true;
+    }
+  }
+}


### PR DESCRIPTION
* Fixes #387 
* The default exception handler will now crash when it encounters an `Error`, even if `exitOnException` is `false`.
* The default exception handler can now generate thread dumps (this is off by default)
* You can now trigger an manual debug crash in utiliti by pressing `CTRL` + `SHIFT` + `ALT` + `c`

Example of debug crash with thread dump:

https://pastebin.com/aWYdvSZC