### PR TITLE
Resolve #471.

### DIFF
--- a/core/src/main/java/de/gurkenlabs/litiengine/entities/CollisionEntity.java
+++ b/core/src/main/java/de/gurkenlabs/litiengine/entities/CollisionEntity.java
@@ -253,7 +253,7 @@ public abstract class CollisionEntity extends Entity implements ICollisionEntity
     if (type == Collision.ANY) {
       log.log(
           Level.WARNING,
-          "CollistionType.ALL is not allowed to be assigned to an entity. It may only be used for filtering in the PhysicsEngine.");
+          "Collision.ANY is not allowed to be assigned to an entity. It may only be used for filtering in the PhysicsEngine.");
       return;
     }
 

--- a/core/src/main/java/de/gurkenlabs/litiengine/util/Imaging.java
+++ b/core/src/main/java/de/gurkenlabs/litiengine/util/Imaging.java
@@ -25,8 +25,12 @@ import java.awt.image.RGBImageFilter;
 import java.awt.image.WritableRaster;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.UnaryOperator;
 
+/**
+ * The type Imaging.
+ */
 public final class Imaging {
   public static final int CROP_ALIGN_CENTER = 0;
   public static final int CROP_ALIGN_LEFT = 1;
@@ -47,9 +51,6 @@ public final class Imaging {
    * Adds a shadow effect by executing the following steps: 1. Transform visible pixels to a semi-transparent black 2.
    * Flip the image vertically 3. Scale it down 4. Render original image and shadow on a buffered image
    *
-   * <p>
-   * TODO: Add support for different shadow types. Add an ellipse shadow, etc..
-   *
    * @param image
    *          the image
    * @param xOffset
@@ -61,7 +62,7 @@ public final class Imaging {
   public static BufferedImage addShadow(
       final BufferedImage image, final int xOffset, final int yOffset) {
     if (image == null) {
-      return image;
+      return null;
     }
 
     final int width = image.getWidth();
@@ -118,7 +119,7 @@ public final class Imaging {
           public final int markerRGB = color.getRGB() | 0xFF000000;
 
           @Override
-          public final int filterRGB(final int x, final int y, final int rgb) {
+          public int filterRGB(final int x, final int y, final int rgb) {
             if ((rgb | 0xFF000000) == this.markerRGB) {
               // Mark the alpha bits as zero - transparent
               return 0x00FFFFFF & rgb;
@@ -133,6 +134,17 @@ public final class Imaging {
     return toBufferedImage(Toolkit.getDefaultToolkit().createImage(ip));
   }
 
+  /**
+   * Draw a stroke around an image in the given color.
+   *
+   * @param image
+   *          the input image
+   * @param strokeColor
+   *          the stroke color
+   * @param borderOnly
+   *          decide whether only the border of the given image will be drawn
+   * @return the buffered image with a border drawn around it
+   */
   public static BufferedImage borderAlpha(
       final BufferedImage image, final Color strokeColor, boolean borderOnly) {
     final BufferedImage bimage =
@@ -170,6 +182,13 @@ public final class Imaging {
     return bimage;
   }
 
+  /**
+   * Checks whether a given BufferedImage only has transparent pixels.
+   *
+   * @param image
+   *          the image
+   * @return true if there are no coloured pixels in the image.
+   */
   public static boolean isEmpty(final BufferedImage image) {
     for (int y = 0; y < image.getHeight(); y++) {
       for (int x = 0; x < image.getWidth(); x++) {
@@ -183,6 +202,15 @@ public final class Imaging {
     return true;
   }
 
+  /**
+   * Checks whether two BufferedImages are equal.
+   *
+   * @param image1
+   *          the image 1
+   * @param image2
+   *          the image 2
+   * @return true if the images are equal
+   */
   public static boolean areEqual(final BufferedImage image1, final BufferedImage image2) {
     if (image1.getWidth() != image2.getWidth() || image1.getHeight() != image2.getHeight()) {
       return false;
@@ -211,7 +239,6 @@ public final class Imaging {
    *          <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_LEFT CROP_ALIGN_LEFT}
    *          <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_RIGHT CROP_ALIGN_RIGHT}
    *          </ul>
-   *
    * @param cropVerticlaAlignment
    *          use the following consts: <br>
    *          <ul>
@@ -220,7 +247,6 @@ public final class Imaging {
    *          <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_TOPCENTER CROP_VALIGN_TOPCENTER}
    *          <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_BOTTOM CROP_VALIGN_BOTTOM}
    *          </ul>
-   *
    * @param width
    *          The width to crop.
    * @param height
@@ -236,36 +262,18 @@ public final class Imaging {
     if (width > image.getWidth() || height > image.getHeight()) {
       return image;
     }
-
     int x;
     switch (cropAlignment) {
-      case CROP_ALIGN_CENTER:
-        x = image.getWidth() / 2 - width / 2;
-        break;
-      case CROP_ALIGN_RIGHT:
-        x = image.getWidth() - width;
-        break;
-      case CROP_ALIGN_LEFT:
-      default:
-        x = 0;
-        break;
+      case CROP_ALIGN_CENTER -> x = image.getWidth() / 2 - width / 2;
+      case CROP_ALIGN_RIGHT -> x = image.getWidth() - width;
+      default -> x = 0;
     }
-
     int y;
     switch (cropVerticlaAlignment) {
-      case CROP_VALIGN_CENTER:
-        y = image.getHeight() / 2 - height / 2;
-        break;
-      case CROP_VALIGN_BOTTOM:
-        y = image.getHeight() - height;
-        break;
-      case CROP_VALIGN_TOPCENTER:
-        y = image.getHeight() / 2 - height;
-        break;
-      case CROP_VALIGN_TOP:
-      default:
-        y = 0;
-        break;
+      case CROP_VALIGN_CENTER -> y = image.getHeight() / 2 - height / 2;
+      case CROP_VALIGN_BOTTOM -> y = image.getHeight() - height;
+      case CROP_VALIGN_TOPCENTER -> y = image.getHeight() / 2 - height;
+      default -> y = 0;
     }
 
     return image.getSubimage(x, y, width, height);
@@ -303,10 +311,26 @@ public final class Imaging {
     return bimage;
   }
 
+  /**
+   * Flip the individual sprites in a {@link Spritesheet} horizontally and return an image from which a new
+   * {@link Spritesheet} can be created.
+   *
+   * @param sprite
+   *          the spritesheet
+   * @return a {@link BufferedImage} containing the horizontally flipped sprites
+   */
   public static BufferedImage flipSpritesHorizontally(final Spritesheet sprite) {
     return flipSprites(sprite, Imaging::horizontalFlip);
   }
 
+  /**
+   * Flip the individual sprites in a {@link Spritesheet} vertically and return an image from which a new
+   * {@link Spritesheet} can be created.
+   *
+   * @param sprite
+   *          the spritesheet
+   * @return a {@link BufferedImage} containing the vertically flipped sprites
+   */
   public static BufferedImage flipSpritesVertically(final Spritesheet sprite) {
     return flipSprites(sprite, Imaging::verticalFlip);
   }
@@ -316,7 +340,7 @@ public final class Imaging {
    *
    * @param image
    *          The image to be copied.
-   * @return A copy of the specified image.
+   * @return A {@link BufferedImage} that is a copy of the input image.
    */
   public static BufferedImage copy(BufferedImage image) {
     ColorModel cm = image.getColorModel();
@@ -325,6 +349,15 @@ public final class Imaging {
     return new BufferedImage(cm, raster, isAlphaPremultiplied, null);
   }
 
+  /**
+   * Gets an empty {@link BufferedImage} with the given size.
+   *
+   * @param width
+   *          the width
+   * @param height
+   *          the height
+   * @return an empty {@link BufferedImage} with the given size
+   */
   public static BufferedImage getCompatibleImage(final int width, final int height) {
     if (width == 0 || height == 0) {
       return null;
@@ -373,7 +406,7 @@ public final class Imaging {
    *
    * @param img
    *          The image to be flipped.
-   * @return The flipped image.
+   * @return The horizontally flipped image.
    */
   public static BufferedImage horizontalFlip(final BufferedImage img) {
     final int w = img.getWidth();
@@ -383,7 +416,7 @@ public final class Imaging {
     }
 
     final BufferedImage dimg = getCompatibleImage(w, h);
-    final Graphics2D g = dimg.createGraphics();
+    final Graphics2D g = Objects.requireNonNull(dimg).createGraphics();
     g.drawImage(img, 0, 0, w, h, w, 0, 0, h, null);
     g.dispose();
     return dimg;
@@ -394,7 +427,7 @@ public final class Imaging {
    *
    * @param img
    *          The image to be flipped.
-   * @return The flipped image.
+   * @return The vertically flipped image.
    */
   public static BufferedImage verticalFlip(final BufferedImage img) {
     final int w = img.getWidth();
@@ -404,8 +437,8 @@ public final class Imaging {
     }
 
     final BufferedImage dimg = getCompatibleImage(w, h);
-    final Graphics2D g = dimg.createGraphics();
-    g.drawImage(img, 0, 0 + h, w, -h, null);
+    final Graphics2D g = Objects.requireNonNull(dimg).createGraphics();
+    g.drawImage(img, 0, h, w, -h, null);
     g.dispose();
     return dimg;
   }
@@ -435,10 +468,28 @@ public final class Imaging {
     return recoloredImage;
   }
 
+  /**
+   * Rotate a given {@link BufferedImage} by a given {@link Rotation}.
+   *
+   * @param bufferedImage
+   *          the input image
+   * @param rotation
+   *          the amount of {@link Rotation}
+   * @return the rotated {@link BufferedImage}
+   */
   public static BufferedImage rotate(final BufferedImage bufferedImage, final Rotation rotation) {
     return rotate(bufferedImage, rotation.getRadians());
   }
 
+  /**
+   * Rotate a {@link BufferedImage} by a given rotation.
+   *
+   * @param bufferedImage
+   *          the input image
+   * @param radians
+   *          the amount of rotation in radians.
+   * @return the rotated {@link BufferedImage}
+   */
   public static BufferedImage rotate(final BufferedImage bufferedImage, final double radians) {
     double sin = Math.abs(Math.sin(radians));
     double cos = Math.abs(Math.cos(radians));
@@ -446,17 +497,17 @@ public final class Imaging {
     int w = bufferedImage.getWidth();
     int h = bufferedImage.getHeight();
 
-    int neww = (int) Math.floor(w * cos + h * sin);
-    int newh = (int) Math.floor(h * cos + w * sin);
+    int newWidth = (int) Math.floor(w * cos + h * sin);
+    int newHeight = (int) Math.floor(h * cos + w * sin);
 
-    BufferedImage bimg = getCompatibleImage(neww, newh);
+    BufferedImage bimg = getCompatibleImage(newWidth, newHeight);
     if (bimg == null) {
       return bufferedImage;
     }
 
     Graphics2D g = bimg.createGraphics();
 
-    g.translate((neww - w) / 2.0, (newh - h) / 2.0);
+    g.translate((newWidth - w) / 2.0, (newHeight - h) / 2.0);
     g.rotate(radians, w / 2.0, h / 2.0);
     g.drawRenderedImage(toBufferedImage(bufferedImage), null);
     g.dispose();
@@ -464,56 +515,204 @@ public final class Imaging {
     return bimg;
   }
 
+  /**
+   * Scale buffered image so that the longer edge of the image will be set to a given maximum.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param max
+   *          the maximum length of the longer image edge
+   * @return the scaled {@link BufferedImage}.
+   */
   public static BufferedImage scale(final BufferedImage image, final int max) {
-    Dimension2D newDimension =
-        GeometricUtilities.scaleWithRatio(image.getWidth(), image.getHeight(), max);
-    return scale(image, (int) newDimension.getWidth(), (int) newDimension.getHeight());
-  }
-
-  public static BufferedImage scale(final BufferedImage image, final double factor) {
-    return scale(image, factor, false);
-  }
-
-  public static BufferedImage scale(
-      final BufferedImage image, final double factor, boolean keepRatio) {
-    if (image == null) {
-      return null;
-    }
-    final double width = image.getWidth();
-    final double height = image.getHeight();
-
-    return scale(
-        image,
-        (int) Math.max(1, Math.round(width * factor)),
-        (int) Math.max(1, Math.round(height * factor)),
-        keepRatio);
+    Dimension2D newDimension = GeometricUtilities.scaleWithRatio(image.getWidth(), image.getHeight(), max);
+    return scale(image, (int) Objects.requireNonNull(newDimension).getWidth(), (int) Objects.requireNonNull(newDimension).getHeight());
   }
 
   /**
-   * The specified image is scaled to a new dimension with the specified width and height. This method doesn't use anti
-   * aliasing for this process to keep the indy look.
+   * Scale buffered image by multiplying its width and height with a given factor. By default,
+   * {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If you want smooth interpolation, use one of the
+   * method overloads with a custom interpolation parameter.
    *
    * @param image
-   *          the image
+   *          the input {@link BufferedImage} to be scaled
+   * @param factor
+   *          the factor by which the image width and height will be multiplied
+   * @return the scaled {@link BufferedImage}.
+   */
+  public static BufferedImage scale(final BufferedImage image, final double factor) {
+    return scale(image, factor, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
+  }
+
+  /**
+   * Scale buffered image by multiplying its width and height with a given factor. This default overload will not generate
+   * white space around the scaled image to match the full target dimensions.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param factor
+   *          the factor by which the image width and height will be multiplied
+   * @param interpolation
+   *          the interpolation mode used for scaling. Choose one of the following:
+   *          <ul>
+   *          <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
+   *          <li>{@link AffineTransformOp#TYPE_BILINEAR}
+   *          <li>{@link AffineTransformOp#TYPE_BICUBIC}
+   *          </ul>
+   * @return the scaled {@link BufferedImage}.
+   */
+  public static BufferedImage scale(final BufferedImage image, final double factor, final int interpolation) {
+    return image == null
+        ? null
+        : scale(image, (int) Math.ceil(image.getWidth() * factor), (int) Math.ceil(image.getHeight() * factor), interpolation);
+  }
+
+  /**
+   * Scale buffered image. The original image ratio will be kept. By default,
+   * {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If you want smooth interpolation, use one of the
+   * method overloads with a custom interpolation parameter. This default overload will not generate white space around
+   * the scaled image to match the full target dimensions.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
    * @param width
-   *          the width
+   *          the width of the scaled image in pixels
    * @param height
-   *          the height
-   * @return the buffered image
+   *          the height of the scaled image in pixels
+   * @return the scaled {@link BufferedImage}.
    */
   public static BufferedImage scale(final BufferedImage image, final int width, final int height) {
-    return scale(image, width, height, false);
+    return scale(image, width, height, AffineTransformOp.TYPE_NEAREST_NEIGHBOR, false, false);
   }
 
+
+  /**
+   * Scale buffered image. By default, {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If you want
+   * smooth interpolation, use one of the method overloads with a custom interpolation parameter. This default overload
+   * will not generate white space around the scaled image to match the full target dimensions.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param width
+   *          the width of the scaled image in pixels
+   * @param height
+   *          the height of the scaled image in pixels
+   * @param keepRatio
+   *          determines whether the original image ratio should be kept while scaling.
+   * @return the scaled {@link BufferedImage}.
+   */
   public static BufferedImage scale(
       final BufferedImage image, final int width, final int height, final boolean keepRatio) {
-    return scale(image, width, height, keepRatio, true);
+    return scale(image, width, height, AffineTransformOp.TYPE_NEAREST_NEIGHBOR, keepRatio, false);
   }
 
+  /**
+   * Scale buffered image. By default, {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If you want
+   * smooth interpolation, use one of the method overloads with a custom interpolation parameter.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param width
+   *          the width of the scaled image in pixels
+   * @param height
+   *          the height of the scaled image in pixels
+   * @param keepRatio
+   *          determines whether the original image ratio should be kept while scaling.
+   * @param fill
+   *          determines whether the target image should contain the transparent space around the scaled image to fill the
+   *          full target dimensions.
+   * @return the scaled {@link BufferedImage}.
+   */
+  public static BufferedImage scale(
+      final BufferedImage image, final int width, final int height, final boolean keepRatio, final boolean fill) {
+    return scale(image, width, height, AffineTransformOp.TYPE_NEAREST_NEIGHBOR, keepRatio, fill);
+  }
+
+  /**
+   * Scale buffered image. This default overload will not generate white space around the scaled image to match the full
+   * target dimensions.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param width
+   *          the width of the scaled image in pixels
+   * @param height
+   *          the height of the scaled image in pixels
+   * @param interpolation
+   *          the interpolation mode used for scaling. Choose one of the following:
+   *          <ul>
+   *          <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
+   *          <li>{@link AffineTransformOp#TYPE_BILINEAR}
+   *          <li>{@link AffineTransformOp#TYPE_BICUBIC}
+   *          </ul>
+   * @param keepRatio
+   *          determines whether the original image ratio should be kept while scaling.
+   * @return the scaled {@link BufferedImage}.
+   */
   public static BufferedImage scale(
       final BufferedImage image,
       final int width,
       final int height,
+      final int interpolation,
+      final boolean keepRatio) {
+    return scale(image, width, height, interpolation, keepRatio, false);
+  }
+
+  /**
+   * Scale buffered image. This default overload will keep the original image ratio and not generate white space around
+   * the scaled image to match the full target dimensions.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param width
+   *          the width of the scaled image in pixels
+   * @param height
+   *          the height of the scaled image in pixels
+   * @param interpolation
+   *          the interpolation mode used for scaling. Choose one of the following:
+   *          <ul>
+   *          <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
+   *          <li>{@link AffineTransformOp#TYPE_BILINEAR}
+   *          <li>{@link AffineTransformOp#TYPE_BICUBIC}
+   *          </ul>
+   * @return the scaled {@link BufferedImage}.
+   */
+  public static BufferedImage scale(
+      final BufferedImage image,
+      final int width,
+      final int height,
+      final int interpolation) {
+    return scale(image, width, height, interpolation, true, false);
+  }
+
+  /**
+   * Scale buffered image.
+   *
+   * @param image
+   *          the input {@link BufferedImage} to be scaled
+   * @param width
+   *          the width of the scaled image in pixels
+   * @param height
+   *          the height of the scaled image in pixels
+   * @param interpolation
+   *          the interpolation mode used for scaling. Choose one of the following:
+   *          <ul>
+   *          <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
+   *          <li>{@link AffineTransformOp#TYPE_BILINEAR}
+   *          <li>{@link AffineTransformOp#TYPE_BICUBIC}
+   *          </ul>
+   * @param keepRatio
+   *          determines whether the original image ratio should be kept while scaling.
+   * @param fill
+   *          determines whether the target image should contain the transparent space around the scaled image to fill the
+   *          full target dimensions.
+   * @return the scaled {@link BufferedImage}.
+   */
+  public static BufferedImage scale(
+      final BufferedImage image,
+      final int width,
+      final int height,
+      final int interpolation,
       final boolean keepRatio,
       final boolean fill) {
     if (width == 0 || height == 0 || image == null) {
@@ -539,7 +738,7 @@ public final class Imaging {
     final double scaleY = newHeight / imageHeight;
     final AffineTransform scaleTransform = AffineTransform.getScaleInstance(scaleX, scaleY);
     final AffineTransformOp bilinearScaleOp =
-        new AffineTransformOp(scaleTransform, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
+        new AffineTransformOp(scaleTransform, interpolation);
     final BufferedImage scaled =
         bilinearScaleOp.filter(image, getCompatibleImage((int) newWidth, (int) newHeight));
     final BufferedImage newImg = getCompatibleImage((int) newWidth, (int) newHeight);
@@ -553,7 +752,7 @@ public final class Imaging {
 
     if (fill && (newWidth != width || newHeight != height)) {
       final BufferedImage wrapperImage = getCompatibleImage(width, height);
-      final Graphics2D g2 = (Graphics2D) wrapperImage.getGraphics();
+      final Graphics2D g2 = (Graphics2D) Objects.requireNonNull(wrapperImage).getGraphics();
       g2.drawImage(
           newImg, (int) ((width - newWidth) / 2.0), (int) ((height - newHeight) / 2.0), null);
       g2.dispose();
@@ -563,9 +762,20 @@ public final class Imaging {
     return newImg;
   }
 
-  public static BufferedImage setOpacity(final Image img, final float opacity) {
-    if (img == null)
+  /**
+   * Sets the opacity of a given image.
+   *
+   * @param img
+   *          the original {@link Image}
+   * @param alpha
+   *          the constant alpha to be multiplied with the alpha of the source. alpha must be a floating point number in
+   *          the inclusive range [0.0, 1.0].
+   * @return the {@link BufferedImage} produced by applying the given alpha on the source image
+   */
+  public static BufferedImage setAlpha(final Image img, final float alpha) {
+    if (img == null) {
       return null;
+    }
     final BufferedImage bimage = getCompatibleImage(img.getWidth(null), img.getHeight(null));
     if (bimage == null) {
       return null;
@@ -573,13 +783,20 @@ public final class Imaging {
 
     // Draw the image on to the buffered image
     final Graphics2D g2d = bimage.createGraphics();
-    g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, opacity));
+    g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
     g2d.drawImage(img, 0, 0, null);
     g2d.dispose();
 
     return bimage;
   }
 
+  /**
+   * Converts a given {@link Image} instance to a {@link BufferedImage}.
+   *
+   * @param img
+   *          the original {@link Image}
+   * @return the {@link BufferedImage} produced from the original {@link Image}
+   */
   public static BufferedImage toBufferedImage(final Image img) {
     if (img == null) {
       return null;
@@ -601,6 +818,13 @@ public final class Imaging {
     return bimage;
   }
 
+  /**
+   * Creates a compatible buffered image that contains the source image.
+   *
+   * @param image
+   *          the source image
+   * @return the compatible buffered image
+   */
   public static BufferedImage toCompatibleImage(final BufferedImage image) {
     if (image == null || image.getWidth() == 0 || image.getHeight() == 0) {
       return image;

--- a/core/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
@@ -15,6 +15,7 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.input.Input;
 import de.gurkenlabs.litiengine.test.SwingTestSuite;
 import de.gurkenlabs.litiengine.tweening.TweenType;
+import de.gurkenlabs.litiengine.util.ColorHelper;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -286,23 +287,35 @@ class GuiComponentTests {
   void testSetTweenValuesOpacity() {
     // arrange
     TestComponent component = new TestComponent(10, 15, 50, 75);
-    component.getCurrentAppearance().setBackgroundColor1(Color.RED);
-    component.getCurrentAppearance().setBackgroundColor2(Color.GREEN);
-    component.getCurrentAppearance().setForeColor(Color.BLUE);
-    component.getCurrentAppearance().setBorderColor(Color.YELLOW);
-    component.setTextShadowColor(Color.PINK);
+    Appearance appearance = component.getCurrentAppearance();
+
+    Color newBG1 = Color.RED;
+    Color newBG2 = Color.GREEN;
+    Color newFore = Color.BLUE;
+    Color newBorder = Color.YELLOW;
+    Color newTextShadow = Color.PINK;
+
+    appearance.setBackgroundColor1(newBG1);
+    appearance.setBackgroundColor2(newBG2);
+    appearance.setForeColor(newFore);
+    appearance.setBorderColor(newBorder);
+    component.setTextShadowColor(newTextShadow);
 
     // act
     component.setTweenValues(TweenType.OPACITY, new float[] {128f, 128f, 128f, 128f, 128f});
 
+    Color compBG1 = ColorHelper.getTransparentVariant(newBG1, 128);
+    Color compBG2 = ColorHelper.getTransparentVariant(newBG2, 128);
+    Color compFore = ColorHelper.getTransparentVariant(newFore, 128);
+    Color compBorder = ColorHelper.getTransparentVariant(newBorder, 128);
+    Color compTextShadow = ColorHelper.getTransparentVariant(newTextShadow, 128);
     // assert
-    Appearance appearance = component.getCurrentAppearance();
 
-    assertEquals(new Color(255, 0, 255, 128), appearance.getBackgroundColor1());
-    assertEquals(new Color(0, 255, 0, 128), appearance.getBackgroundColor2());
-    assertEquals(new Color(0, 0, 0, 128), appearance.getForeColor());
-    assertEquals(new Color(255, 255, 255, 128), appearance.getBorderColor());
-    assertEquals(new Color(255, 175, 255, 128), component.getTextShadowColor());
+    assertEquals(compBG1, appearance.getBackgroundColor1());
+    assertEquals(compBG2, appearance.getBackgroundColor2());
+    assertEquals(compFore, appearance.getForeColor());
+    assertEquals(compBorder, appearance.getBorderColor());
+    assertEquals(compTextShadow, component.getTextShadowColor());
   }
 
   @Test

--- a/core/src/test/java/de/gurkenlabs/litiengine/physics/PhysicsTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/physics/PhysicsTests.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class PhysicsTests {
+class PhysicsTests {
   @BeforeEach
   public void init() {
     Game.init(Game.COMMANDLINE_ARG_NOGUI);
@@ -28,7 +28,7 @@ public class PhysicsTests {
   }
 
   @Test
-  public void testBasicCollisionDetection() {
+  void testBasicCollisionDetection() {
     Creature ent = new Creature();
     ent.setSize(16, 16);
     ent.setCollision(true);
@@ -58,7 +58,7 @@ public class PhysicsTests {
   }
 
   @Test
-  public void testPointCollides() {
+  void testPointCollides() {
     IMobileEntity ent = mock(IMobileEntity.class);
     when(ent.getCollisionBox()).thenReturn(new Rectangle2D.Double(0, 0, 10, 10));
     when(ent.hasCollision()).thenReturn(true);
@@ -80,7 +80,7 @@ public class PhysicsTests {
   }
 
   @Test
-  public void testRaycastCollides() {
+  void testRaycastCollides() {
     IMobileEntity ent = mock(IMobileEntity.class);
     when(ent.getCollisionBox()).thenReturn(new Rectangle2D.Double(0, 0, 10, 10));
     when(ent.hasCollision()).thenReturn(true);
@@ -96,7 +96,7 @@ public class PhysicsTests {
   }
 
   @Test
-  public void testRectangleCollides() {
+  void testRectangleCollides() {
     IMobileEntity ent = mock(IMobileEntity.class);
     when(ent.getCollisionBox()).thenReturn(new Rectangle2D.Double(0, 0, 10, 10));
     when(ent.hasCollision()).thenReturn(true);

--- a/core/src/test/java/de/gurkenlabs/litiengine/util/ImagingTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/util/ImagingTests.java
@@ -112,7 +112,7 @@ class ImagingTests {
     BufferedImage scaledx2 = Imaging.scale(image, 2.0);
     BufferedImage scaledMaxDouble = Imaging.scale(image, 60);
     BufferedImage stretched = Imaging.scale(image, 30, 32, false);
-    BufferedImage stretchedRatio = Imaging.scale(image, 30, 32, true);
+    BufferedImage stretchedRatio = Imaging.scale(image, 30, 32, true, true);
 
     int[] actualPixelsx2 = ((DataBufferInt) scaledx2.getData().getDataBuffer()).getData();
     int[] actualPixelsMaxDouble =
@@ -138,8 +138,8 @@ class ImagingTests {
     int[] expectedPixels25 = ((DataBufferInt) expected25.getData().getDataBuffer()).getData();
     int[] expectedPixels50 = ((DataBufferInt) expected50.getData().getDataBuffer()).getData();
 
-    BufferedImage opacity25 = Imaging.setOpacity(image, .25f);
-    BufferedImage opacity50 = Imaging.setOpacity(image, .5f);
+    BufferedImage opacity25 = Imaging.setAlpha(image, .25f);
+    BufferedImage opacity50 = Imaging.setAlpha(image, .5f);
 
     int[] actualPixels25 = ((DataBufferInt) opacity25.getData().getDataBuffer()).getData();
     int[] actualPixels50 = ((DataBufferInt) opacity50.getData().getDataBuffer()).getData();

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/AssetPanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/AssetPanel.java
@@ -19,14 +19,13 @@ import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 
 public class AssetPanel extends JPanel {
-  private final WrapLayout layout;
 
   public AssetPanel() {
-    this.layout = new WrapLayout();
-    this.layout.setVgap(5);
-    this.layout.setHgap(5);
-    this.layout.setAlignment(LEFT);
-    this.setLayout(this.layout);
+    WrapLayout layout = new WrapLayout();
+    layout.setVgap(5);
+    layout.setHgap(5);
+    layout.setAlignment(LEFT);
+    this.setLayout(layout);
 
     this.setBorder(new EmptyBorder(5, 5, 5, 5));
   }
@@ -34,8 +33,7 @@ public class AssetPanel extends JPanel {
   public void loadSprites(List<SpritesheetResource> infos) {
     this.load(
         () -> {
-          Collections.sort(infos);
-          for (SpritesheetResource info : infos) {
+          for (SpritesheetResource info : infos.stream().sorted().toList()) {
             Icon icon;
             Spritesheet opt = Resources.spritesheets().get(info.getName());
 

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/SpritesheetImportPanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/SpritesheetImportPanel.java
@@ -24,6 +24,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.DefaultListCellRenderer;
@@ -43,24 +44,23 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableModel;
 
-@SuppressWarnings("serial")
 public class SpritesheetImportPanel extends JPanel implements IUpdateable {
   private static final int PREVIEW_SIZE = 128;
   private static final int SPINNER_WIDTH = 100;
 
   private JTextField textField;
-  private JTable tableKeyFrames;
-  private JLabel labelAnimationPreview;
-  private JList<SpriteFileWrapper> fileList;
-  private DefaultListModel<SpriteFileWrapper> fileListModel;
-  private DefaultTableModel treeModel;
+  private final JTable tableKeyFrames;
+  private final JLabel labelAnimationPreview;
+  private final JList<SpriteFileWrapper> fileList;
+  private final DefaultListModel<SpriteFileWrapper> fileListModel;
+  private final DefaultTableModel treeModel;
   private JLabel labelImage;
   private JLabel labelWidth;
   private JLabel labelHeight;
   private JSpinner spinnerWidth;
   private JSpinner spinnerHeight;
   private boolean isUpdating;
-  private transient AnimationController controller;
+  private final transient AnimationController controller;
 
   private static final Logger log = Logger.getLogger(SpritesheetImportPanel.class.getName());
 
@@ -128,6 +128,7 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
                     new SpinnerNumberModel(file.getSpriteHeight(), 1, file.getHeight(), 1));
 
                 this.updateKeyframeTable(file);
+                textField = new JTextField();
                 textField.setText(file.getName());
 
                 this.updatePreview(file);
@@ -413,7 +414,7 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
     scrollPane1.setViewportView(tableKeyFrames);
     treeModel =
         new DefaultTableModel(new Object[][] {}, new String[] {"sprite", "duration"}) {
-          Class<?>[] columnTypes = new Class<?>[] {Integer.class, Integer.class};
+          final Class<?>[] columnTypes = new Class<?>[] {Integer.class, Integer.class};
 
           @Override
           public Class<?> getColumnClass(int columnIndex) {
@@ -504,7 +505,7 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
       double factor =
           (double) PREVIEW_SIZE / Math.max(file.getSpriteWidth(), file.getSpriteHeight());
 
-      BufferedImage img = Imaging.scale(file.getImage(), factor, true);
+      BufferedImage img = Imaging.scale(file.getImage(), factor);
 
       Spritesheet sprite =
           new Spritesheet(
@@ -526,7 +527,7 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
     }
   }
 
-  private class SpriteFileWrapper {
+  private static class SpriteFileWrapper {
     private static final int MAX_WIDTH_ICON = 280;
     private static final int MAX_HEIGHT_ICON = 128;
     private final BufferedImage image;
@@ -633,16 +634,15 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
     }
 
     private void updateGridImage() {
-      BufferedImage scaled =
-          Imaging.scale(this.image, MAX_WIDTH_ICON, MAX_HEIGHT_ICON, true, false);
-      BufferedImage img = Imaging.getCompatibleImage(scaled.getWidth() + 1, scaled.getHeight() + 1);
+      BufferedImage scaled = Imaging.scale(this.image, MAX_WIDTH_ICON, MAX_HEIGHT_ICON, true);
+      BufferedImage img = Imaging.getCompatibleImage(Objects.requireNonNull(scaled).getWidth() + 1, scaled.getHeight() + 1);
       int cols = this.getWidth() / this.getSpriteWidth();
       int rows = this.getHeight() / this.getSpriteHeight();
 
       int scaledWidth = scaled.getWidth() / cols;
       int scaledHeight = scaled.getHeight() / rows;
 
-      Graphics2D g = (Graphics2D) img.getGraphics();
+      Graphics2D g = (Graphics2D) Objects.requireNonNull(img).getGraphics();
       g.drawImage(scaled, 0, 0, null);
       g.setColor(Style.COLOR_COLLISION_BORDER);
       for (int i = 1; i < cols; i++) {


### PR DESCRIPTION
Add image scaling overloads for bilinear and bicubic interpolation. 
Fix bug that prevented the utiLITI asset panel from refreshing. Prevent some exceptions in PhysicsEngine.
Improve Collision type handling in collision resolution. 
Add JavaDocs for Imaging utilities.