### PR TITLE
Add more information to crash report.

### DIFF
--- a/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
+++ b/src/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
@@ -1,16 +1,21 @@
 package de.gurkenlabs.litiengine;
 
+import java.awt.DisplayMode;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.time.Duration;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import de.gurkenlabs.litiengine.configuration.ClientConfiguration;
+import static de.gurkenlabs.litiengine.util.io.FileUtilities.humanReadableByteCount;
 
 /**
  * Handles the uncaught exceptions that might occur while running a game or application with the LITIENGINE.
@@ -64,6 +69,7 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
       stream.print(new Date() + " ");
       stream.println(t.getName() + " threw an exception:");
       e.printStackTrace(stream);
+      stream.println("\n" + getSystemInfo());
       if(dumpsThreads()) {
         stream.println();
         stream.println(dump());
@@ -138,6 +144,38 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
         text.append("\n");
       }
       text.append("\n\n");
+    }
+    return text.toString();
+  }
+  
+  protected static String getSystemInfo() {
+    StringBuilder text = new StringBuilder();
+    text.append("====Runtime Information====\n");
+    text.append("Operating System: " + System.getProperty("os.name") + "\n"); 
+    text.append("\tArchitecture: " + System.getProperty("os.arch") + "\n");
+    text.append("\tVersion: " + System.getProperty("os.version") + "\n");
+    text.append("Memory:\n");
+    long heapSize = Runtime.getRuntime().totalMemory();
+    long maxHeapSize = Runtime.getRuntime().maxMemory();
+    long freeHeapSize = Runtime.getRuntime().freeMemory();
+    text.append("\tMax heap size: " + humanReadableByteCount(maxHeapSize) + "\n");
+    text.append("\tCurrent heap size: " + humanReadableByteCount(heapSize) + "\n");
+    text.append("\tHeap used: " + humanReadableByteCount(heapSize - freeHeapSize) + "\n");
+    text.append("\tFree heap: " + humanReadableByteCount(freeHeapSize) + "\n");
+    text.append("Java Version: " + System.getProperty("java.runtime.name") + " " + System.getProperty("java.runtime.version")+ " \n");
+    text.append("\tVendor: " + System.getProperty("java.vm.vendor") + "\n");
+    text.append("Uptime: " + Duration.ofMillis(ManagementFactory.getRuntimeMXBean().getUptime()) + "\n");
+    GraphicsEnvironment g = GraphicsEnvironment.getLocalGraphicsEnvironment();
+    GraphicsDevice[] screens = g.getScreenDevices();
+    text.append("Screens: " + screens.length + "\n");
+    for(int i = 0; i < screens.length;) {
+      GraphicsDevice screen = screens[i];
+      DisplayMode displayMode = screen.getDisplayMode();
+      text.append("\tScreen " + ++i +": "+ displayMode.getWidth() + "x" + displayMode.getHeight());
+      if(displayMode.getRefreshRate() != DisplayMode.REFRESH_RATE_UNKNOWN) {
+        text.append("@" + displayMode.getRefreshRate() + "hz");
+      }
+      text.append("\n");
     }
     return text.toString();
   }

--- a/src/de/gurkenlabs/litiengine/util/io/FileUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/io/FileUtilities.java
@@ -200,4 +200,12 @@ public final class FileUtilities {
 
     return false;
   }
+  
+  public static String humanReadableByteCount(long bytes) {
+    int unit = 1024;
+    if (bytes < unit) return bytes + " bytes";
+    int exp = (int) (Math.log(bytes) / Math.log(unit));
+    String pre = new String[] {"kibi", "mebi", "gibi", "tebi", "pebi", "exbi"}[exp-1];
+    return String.format("%.1f %sbytes", bytes / Math.pow(unit, exp), pre);
+  }
 }

--- a/src/de/gurkenlabs/litiengine/util/io/FileUtilities.java
+++ b/src/de/gurkenlabs/litiengine/util/io/FileUtilities.java
@@ -202,10 +202,15 @@ public final class FileUtilities {
   }
   
   public static String humanReadableByteCount(long bytes) {
-    int unit = 1024;
+    return humanReadableByteCount(bytes, false);
+  }
+  
+  public static String humanReadableByteCount(long bytes, boolean decimal) {
+    int unit = decimal ? 1000 : 1024;
     if (bytes < unit) return bytes + " bytes";
     int exp = (int) (Math.log(bytes) / Math.log(unit));
-    String pre = new String[] {"kibi", "mebi", "gibi", "tebi", "pebi", "exbi"}[exp-1];
-    return String.format("%.1f %sbytes", bytes / Math.pow(unit, exp), pre);
+    String pre = new String[] {"K", "M", "G", "T", "P", "E"}[exp-1];
+    pre = decimal ? pre : pre + "i";
+    return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
   }
 }

--- a/tests/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
+++ b/tests/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
@@ -119,4 +119,28 @@ public class FileUtilitiesTests {
     assertEquals("", extension4);
     assertEquals("", extension5);
   }
+  
+  @Test
+  public void testHumanReadableByteCount() {
+    long zero = 0;
+    long lessThanKibibyte = 1023;
+    long kibibyte = 1024;
+    long moreThanKibibyte = 1025;
+    long mebibyte = 1048576;
+    long gibibyte = 1073741824;
+    long tebibyte = 1099511627776l;
+    long exbibyte = 1152921504606846976l;
+    long max = Long.MAX_VALUE;
+    
+    assertEquals("0 bytes", FileUtilities.humanReadableByteCount(zero));
+    assertEquals("1023 bytes", FileUtilities.humanReadableByteCount(lessThanKibibyte));
+    assertEquals("1.0 kibibytes", FileUtilities.humanReadableByteCount(kibibyte));
+    assertEquals("1.0 kibibytes", FileUtilities.humanReadableByteCount(moreThanKibibyte));
+    assertEquals("1.5 kibibytes", FileUtilities.humanReadableByteCount(kibibyte + kibibyte / 2));
+    assertEquals("1.0 mebibytes", FileUtilities.humanReadableByteCount(mebibyte));
+    assertEquals("1.0 gibibytes", FileUtilities.humanReadableByteCount(gibibyte));
+    assertEquals("1.0 tebibytes", FileUtilities.humanReadableByteCount(tebibyte));
+    assertEquals("1.0 exbibytes", FileUtilities.humanReadableByteCount(exbibyte));
+    assertEquals("8.0 exbibytes", FileUtilities.humanReadableByteCount(max));
+  }
 }

--- a/tests/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
+++ b/tests/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
@@ -123,24 +123,59 @@ public class FileUtilitiesTests {
   @Test
   public void testHumanReadableByteCount() {
     long zero = 0;
-    long lessThanKibibyte = 1023;
-    long kibibyte = 1024;
-    long moreThanKibibyte = 1025;
-    long mebibyte = 1048576;
-    long gibibyte = 1073741824;
-    long tebibyte = 1099511627776l;
-    long exbibyte = 1152921504606846976l;
     long max = Long.MAX_VALUE;
+    {
+      long lessThanKibibyte = 1023;
+      long kibibyte = 1024;
+      long moreThanKibibyte = 1025;
+      long mebibyte = 1048576;
+      long gibibyte = 1073741824;
+      long tebibyte = 1099511627776l;
+      long pebibyte = 1125899906842624l;
+      long exbibyte = 1152921504606846976l;
+      
+      assertEquals("0 bytes", FileUtilities.humanReadableByteCount(zero));
+      assertEquals("1023 bytes", FileUtilities.humanReadableByteCount(lessThanKibibyte));
+      assertEquals("1.0 KiB", FileUtilities.humanReadableByteCount(kibibyte));
+      assertEquals("1.0 KiB", FileUtilities.humanReadableByteCount(moreThanKibibyte));
+      assertEquals("1.5 KiB", FileUtilities.humanReadableByteCount(kibibyte + kibibyte / 2));
+      assertEquals("1.0 MiB", FileUtilities.humanReadableByteCount(mebibyte));
+      assertEquals("1.0 GiB", FileUtilities.humanReadableByteCount(gibibyte));
+      assertEquals("1.0 TiB", FileUtilities.humanReadableByteCount(tebibyte));
+      assertEquals("1.0 PiB", FileUtilities.humanReadableByteCount(pebibyte));
+      assertEquals("1.5 PiB", FileUtilities.humanReadableByteCount(pebibyte + pebibyte / 2));
+      assertEquals("1.0 EiB", FileUtilities.humanReadableByteCount(exbibyte));
+      assertEquals("8.0 EiB", FileUtilities.humanReadableByteCount(max));
+      
+      assertEquals("1.2 EB", FileUtilities.humanReadableByteCount(exbibyte, true));
+      
+    }
     
-    assertEquals("0 bytes", FileUtilities.humanReadableByteCount(zero));
-    assertEquals("1023 bytes", FileUtilities.humanReadableByteCount(lessThanKibibyte));
-    assertEquals("1.0 kibibytes", FileUtilities.humanReadableByteCount(kibibyte));
-    assertEquals("1.0 kibibytes", FileUtilities.humanReadableByteCount(moreThanKibibyte));
-    assertEquals("1.5 kibibytes", FileUtilities.humanReadableByteCount(kibibyte + kibibyte / 2));
-    assertEquals("1.0 mebibytes", FileUtilities.humanReadableByteCount(mebibyte));
-    assertEquals("1.0 gibibytes", FileUtilities.humanReadableByteCount(gibibyte));
-    assertEquals("1.0 tebibytes", FileUtilities.humanReadableByteCount(tebibyte));
-    assertEquals("1.0 exbibytes", FileUtilities.humanReadableByteCount(exbibyte));
-    assertEquals("8.0 exbibytes", FileUtilities.humanReadableByteCount(max));
+    {
+      long lessThanKilobyte = 999;
+      long kilobyte = 1000;
+      long moreThanOneKilobyte = 1001;
+      long megabyte = 1000000;
+      long gigabyte = 1000000000;
+      long terabyte = 1000000000000l;
+      long petabyte = 1000000000000000l;
+      long exabyte =  1000000000000000000l;
+      
+      assertEquals("0 bytes", FileUtilities.humanReadableByteCount(zero, true));
+      assertEquals("999 bytes", FileUtilities.humanReadableByteCount(lessThanKilobyte, true));
+      assertEquals("1.0 KB", FileUtilities.humanReadableByteCount(moreThanOneKilobyte, true));
+      assertEquals("1.0 KB", FileUtilities.humanReadableByteCount(kilobyte, true));
+      assertEquals("1.5 KB", FileUtilities.humanReadableByteCount(kilobyte + kilobyte / 2, true));
+      assertEquals("1.0 MB", FileUtilities.humanReadableByteCount(megabyte, true));
+      assertEquals("1.0 GB", FileUtilities.humanReadableByteCount(gigabyte, true));
+      assertEquals("1.0 TB", FileUtilities.humanReadableByteCount(terabyte, true));
+      assertEquals("1.0 PB", FileUtilities.humanReadableByteCount(petabyte, true));
+      assertEquals("1.5 PB", FileUtilities.humanReadableByteCount(petabyte + petabyte / 2, true));
+      assertEquals("1.0 EB", FileUtilities.humanReadableByteCount(exabyte, true));
+      assertEquals("9.2 EB", FileUtilities.humanReadableByteCount(max, true));
+      
+      assertEquals("888.2 PiB", FileUtilities.humanReadableByteCount(exabyte, false));
+      
+    }
   }
 }


### PR DESCRIPTION
Adds more info to the crash report, including:

* Operating System
* System Architecture
* Memory (max heap, current heap, heap used, free heap)
* Java version
* Program uptime
* Amount of Screens
* Resolution and FPS of connected screens

Here is an example crash report: https://pastebin.com/LSTgKr00

Note: I'd like to add the LitiEngine version too but that doesn't seem to be stored anywhere.