### PR TITLE
Fix implementation project name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -102,6 +102,7 @@ include(
     "utiliti",
     "shared"
 )
+project(":core").name = "litiengine"
 
 gradle.projectsLoaded {
     rootProject.allprojects {

--- a/utiliti/build.gradle.kts
+++ b/utiliti/build.gradle.kts
@@ -34,7 +34,7 @@ application {
 }
 
 dependencies {
-    implementation(project(":core"))
+    implementation(project(":litiengine"))
     implementation(libs.darklaf.core)
     testImplementation(project(":shared"))
 }


### PR DESCRIPTION
Dependents should now be able to use `implementation 'de.gurkenlabs:litiengine:VERSION'` once again, instead of `implementation 'de.gurkenlabs:core:VERSION`.

I don't have a project to test these changes on, please test before merging.