### PR TITLE
Fix #444 - Don't attempt to publish nightly snapshots from forks

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   gradle:
-    if: github.repository_owner == 'gurklenlabs'
+    if: github.repository_owner == 'gurkenlabs'
     name: Publish nightly snapshot
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,6 +1,7 @@
 name: Build nightly SNAPSHOT
 
 on:
+  workflow_dispatch:
   schedule:
     # Midnight every day
     - cron: "0 0 * * *"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   gradle:
-    if: github.repository_owner = 'gurklenlabs'
+    if: github.repository_owner == 'gurklenlabs'
     name: Publish nightly snapshot
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Also now allows the nightly snapshot to be built manually.

![image](https://user-images.githubusercontent.com/7155747/148727254-87ed9664-2892-4472-a193-7d2c9d44ae44.png)
