### PR TITLE
Fix alignment of text that overflows the boundaries

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/Align.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/Align.java
@@ -78,8 +78,12 @@ public enum Align {
   }
 
   /**
-   * Gets the location for the specified object height to be horizontally aligned within the bounds of the specified
-   * width.
+   * Gets the location for the specified object width to be horizontally aligned relatively to the bounds of the specified
+   * width.<br>
+   * Suitable for <b>entity</b> alignment. The return value might be negative or exceed the right boundary which is
+   * <i>{@code width} - {@code objectWidth}</i>. <br>
+   * For <b>text</b> alignment {@link #getLocation(double, double, boolean)} should be used with
+   * <i>{@code preventOverflow}</i> set to {@code true}.
    *
    * @param width
    *          The width, limiting the horizontal alignment.
@@ -88,9 +92,32 @@ public enum Align {
    * @return The x-coordinate for the location of the object with the specified width.
    */
   public double getLocation(final double width, final double objectWidth) {
+    return getLocation(width, objectWidth, false);
+  }
+
+  /**
+   * Gets the location for the specified object width to be horizontally aligned relatively to the bounds of the specified
+   * width. An overflow behavior (whenever <i>{@code objectWidth} > {@code width}</i>) can be controlled using
+   * <b>{@code preventOverflow}</b> parameter:
+   * <ul>
+   * <li><i>false</i>: the return value might be negative or exceed the right boundary which is <i>{@code width} -
+   * {@code objectWidth}</i> (good for <b>entity</b> alignment).</li>
+   * <li><i>true</i>: the return value will always be clamped within the bounds (good for <b>text</b> alignment).</li>
+   * </ul>
+   *
+   * @param width
+   *          The width, limiting the horizontal alignment.
+   * @param objectWidth
+   *          The width of the object for which to calculate the horizontally aligned location.
+   * @param preventOverflow
+   *          A flag indicating whether the return value should be clamped to keep it within the bounds (prevent values
+   *          that are negative or beyond the right boundary).
+   * @return The x-coordinate for the location of the object with the specified width.
+   */
+  public double getLocation(final double width, final double objectWidth, final boolean preventOverflow) {
     double value = this.getValue(width);
     double location = value - objectWidth / 2.0;
-    if (objectWidth > width) {
+    if (objectWidth > width && !preventOverflow) {
       return location;
     }
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/Valign.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/Valign.java
@@ -77,7 +77,12 @@ public enum Valign {
   }
 
   /**
-   * Gets the location for the specified object height to be vertically aligned within the bounds of the specified height.
+   * Gets the location for the specified object height to be vertically aligned relatively to the bounds of the specified
+   * height.<br>
+   * Suitable for <b>entity</b> alignment. The return value might be negative or exceed the bottom boundary which is
+   * <i>{@code height} - {@code objectHeight}</i>. <br>
+   * For <b>text</b> alignment {@link #getLocation(double, double, boolean)} should be used with
+   * <i>{@code preventOverflow}</i> set to {@code true}.
    *
    * @param height
    *          The height, limiting the vertical alignment.
@@ -86,10 +91,33 @@ public enum Valign {
    * @return The y-coordinate for the location of the object with the specified height.
    */
   public double getLocation(final double height, final double objectHeight) {
+    return getLocation(height, objectHeight, false);
+  }
+
+  /**
+   * Gets the location for the specified object height to be vertically aligned relatively to the bounds of the specified
+   * height. An overflow behavior (whenever <i>{@code objectHeight} > {@code height}</i>) can be controlled using
+   * <b>{@code preventOverflow}</b> parameter:
+   * <ul>
+   * <li><i>false</i>: the return value might be negative or exceed the bottom boundary which is <i>{@code height} -
+   * {@code objectHeight}</i> (good for <b>entity</b> alignment).</li>
+   * <li><i>true</i>: the return value will always be clamped within the bounds (good for <b>text</b> alignment).</li>
+   * </ul>
+   *
+   * @param height
+   *          The height, limiting the vertical alignment.
+   * @param objectHeight
+   *          The height of the object for which to calculate the vertically aligned location.
+   * @param preventOverflow
+   *          A flag indicating whether the return value should be clamped to keep it within the bounds (prevent values
+   *          that are negative or beyond the bottom boundary).
+   * @return The y-coordinate for the location of the object with the specified height.
+   */
+  public double getLocation(final double height, final double objectHeight, final boolean preventOverflow) {
     double value = this.getValue(height);
     double location = value - objectHeight / 2.0;
 
-    if (objectHeight > height) {
+    if (objectHeight > height && !preventOverflow) {
       return location;
     }
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TextRenderer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TextRenderer.java
@@ -132,11 +132,11 @@ public final class TextRenderer {
     }
     double locationX =
         bounds.getX()
-            + align.getLocation(bounds.getWidth(), g.getFontMetrics().stringWidth(text))
+            + align.getLocation(bounds.getWidth(), g.getFontMetrics().stringWidth(text), true)
             + offsetX;
     double locationY =
         bounds.getY()
-            + valign.getLocation(bounds.getHeight(), getHeight(g, text))
+            + valign.getLocation(bounds.getHeight(), getHeight(g, text), true)
             + g.getFontMetrics().getAscent()
             + offsetY;
     render(g, text, locationX, locationY);
@@ -337,10 +337,10 @@ public final class TextRenderer {
         textHeight += nextLayout.getLeading();
       }
     }
-    float textY = (float) (y + valign.getLocation(height, textHeight));
+    float textY = (float) (y + valign.getLocation(height, textHeight, true));
     for (TextLayout layout : lines) {
       textY += layout.getAscent();
-      layout.draw(g, (float) (x + align.getLocation(width, layout.getAdvance())), textY);
+      layout.draw(g, (float) (x + align.getLocation(width, layout.getAdvance(), true)), textY);
       textY += layout.getDescent() + layout.getLeading();
     }
     g.setRenderingHints(originalHints);
@@ -488,8 +488,8 @@ public final class TextRenderer {
     // get the shape object
     AffineTransform at = new AffineTransform();
     at.translate(
-        x + align.getLocation(width, bounds.getWidth()),
-        y + valign.getLocation(height, bounds.getHeight()) + bounds.getHeight());
+        x + align.getLocation(width, bounds.getWidth(), true),
+        y + valign.getLocation(height, bounds.getHeight(), true) + bounds.getHeight());
     Shape textShape = at.createTransformedShape(glyphVector.getOutline());
 
     // activate anti aliasing for text rendering (if you want it to look nice)

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
@@ -1350,11 +1350,11 @@ public abstract class GuiComponent
 
     double xCoord =
       getTextAlign() != null
-        ? getX() + getTextAlign().getLocation(getWidth(), textWidth)
+        ? getX() + getTextAlign().getLocation(getWidth(), textWidth, true)
         : getTextX();
     double yCoord =
       getTextValign() != null
-        ? getY() + getTextValign().getLocation(getHeight(), textHeight)
+        ? getY() + getTextValign().getLocation(getHeight(), textHeight, true)
         : getTextY();
     if (getTextAngle() == 0) {
       if (hasTextShadow()) {

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/ValignTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/ValignTests.java
@@ -5,18 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class AlignTests {
-  private Align alignObject;
+class ValignTests {
+  private Valign valignObject;
 
   @BeforeEach
   public void initAlign() {
-    alignObject = Align.get("right"); // portion = 1
+    valignObject = Valign.get("down"); // portion = 1
   }
 
   @Test
   void getLocation_OnPoint() {
     // act
-    double onPointLocation = alignObject.getLocation(1.0, 1.0);
+    double onPointLocation = valignObject.getLocation(1.0, 1.0);
 
     // assert
     assertEquals(0.0, onPointLocation, 0.001); // clamp(0.5, 0, 0)
@@ -25,7 +25,7 @@ class AlignTests {
   @Test
   void getLocation_OffPoint() {
     // act
-    double offPointLocation = alignObject.getLocation(1.0, 1.1);
+    double offPointLocation = valignObject.getLocation(1.0, 1.1);
 
     // assert
     assertEquals(0.45, offPointLocation, 0.001); // 1.0 - 1.1 / 2.0
@@ -34,7 +34,7 @@ class AlignTests {
   @Test
   void getLocation_InPoint() {
     // act
-    double inPointLocation = alignObject.getLocation(1.0, 5.0);
+    double inPointLocation = valignObject.getLocation(1.0, 5.0);
 
     // assert
     assertEquals(-1.5, inPointLocation, 0.001); // 1.0 - 5.0 / 2.0
@@ -43,7 +43,7 @@ class AlignTests {
   @Test
   void getLocation_OutPoint() {
     // act
-    double outPointLocation = alignObject.getLocation(1.0, 0.5);
+    double outPointLocation = valignObject.getLocation(1.0, 0.5);
 
     // assert
     assertEquals(0.5, outPointLocation, 0.001); // clamp(0.75, 0, 0.5)
@@ -52,7 +52,7 @@ class AlignTests {
   @Test
   void getClampedLocation_OnPoint() {
     // act
-    double onPointLocation = alignObject.getLocation(1.0, 1.0, true);
+    double onPointLocation = valignObject.getLocation(1.0, 1.0, true);
 
     // assert
     assertEquals(0.0, onPointLocation, 0.001); // clamp(0.5, 0, 0)
@@ -61,7 +61,7 @@ class AlignTests {
   @Test
   void getClampedLocation_OffPoint() {
     // act
-    double offPointLocation = alignObject.getLocation(1.0, 1.1, true);
+    double offPointLocation = valignObject.getLocation(1.0, 1.1, true);
 
     // assert
     assertEquals(0.0, offPointLocation, 0.001); // clamp(0.45, 0, -0.1)
@@ -70,7 +70,7 @@ class AlignTests {
   @Test
   void getClampedLocation_InPoint() {
     // act
-    double inPointLocation = alignObject.getLocation(1.0, 5.0, true);
+    double inPointLocation = valignObject.getLocation(1.0, 5.0, true);
 
     // assert
     assertEquals(0.0, inPointLocation, 0.001); // clamp(-1.5, 0, -4.0)
@@ -79,7 +79,7 @@ class AlignTests {
   @Test
   void getClampedLocation_OutPoint() {
     // act
-    double outPointLocation = alignObject.getLocation(1.0, 0.5, true);
+    double outPointLocation = valignObject.getLocation(1.0, 0.5, true);
 
     // assert
     assertEquals(0.5, outPointLocation, 0.001); // clamp(0.75, 0, 0.5)


### PR DESCRIPTION
Add `getLocation` method overload to Align and Valign enums.
Implement an option to prevent the values that are out of bounds.

Make `getLocation` calls in text scenarios use `preventOverflow` option.
Do not alter the default uses of `getLocation` for entities.

Add basic tests for `Align.getLocation` with `preventOverflow:true`.
Create similar tests for `Valign.getLocation`: default and no-overflow.