### PR TITLE
Prevent setX and setY functions from moving child components twice.

### DIFF
--- a/core/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
+++ b/core/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
@@ -1184,12 +1184,7 @@ public abstract class GuiComponent
    *          the new x coordinate
    */
   public void setX(final double x) {
-    final double delta = x - getX();
     setLocation(x, getY());
-
-    for (final GuiComponent component : getComponents()) {
-      component.setX(component.getX() + delta);
-    }
   }
 
   /**
@@ -1199,11 +1194,7 @@ public abstract class GuiComponent
    *          the new y coordinate
    */
   public void setY(final double y) {
-    final double delta = y - getY();
     setLocation(getX(), y);
-    for (final GuiComponent component : getComponents()) {
-      component.setY(component.getY() + delta);
-    }
   }
 
   /**


### PR DESCRIPTION
These functions in GuiComponent currently move child components twice. This happens because they both call setLocation, which moves child components, and then they also move child components themselves. This commit fixes this.