### PR TITLE
fixing endless recursion for ResourcesContainer::getAsync(String)

### DIFF
--- a/src/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
+++ b/src/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
@@ -299,7 +299,7 @@ public abstract class ResourcesContainer<T> {
    * @return A {@code Future} object that can be used to retrieve the resource once it is finished loading
    */
   public Future<T> getAsync(String name) {
-    return this.getAsync(this.getIdentifier(name));
+    return this.getAsync(Resources.getLocation(this.getIdentifier(name)));
   }
 
   /**


### PR DESCRIPTION
As `ResourcesContainer::getIdentifier(String)` returns a `String`, calling `getAsync(String)` inside of `getAsync(String)` would cause an endless recursion.