### PR TITLE
Adjust Creature sprite naming conventions

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CreatureAnimationState.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CreatureAnimationState.java
@@ -2,7 +2,7 @@ package de.gurkenlabs.litiengine.graphics;
 
 public enum CreatureAnimationState {
   IDLE,
-  WALK,
+  MOVE,
   DEAD;
 
   private final String spriteString;
@@ -16,6 +16,6 @@ public enum CreatureAnimationState {
   }
 
   public CreatureAnimationState getOpposite() {
-    return this == CreatureAnimationState.IDLE ? WALK : IDLE;
+    return this == CreatureAnimationState.IDLE ? MOVE : IDLE;
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/CreatureAnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/CreatureAnimationController.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  *
  * <ul>
  * <li>{@link #getSpritePrefix()}-idle-{DIRECTION}.{EXTENSION}
- * <li>{@link #getSpritePrefix()}-walk-{DIRECTION}.{EXTENSION}
+ * <li>{@link #getSpritePrefix()}-move-{DIRECTION}.{EXTENSION}
  * </ul>
  * <p>
  * Where {DIRECTION} refers to a value of the {@link Direction} enum and {@link #getSpritePrefix()} refers to the
@@ -126,10 +126,10 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
       return hasAnimation(deadName) ? deadName : chooseRandomDeathAnimation();
     } else if (entity.isIdle()) {
       String idleName = getIdleSpriteName(direction);
-      return hasAnimation(idleName) ? idleName : getWalkSpriteName(direction);
+      return hasAnimation(idleName) ? idleName : getMoveSpriteName(direction);
     } else {
-      String walkName = getWalkSpriteName(direction);
-      return hasAnimation(walkName) ? walkName : getIdleSpriteName(direction);
+      String moveName = getMoveSpriteName(direction);
+      return hasAnimation(moveName) ? moveName : getIdleSpriteName(direction);
     }
   }
 
@@ -152,7 +152,7 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
   }
 
   /**
-   * Initializes the available animations for the creature. This method sets up walking, idle, and dead animations for all directions.
+   * Initializes the available animations for the creature. This method sets up moving, idle, and dead animations for all directions.
    */
 
   private void initializeAvailableAnimations() {
@@ -203,8 +203,8 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
     return getSpriteNameWithDirection(CreatureAnimationState.IDLE, dir);
   }
 
-  private String getWalkSpriteName(Direction dir) {
-    return getSpriteNameWithDirection(CreatureAnimationState.WALK, dir);
+  private String getMoveSpriteName(Direction dir) {
+    return getSpriteNameWithDirection(CreatureAnimationState.MOVE, dir);
   }
 
   private String getSpriteNameWithDirection(CreatureAnimationState state, Direction dir) {

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/IconTreeListRenderer.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/IconTreeListRenderer.java
@@ -121,7 +121,7 @@ public class IconTreeListRenderer implements TreeCellRenderer {
                                   || s.getName()
                                       .equals(
                                           CreatureAnimationController.getSpriteName(
-                                              creature, CreatureAnimationState.WALK))
+                                              creature, CreatureAnimationState.MOVE))
                                   || s.getName()
                                       .equals(
                                           CreatureAnimationController.getSpriteName(


### PR DESCRIPTION
### Context
**Description** - Adjust Creature sprite naming conventions
**Fixes** - Closes https://github.com/gurkenlabs/litiengine/issues/777

### Summary 
Updated Creature Sprite state to MOVE from WALK to make it more generic.

### Additional thoughts
For the issue #777, as per the present implementation, I didn't find any place where state and direction is calculated by splitting the sprite name at '-' characters. As per my understanding, sprite name is calculated from state or direction to prepare the name of the image. Therefore, in my opinion, the 2nd point most probably is not  relevant as per the current implementation. Please correct me if I am wrong. Thanks so much!