### PR TITLE
Use composite name litiengine-<project name> for sub-projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,7 +81,7 @@ allprojects {
                     attributes["Specification-Version"] = project.version
                     attributes["Specification-Title"] = "LITIENGINE"
                     attributes["Implementation-Vendor"] = "Gurkenlabs"
-                    attributes["Implementation-Vendor-Id"] = "de.gurkenlabs"
+                    attributes["Implementation-Vendor-Id"] = project.group
                 }
 
                 CrLfSpec(LineEndings.LF).run {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     // This needs to be api to make the annotations on the class visible to the compiler.
     api(libs.xml.api)
     runtimeOnly(libs.bundles.xml.runtime)
-    testImplementation(project(":shared"))
+    testImplementation(projects.litiengineShared)
 }
 
 natives {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 enableFeaturePreview("VERSION_CATALOGS")
 rootProject.name = "litiengine"
 
@@ -102,6 +103,13 @@ include(
     "utiliti",
     "shared"
 )
+
+for (p in rootProject.children) {
+    if (p.children.isEmpty()) {
+        // Rename leaf projects only
+        p.name = "${rootProject.name}-${p.name}"
+    }
+}
 
 gradle.projectsLoaded {
     rootProject.allprojects {

--- a/utiliti/build.gradle.kts
+++ b/utiliti/build.gradle.kts
@@ -34,9 +34,9 @@ application {
 }
 
 dependencies {
-    implementation(project(":core"))
+    implementation(projects.litiengineCore)
     implementation(libs.darklaf.core)
-    testImplementation(project(":shared"))
+    testImplementation(projects.litiengineShared)
 }
 
 tasks {


### PR DESCRIPTION
This is a suggestion for a solution for the problem discussed on discord. To avoid confusion about dependency names (and to not tie the `de.gurkenlabs` group to the `litiengine` project all sub-projects are renamed to `litiengine-<project-name>`. Then the dependency notation one would have to use would be `de.gurkenlabs:litiengine-core` (for the `core` project). This would also allow to publish additional optional apis as separate projects without causing confusion.
Any thoughts about this?