### PR TITLE
Fix ~200 failing tests caused by concurrent execution of Game tests

### DIFF
--- a/core/src/main/java/de/gurkenlabs/litiengine/Game.java
+++ b/core/src/main/java/de/gurkenlabs/litiengine/Game.java
@@ -483,7 +483,7 @@ public final class Game {
    *          The arguments passed to the programs entry point.
    */
   public static void init(String... args) {
-    init(true, args);
+    init(!SwingUtilities.isEventDispatchThread(), args);
   }
 
   private static Runnable initImpl(String... args) {

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
@@ -2,15 +2,11 @@ package de.gurkenlabs.litiengine;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.awt.AWTError;
 import de.gurkenlabs.litiengine.test.GameTestSuite;
 
 import java.io.File;
-
-import javax.swing.SwingUtilities;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -80,17 +76,4 @@ public class GameTest {
     assertTrue(started.wasCalled);
   }
 
-  @Test
-  public void testSwingThreadAssertions() {
-    assertThrows(AWTError.class, () -> Game.init(false, Game.COMMANDLINE_ARG_NOGUI));
-    Game.terminate();
-    Game.init(
-        () -> {
-          assertTrue(SwingUtilities.isEventDispatchThread());
-        },
-        () -> {
-          assertTrue(SwingUtilities.isEventDispatchThread());
-        },
-        Game.COMMANDLINE_ARG_NOGUI);
-  }
 }

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
@@ -6,13 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.AWTError;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.io.File;
 
 import javax.swing.SwingUtilities;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 public class GameTest {
   // test-only helper method to call the package-private Game.terminate()
   public static void terminateGame() {

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTest.java
@@ -2,11 +2,14 @@ package de.gurkenlabs.litiengine;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.gurkenlabs.litiengine.test.GameTestSuite;
 
+import java.awt.AWTError;
 import java.io.File;
+
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -74,6 +77,16 @@ public class GameTest {
 
     Game.start();
     assertTrue(started.wasCalled);
+  }
+
+  @Test
+  public void testSwingThreadAssertionsInsideSwing() {
+    assertThrows(AWTError.class, () -> {
+      Game.init(
+          () -> {},
+          () -> {},
+          Game.COMMANDLINE_ARG_NOGUI);
+    });
   }
 
 }

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTestNoSwing.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTestNoSwing.java
@@ -4,9 +4,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javax.swing.SwingUtilities;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 public class GameTestNoSwing {
+
+
+  @BeforeAll
+  private void onTestStart() {
+    GameTestSuite.GameLock.lock();
+  }
+
+  @AfterAll
+  private void onTestEnd() {
+    GameTestSuite.GameLock.unlock();
+  }
 
   @Test
   public void testSwingThreadAssertionsOutsideSwing() {

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTestNoSwing.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTestNoSwing.java
@@ -1,0 +1,23 @@
+package de.gurkenlabs.litiengine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+
+public class GameTestNoSwing {
+
+  @Test
+  public void testSwingThreadAssertionsOutsideSwing() {
+    Game.init(
+        () -> {
+          assertTrue(SwingUtilities.isEventDispatchThread());
+        },
+        () -> {
+          assertTrue(SwingUtilities.isEventDispatchThread());
+        },
+        Game.COMMANDLINE_ARG_NOGUI);
+  }
+
+}

--- a/core/src/test/java/de/gurkenlabs/litiengine/GameTimeTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/GameTimeTests.java
@@ -4,9 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
+@ExtendWith(GameTestSuite.class)
 class GameTimeTests {
   @ParameterizedTest(name = "toMilliseconds_Positive ticks={0}, updateRate={1}, expected={2}")
   @CsvSource({"100, 50, 2000", "450, 33, 13636", "33, 100, 330"})

--- a/core/src/test/java/de/gurkenlabs/litiengine/RandomTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/RandomTests.java
@@ -13,8 +13,12 @@ import java.awt.geom.Point2D;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 
 // TODO: merge with GameRandomTests
+@ExtendWith(GameTestSuite.class)
 class RandomTests {
 
   private static final String SEED = "myseed";

--- a/core/src/test/java/de/gurkenlabs/litiengine/abilities/AbilityExecutionTest.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/abilities/AbilityExecutionTest.java
@@ -19,13 +19,17 @@ import de.gurkenlabs.litiengine.IGameLoop;
 import de.gurkenlabs.litiengine.abilities.effects.Effect;
 import de.gurkenlabs.litiengine.abilities.effects.EffectTarget;
 import de.gurkenlabs.litiengine.entities.Creature;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Shape;
 import java.util.Objects;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 
+@ExtendWith(GameTestSuite.class)
 class AbilityExecutionTest {
 
   private TestAbility ability;

--- a/core/src/test/java/de/gurkenlabs/litiengine/abilities/AbilityTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/abilities/AbilityTests.java
@@ -19,6 +19,8 @@ import de.gurkenlabs.litiengine.abilities.effects.EffectTarget;
 import de.gurkenlabs.litiengine.entities.Creature;
 import de.gurkenlabs.litiengine.entities.EntityPivotType;
 import de.gurkenlabs.litiengine.graphics.RenderEngine;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Graphics2D;
 import java.awt.Shape;
 import java.awt.geom.Arc2D;
@@ -26,8 +28,10 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 
+@ExtendWith(GameTestSuite.class)
 class AbilityTests {
   @BeforeEach
   public void init() {

--- a/core/src/test/java/de/gurkenlabs/litiengine/abilities/effects/EffectTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/abilities/effects/EffectTests.java
@@ -8,11 +8,15 @@ import static org.mockito.Mockito.verify;
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.abilities.Ability;
 import de.gurkenlabs.litiengine.entities.Creature;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Shape;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class EffectTests {
 
   private Creature creature;

--- a/core/src/test/java/de/gurkenlabs/litiengine/entities/CombatEntityTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/entities/CombatEntityTests.java
@@ -17,13 +17,16 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.GameTime;
 import de.gurkenlabs.litiengine.abilities.Ability;
 import de.gurkenlabs.litiengine.attributes.RangeAttribute;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 import de.gurkenlabs.litiengine.tweening.TweenType;
 import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 
+@ExtendWith(GameTestSuite.class)
 class CombatEntityTests {
 
   private CombatEntity combatEntitySpy;

--- a/core/src/test/java/de/gurkenlabs/litiengine/entities/CreatureTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/entities/CreatureTests.java
@@ -6,12 +6,16 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+@ExtendWith(GameTestSuite.class)
 public class CreatureTests {
 
   private Creature creature;

--- a/core/src/test/java/de/gurkenlabs/litiengine/entities/EntityHitEventTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/entities/EntityHitEventTests.java
@@ -7,9 +7,13 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.abilities.Ability;
 import de.gurkenlabs.litiengine.abilities.AbilityInfo;
 import de.gurkenlabs.litiengine.abilities.CastType;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class EntityHitEventTests {
 
   @BeforeAll

--- a/core/src/test/java/de/gurkenlabs/litiengine/entities/SpawnpointTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/entities/SpawnpointTests.java
@@ -11,12 +11,16 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.GameTest;
 import de.gurkenlabs.litiengine.environment.Environment;
 import de.gurkenlabs.litiengine.environment.tilemap.IMap;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Dimension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class SpawnpointTests {
   private Environment testEnvironment;
   private boolean eventCalled;

--- a/core/src/test/java/de/gurkenlabs/litiengine/entities/TriggerTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/entities/TriggerTests.java
@@ -16,6 +16,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.environment.tilemap.MapOrientations;
 import de.gurkenlabs.litiengine.graphics.RenderType;
 import de.gurkenlabs.litiengine.physics.Collision;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 
 import java.awt.Dimension;
 import java.awt.geom.Rectangle2D;
@@ -27,7 +28,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class TriggerTests {
   private Environment testEnvironment;
 

--- a/core/src/test/java/de/gurkenlabs/litiengine/environment/EntitySpawnerTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/environment/EntitySpawnerTests.java
@@ -10,12 +10,16 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.GameTest;
 import de.gurkenlabs.litiengine.entities.Creature;
 import de.gurkenlabs.litiengine.entities.Spawnpoint;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.util.Collections;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class EntitySpawnerTests {
   private Environment testEnvironment;
   private Spawnpoint spawnPoint;

--- a/core/src/test/java/de/gurkenlabs/litiengine/environment/EnvironmentEventTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/environment/EnvironmentEventTests.java
@@ -12,6 +12,8 @@ import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.environment.tilemap.MapOrientations;
 import de.gurkenlabs.litiengine.graphics.RenderType;
 import de.gurkenlabs.litiengine.physics.Collision;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.util.ArrayList;
@@ -19,10 +21,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 
+@ExtendWith(GameTestSuite.class)
 public class EnvironmentEventTests {
   private Environment testEnvironment;
 

--- a/core/src/test/java/de/gurkenlabs/litiengine/environment/EnvironmentTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/environment/EnvironmentTests.java
@@ -32,6 +32,8 @@ import de.gurkenlabs.litiengine.graphics.StaticShadowType;
 import de.gurkenlabs.litiengine.graphics.emitters.Emitter;
 import de.gurkenlabs.litiengine.graphics.emitters.particles.Particle;
 import de.gurkenlabs.litiengine.physics.Collision;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.geom.Ellipse2D;
@@ -44,9 +46,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+@ExtendWith(GameTestSuite.class)
 class EnvironmentTests {
   private Environment testEnvironment;
 

--- a/core/src/test/java/de/gurkenlabs/litiengine/environment/GameWorldTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/environment/GameWorldTests.java
@@ -7,10 +7,14 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.GameTest;
 import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.resources.Resources;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class GameWorldTests {
 
   @BeforeEach

--- a/core/src/test/java/de/gurkenlabs/litiengine/environment/MapObjectLoaderTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/environment/MapObjectLoaderTests.java
@@ -32,6 +32,7 @@ import de.gurkenlabs.litiengine.environment.tilemap.MapOrientations;
 import de.gurkenlabs.litiengine.environment.tilemap.TmxProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.CustomProperty;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.MapObject;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -46,7 +47,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class MapObjectLoaderTests {
   private Environment testEnvironment;
 

--- a/core/src/test/java/de/gurkenlabs/litiengine/graphics/emitters/particles/ParticleTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/graphics/emitters/particles/ParticleTests.java
@@ -13,6 +13,8 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.GameTest;
 import de.gurkenlabs.litiengine.physics.Collision;
 import de.gurkenlabs.litiengine.physics.PhysicsEngine;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 
@@ -20,10 +22,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 
+@ExtendWith(GameTestSuite.class)
 class ParticleTests {
 
   private Particle particle;

--- a/core/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.input.Input;
-import de.gurkenlabs.litiengine.test.SwingTestSuite;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 import de.gurkenlabs.litiengine.tweening.TweenType;
 import de.gurkenlabs.litiengine.util.ColorHelper;
 import java.awt.Color;
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@ExtendWith(SwingTestSuite.class)
+@ExtendWith(GameTestSuite.class)
 class GuiComponentTests {
 
   @BeforeEach

--- a/core/src/test/java/de/gurkenlabs/litiengine/gui/ListFieldTest.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/gui/ListFieldTest.java
@@ -15,13 +15,13 @@ import static org.mockito.Mockito.when;
 import de.gurkenlabs.litiengine.Game;
 import javax.swing.SwingUtilities;
 
-import de.gurkenlabs.litiengine.test.SwingTestSuite;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(SwingTestSuite.class)
+@ExtendWith(GameTestSuite.class)
 class ListFieldTest {
 
   private final String[] content_1D = new String[] {"A", "B", "C", "D", "E", "F", "G"};

--- a/core/src/test/java/de/gurkenlabs/litiengine/gui/NumberAdjusterTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/gui/NumberAdjusterTests.java
@@ -5,10 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.input.Input;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.math.BigDecimal;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 public class NumberAdjusterTests {
 
   @BeforeAll

--- a/core/src/test/java/de/gurkenlabs/litiengine/gui/SliderTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/gui/SliderTests.java
@@ -5,9 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.input.Input;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class SliderTests {
 
   /*

--- a/core/src/test/java/de/gurkenlabs/litiengine/gui/SpeechBubbleTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/gui/SpeechBubbleTests.java
@@ -9,8 +9,11 @@ import de.gurkenlabs.litiengine.environment.Environment;
 import de.gurkenlabs.litiengine.gui.screens.Screen;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.sound.Sound;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -23,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(GameTestSuite.class)
 class SpeechBubbleTests {
 
   private IEntity entity;

--- a/core/src/test/java/de/gurkenlabs/litiengine/input/KeyboardEntityControllerTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/input/KeyboardEntityControllerTests.java
@@ -6,15 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.entities.Creature;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Component;
 import java.awt.event.KeyEvent;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@ExtendWith(GameTestSuite.class)
 class KeyboardEntityControllerTests {
   @BeforeAll
   public static void initializeKeyboard() {

--- a/core/src/test/java/de/gurkenlabs/litiengine/pathfinding/AStarTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/pathfinding/AStarTests.java
@@ -14,6 +14,8 @@ import de.gurkenlabs.litiengine.entities.behavior.AStarNode;
 import de.gurkenlabs.litiengine.environment.Environment;
 import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.environment.tilemap.MapOrientations;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.geom.Point2D;
@@ -24,10 +26,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@ExtendWith(GameTestSuite.class)
 public class AStarTests {
   @BeforeAll
   public static void initGame() {

--- a/core/src/test/java/de/gurkenlabs/litiengine/physics/CollisionResolvingTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/physics/CollisionResolvingTests.java
@@ -7,16 +7,20 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.Valign;
 import de.gurkenlabs.litiengine.entities.CollisionBox;
 import de.gurkenlabs.litiengine.entities.Creature;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.geom.Rectangle2D;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@ExtendWith(GameTestSuite.class)
 class CollisionResolvingTests {
   final double EPSILON = 1e-6;
   final double MOVE_10X10Y_DISTANCE = 14.14213562373095; // = root of 200 because 10² + 10² = 200

--- a/core/src/test/java/de/gurkenlabs/litiengine/physics/MovementControllerTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/physics/MovementControllerTests.java
@@ -16,15 +16,18 @@ import de.gurkenlabs.litiengine.GameLoop;
 import de.gurkenlabs.litiengine.IGameLoop;
 import de.gurkenlabs.litiengine.entities.Creature;
 import de.gurkenlabs.litiengine.entities.IMobileEntity;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
 import de.gurkenlabs.litiengine.util.geom.GeometricUtilities;
 import java.awt.geom.Point2D;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 
+@ExtendWith(GameTestSuite.class)
 class MovementControllerTests {
 
   private MovementController<IMobileEntity> controller;

--- a/core/src/test/java/de/gurkenlabs/litiengine/physics/PhysicsEngineTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/physics/PhysicsEngineTests.java
@@ -3,9 +3,12 @@ package de.gurkenlabs.litiengine.physics;
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.entities.CollisionBox;
 import de.gurkenlabs.litiengine.entities.ICollisionEntity;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -20,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(GameTestSuite.class)
 class PhysicsEngineTests {
 
   @BeforeEach

--- a/core/src/test/java/de/gurkenlabs/litiengine/physics/PhysicsTests.java
+++ b/core/src/test/java/de/gurkenlabs/litiengine/physics/PhysicsTests.java
@@ -9,12 +9,16 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.entities.CollisionBox;
 import de.gurkenlabs.litiengine.entities.Creature;
 import de.gurkenlabs.litiengine.entities.IMobileEntity;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class PhysicsTests {
   @BeforeEach
   public void init() {

--- a/shared/src/main/java/de/gurkenlabs/litiengine/test/GameTestSuite.java
+++ b/shared/src/main/java/de/gurkenlabs/litiengine/test/GameTestSuite.java
@@ -1,0 +1,24 @@
+package de.gurkenlabs.litiengine.test;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class GameTestSuite extends SwingTestSuite implements BeforeAllCallback, AfterAllCallback {
+
+  private static final Lock GameLock = new ReentrantLock();
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    GameLock.lock();
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    GameLock.unlock();
+  }
+
+}

--- a/shared/src/main/java/de/gurkenlabs/litiengine/test/GameTestSuite.java
+++ b/shared/src/main/java/de/gurkenlabs/litiengine/test/GameTestSuite.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class GameTestSuite extends SwingTestSuite implements BeforeAllCallback, AfterAllCallback {
 
-  private static final Lock GameLock = new ReentrantLock();
+  public static final Lock GameLock = new ReentrantLock();
 
   @Override
   public void beforeAll(ExtensionContext context) throws Exception {


### PR DESCRIPTION
The changes in #766 removed synchronized methods from Game.class. This allowed tests on Game.class to run concurrently. This caused about ~20% of tests to fail.

Before #766, an attempt was made to prevent tests from failing by using synchronized methods in Game.class.

However, this would still have allowed tests to fail randomly. Lets say Thread 1 and Thread 2 both wanted to do tests on Game.class at the same time.

Ex:
* Thread 1 wants to call Game.init() which was synchronized.
* Because it was synchronized, Thread 1 acquires lock to Game.class
* Thread 2 wants to call Game.init(), but Game.class is locked, so it waits.
* Thread 1 calls Game.init()
* Thread 1 has finished calling Game.init, so it releases the lock to Game.class
* Thread 2 is free to call Game.init()
* Game gets initialized twice without being terminated so test fails

The proper way to do this is to prevent other tests that use the Game class from running until the current one has finished. GameTestSuite does that.