### PR TITLE
Fix threading issues in Game.class

### DIFF
--- a/core/src/main/java/de/gurkenlabs/litiengine/Game.java
+++ b/core/src/main/java/de/gurkenlabs/litiengine/Game.java
@@ -444,7 +444,7 @@ public final class Game {
    * @param args
    *          The arguments passed to the program's entry point.
    * @throws AWTError
-   *          if this method is called on the Swing Event Dispatcher thread
+   *           if this method is called on the Swing Event Dispatcher thread
    */
   public static void init(Runnable preInitialization, Runnable postInitialization, String... args) {
     try {

--- a/core/src/main/java/de/gurkenlabs/litiengine/Game.java
+++ b/core/src/main/java/de/gurkenlabs/litiengine/Game.java
@@ -443,6 +443,8 @@ public final class Game {
    *          Event Dispatch Thread.
    * @param args
    *          The arguments passed to the program's entry point.
+   * @throws AWTError
+   *          if this method is called on the Swing Event Dispatcher thread
    */
   public static void init(Runnable preInitialization, Runnable postInitialization, String... args) {
     try {

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
@@ -2,9 +2,14 @@ package de.gurkenlabs.litiengine;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.awt.AWTError;
 import java.io.File;
+
+import javax.swing.SwingUtilities;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -69,5 +74,19 @@ public class GameTest {
 
     Game.start();
     assertTrue(started.wasCalled);
+  }
+
+  @Test
+  public void testSwingThreadAssertions() {
+    assertThrows(AWTError.class, () -> Game.init(false, Game.COMMANDLINE_ARG_NOGUI));
+    Game.terminate();
+    Game.init(
+        () -> {
+          assertTrue(SwingUtilities.isEventDispatchThread());
+        },
+        () -> {
+          assertTrue(SwingUtilities.isEventDispatchThread());
+        },
+        Game.COMMANDLINE_ARG_NOGUI);
   }
 }

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
@@ -11,53 +11,65 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
-import javax.swing.SwingUtilities;
 
 public class Program {
 
   public static void main(String[] args) {
-    SwingUtilities.invokeLater(
-        () -> {
-          try {
-            // setup basic settings
-            Game.info().setName("utiLITI");
-            Game.info().setSubTitle("LITIENGINE Creation Kit");
-            Game.info().setVersion("v0.5.2-beta");
-            Resources.strings().setEncoding(StandardCharsets.UTF_8);
+    try {
+      // setup basic settings
 
-            // hook up configuration and initialize the game
-            Game.config().add(Editor.preferences());
 
-            Game.config().load();
+        Game.init(
+        	      () -> { //preInitialization
+        	      	
+        	          Game.info().setName("utiLITI");
+        	          Game.info().setSubTitle("LITIENGINE Creation Kit");
+        	          Game.info().setVersion("v0.5.2-beta");
+        	          Resources.strings().setEncoding(StandardCharsets.UTF_8);
 
-            UI.initLookAndFeel();
-            Game.init(args);
-            forceBasicEditorConfiguration();
-            Game.world()
-                .camera()
-                .onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
+        	          // hook up configuration and initialize the game
+        	          Game.config().add(Editor.preferences());
 
-            // prepare UI and start the game
-            UI.init();
-            Game.start();
-            Input.keyboard().addKeyListener(new DebugCrasher());
-          } catch (Throwable e) {
-            throw new UtiLITIInitializationError(
-                "UtiLITI failed to initialize, see the stacktrace below for more information", e);
-          }
+        	          Game.config().load();
+        	          
+        	          UI.initLookAndFeel();
+        	          
+        	          // prepare UI and start the game
 
-          // configure input settings
-          Input.mouse().setGrabMouse(false);
-          Input.keyboard().consumeAlt(true);
+        	      },
+        	      () -> { //postInitialization
+        	          UI.init();
+        	          forceBasicEditorConfiguration();
+        	          Game.world()
+        	          .camera()
+        	          .onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
 
-          // load up previously opened project file or the one that is specified in
-          // the command line arguments
-          handleArgs(args);
-          String gameFile = Editor.preferences().getLastGameFile();
-          if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
-            Editor.instance().load(new File(gameFile.trim()), false);
-          }
-        });
+
+        	          
+        	          Game.start();
+
+        	          Input.keyboard().addKeyListener(new DebugCrasher());
+        	      },
+        	      args
+        	    );
+
+
+    } catch (Throwable e) {
+      throw new UtiLITIInitializationError(
+          "UtiLITI failed to initialize, see the stacktrace below for more information", e);
+    }
+    
+    // configure input settings
+    Input.mouse().setGrabMouse(false);
+    Input.keyboard().consumeAlt(true);
+
+    // load up previously opened project file or the one that is specified in
+    // the command line arguments
+    handleArgs(args);
+    String gameFile = Editor.preferences().getLastGameFile();
+    if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
+      Editor.instance().load(new File(gameFile.trim()), false);
+    }
   }
 
   private static void forceBasicEditorConfiguration() {

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
@@ -19,46 +19,44 @@ public class Program {
       // setup basic settings
 
 
-        Game.init(
-        	      () -> { //preInitialization
-        	      	
-        	          Game.info().setName("utiLITI");
-        	          Game.info().setSubTitle("LITIENGINE Creation Kit");
-        	          Game.info().setVersion("v0.5.2-beta");
-        	          Resources.strings().setEncoding(StandardCharsets.UTF_8);
+      Game.init(
+          () -> { // preInitialization
 
-        	          // hook up configuration and initialize the game
-        	          Game.config().add(Editor.preferences());
+            Game.info().setName("utiLITI");
+            Game.info().setSubTitle("LITIENGINE Creation Kit");
+            Game.info().setVersion("v0.5.2-beta");
+            Resources.strings().setEncoding(StandardCharsets.UTF_8);
 
-        	          Game.config().load();
-        	          
-        	          UI.initLookAndFeel();
-        	          
-        	          // prepare UI and start the game
+            // hook up configuration and initialize the game
+            Game.config().add(Editor.preferences());
 
-        	      },
-        	      () -> { //postInitialization
-        	          UI.init();
-        	          forceBasicEditorConfiguration();
-        	          Game.world()
-        	          .camera()
-        	          .onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
+            Game.config().load();
+
+            UI.initLookAndFeel();
+
+            // prepare UI and start the game
+
+          },
+          () -> { // postInitialization
+            UI.init();
+            forceBasicEditorConfiguration();
+            Game.world()
+                .camera()
+                .onZoom(event -> Editor.preferences().setZoom((float) event.getZoom()));
 
 
-        	          
-        	          Game.start();
+            Game.start();
 
-        	          Input.keyboard().addKeyListener(new DebugCrasher());
-        	      },
-        	      args
-        	    );
+            Input.keyboard().addKeyListener(new DebugCrasher());
+          },
+          args);
 
 
     } catch (Throwable e) {
       throw new UtiLITIInitializationError(
           "UtiLITI failed to initialize, see the stacktrace below for more information", e);
     }
-    
+
     // configure input settings
     Input.mouse().setGrabMouse(false);
     Input.keyboard().consumeAlt(true);

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
@@ -46,25 +46,23 @@ public class Program {
             Game.start();
 
             Input.keyboard().addKeyListener(new DebugCrasher());
+
+            // configure input settings
+            Input.mouse().setGrabMouse(false);
+            Input.keyboard().consumeAlt(true);
+
+            // load up previously opened project file or the one that is specified in
+            // the command line arguments
+            handleArgs(args);
+            String gameFile = Editor.preferences().getLastGameFile();
+            if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
+              Editor.instance().load(new File(gameFile.trim()), false);
+            }
           },
           args);
-
-
     } catch (Throwable e) {
       throw new UtiLITIInitializationError(
           "UtiLITI failed to initialize, see the stacktrace below for more information", e);
-    }
-
-    // configure input settings
-    Input.mouse().setGrabMouse(false);
-    Input.keyboard().consumeAlt(true);
-
-    // load up previously opened project file or the one that is specified in
-    // the command line arguments
-    handleArgs(args);
-    String gameFile = Editor.preferences().getLastGameFile();
-    if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
-      Editor.instance().load(new File(gameFile.trim()), false);
     }
   }
 

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
@@ -16,28 +16,26 @@ public class Program {
 
   public static void main(String[] args) {
     try {
-      // setup basic settings
-
-
       Game.init(
           () -> { // preInitialization
 
+            // setup basic settings
             Game.info().setName("utiLITI");
             Game.info().setSubTitle("LITIENGINE Creation Kit");
             Game.info().setVersion("v0.5.2-beta");
             Resources.strings().setEncoding(StandardCharsets.UTF_8);
 
-            // hook up configuration and initialize the game
+            // hook up configuration
             Game.config().add(Editor.preferences());
 
             Game.config().load();
 
             UI.initLookAndFeel();
 
-            // prepare UI and start the game
-
           },
           () -> { // postInitialization
+
+            // prepare UI and start the game
             UI.init();
             forceBasicEditorConfiguration();
             Game.world()


### PR DESCRIPTION
Fixes threading issues in Game.class.

* Fixes #765 
* Fixes #764 
* Fixes a issue where shutdown hooks and event dispatcher thread could both try to acquire a lock to Game.class, and not release the lock during shutdown, causing a deadlock.

* Adds an init(Runnable, Runnable, String...) method to Game.class, to make it easier to run code before and after initialization on the event dispatch thread.