### PR TITLE
Better Thread Dumps

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
@@ -120,28 +120,13 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
   }
 
   protected static String dump() {
-    StringBuilder text = new StringBuilder();
-    ThreadMXBean threads = ManagementFactory.getThreadMXBean();
-    ThreadInfo[] dumps = threads.getThreadInfo(threads.getAllThreadIds(), 255);
-    text.append("====THREAD DUMP====\n\n");
-    for (ThreadInfo dump : dumps) {
-      text.append("\"").append(dump.getThreadName()).append("\"\n");
-      Thread.State state = dump.getThreadState();
-      text.append("\tState: ").append(state);
-      String blockedBy = dump.getLockOwnerName();
-      if (blockedBy != null) {
-        text.append(" on ").append(blockedBy);
-      }
-      text.append("\n");
-      StackTraceElement[] elements = dump.getStackTrace();
-      for (StackTraceElement element : elements) {
-        text.append("\t\tat ");
-        text.append(element);
-        text.append("\n");
-      }
-      text.append("\n\n");
-    }
-    return text.toString();
+		StringBuilder text = new StringBuilder();
+		ThreadMXBean threads = ManagementFactory.getThreadMXBean();
+		text.append("---- THREAD DUMP ----\n\n");
+		for (ThreadInfo dump : threads.dumpAllThreads(true, true)) {
+			text.append(dump.toString());
+		}
+		return text.toString();
   }
 
   protected static String getSystemInfo() {


### PR DESCRIPTION
Thread dumps are now more complete and are in a format compatible with programs that read jstack thread dumps.

**This code was not tested on this repository.** However I use the code in a different project (https://github.com/WilderForge/WilderForge/blob/3d905748a018801c12c0cf764e4343decabf3ece/src/main/java/com/wildermods/wilderforge/launch/logging/CrashInfo.java#L276C1-L282C26)

Example thread dump from that project in this crash report:



```
---- WilderForge Crash Report----
//I never asked to be created.

Time: 2024-09-25T04:24:38.353888521Z
Description: Manually Triggered Debug Crash With Thread Dump Enabled (CTRL + ALT + SHIFT + F1 + C)

net.fabricmc.loader.impl.FormattedException: com.badlogic.gdx.utils.GdxRuntimeException: java.lang.Error: Manually Triggered Debug Crash With Thread Dump Enabled CTRL + ALT + SHIFT + F1 + C)
	at com.wildermods.provider.WildermythGameProvider.launch(WildermythGameProvider.java:389)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
Caused by: com.badlogic.gdx.utils.GdxRuntimeException: java.lang.Error: Manually Triggered Debug Crash With Thread Dump Enabled CTRL + ALT + SHIFT + F1 + C)
	at com.badlogic.gdx.backends.lwjgl3.NiceLwjgl3Application.<init>(NiceLwjgl3Application.java:86)
	at com.worldwalkergames.legacy.LegacyDesktop.main(LegacyDesktop.java:151)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.wildermods.provider.WildermythGameProvider.launch(WildermythGameProvider.java:386)
	... 2 more
Caused by: java.lang.Error: Manually Triggered Debug Crash With Thread Dump Enabled CTRL + ALT + SHIFT + F1 + C)
	at com.wildermods.wilderforge.launch.WilderForge.lambda$init$0(WilderForge.java:93)
	at com.worldwalkergames.communication.observer.signals.Signal2.dispatch(Signal2.java:188)
	at com.worldwalkergames.legacy.input.GlobalInputProcessor.keyDown(GlobalInputProcessor.java:49)
	at com.badlogic.gdx.InputMultiplexer.keyDown(InputMultiplexer.java:80)
	at com.worldwalkergames.legacy.ui.FaultTolerantInputMultiplexer.keyDown(FaultTolerantInputMultiplexer.java:20)
	at com.badlogic.gdx.InputEventQueue.drain(InputEventQueue.java:58)
	at com.badlogic.gdx.backends.lwjgl3.DefaultLwjgl3Input.update(DefaultLwjgl3Input.java:189)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:378)
	at com.badlogic.gdx.backends.lwjgl3.NiceLwjgl3Application.loop(NiceLwjgl3Application.java:104)
	at com.badlogic.gdx.backends.lwjgl3.NiceLwjgl3Application.<init>(NiceLwjgl3Application.java:80)
	... 6 more

---- Additonal Information----

--System Details--
Wildermyth Version: 1.16+550 Patch
Operating System: Linux
	Architecture: amd64
	Version: 6.8.0-40-generic
Cores: 24
Memory:
	Max heap size: 7.8 GiB
	Current heap size: 1.0 GiB
	Heap used: 458.1 MiB
	Free heap: 601.9 MiB
Graphical information:
	Vendor: 
		NVIDIA Corporation
	Card: 
		NVIDIA GeForce RTX 3080/PCIe/SSE2
	Monitors:
		Total monitors (OpenGL) 2:
			Monitor 0:
				Name: DP-0
				Resolution: 3840x2160@60hz
			Monitor 1:
				Name: HDMI-0
				Resolution: 1920x1080@75hz
		Total monitors (Java): 2
			Monitor 0
				Name: :0.0
				Resolution: 5760x2160@50hz
			Monitor 1
				Name: :0.1
				Resolution: 1920x1080@0hz
Java Version: OpenJDK Runtime Environment 21.0.4+7-Ubuntu-1ubuntu222.04 
	Vendor: Ubuntu
Uptime: PT16.814S


-- Coremod Details --
Coremods Detected: 7:

	asm 9.0
	fabricloader 0.16.3
	java 21
	mixin 0.8.7
	mixinextras 0.4.1
	wilderforge ${WILDERFORGE_VERSION}
	wildermyth 1.16+550


---- THREAD DUMP ----

"main" prio=5 Id=1 RUNNABLE
	at java.management@21.0.4/sun.management.ThreadImpl.dumpThreads0(Native Method)
	at java.management@21.0.4/sun.management.ThreadImpl.dumpAllThreads(ThreadImpl.java:518)
	at java.management@21.0.4/sun.management.ThreadImpl.dumpAllThreads(ThreadImpl.java:506)
	at com.wildermods.wilderforge.launch.logging.CrashInfo.getThreadDump(CrashInfo.java:279)
	at com.wildermods.wilderforge.launch.logging.CrashInfo.appendThreadDump(CrashInfo.java:233)
	at com.wildermods.wilderforge.launch.logging.CrashInfo.logCrash(CrashInfo.java:92)
	at java.base@21.0.4/java.lang.invoke.LambdaForm$DMH/0x00007d21c00e0800.invokeSpecial(LambdaForm$DMH)
	at java.base@21.0.4/java.lang.invoke.LambdaForm$MH/0x00007d21c05d4400.invoke(LambdaForm$MH)
	...

"Reference Handler" daemon prio=10 Id=9 RUNNABLE
	at java.base@21.0.4/java.lang.ref.Reference.waitForReferencePendingList(Native Method)
	at java.base@21.0.4/java.lang.ref.Reference.processPendingReferences(Reference.java:246)
	at java.base@21.0.4/java.lang.ref.Reference$ReferenceHandler.run(Reference.java:208)

"Finalizer" daemon prio=8 Id=10 WAITING on java.lang.ref.NativeReferenceQueue$Lock@59aa1d1c
	at java.base@21.0.4/java.lang.Object.wait0(Native Method)
	-  waiting on java.lang.ref.NativeReferenceQueue$Lock@59aa1d1c
	at java.base@21.0.4/java.lang.Object.wait(Object.java:366)
	at java.base@21.0.4/java.lang.Object.wait(Object.java:339)
	at java.base@21.0.4/java.lang.ref.NativeReferenceQueue.await(NativeReferenceQueue.java:48)
	at java.base@21.0.4/java.lang.ref.ReferenceQueue.remove0(ReferenceQueue.java:158)
	at java.base@21.0.4/java.lang.ref.NativeReferenceQueue.remove(NativeReferenceQueue.java:89)
	at java.base@21.0.4/java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:173)

"Signal Dispatcher" daemon prio=9 Id=11 RUNNABLE

"Notification Thread" daemon prio=9 Id=26 RUNNABLE

"Common-Cleaner" daemon prio=8 Id=27 TIMED_WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@169d4aba
	at java.base@21.0.4/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@169d4aba
	at java.base@21.0.4/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:269)
	at java.base@21.0.4/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1847)
	at java.base@21.0.4/java.lang.ref.ReferenceQueue.await(ReferenceQueue.java:71)
	at java.base@21.0.4/java.lang.ref.ReferenceQueue.remove0(ReferenceQueue.java:143)
	at java.base@21.0.4/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:218)
	at java.base@21.0.4/jdk.internal.ref.CleanerImpl.run(CleanerImpl.java:140)
	at java.base@21.0.4/java.lang.Thread.runWith(Thread.java:1596)
	...

"Decompiler thread" daemon prio=1 Id=33 WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@612bb755
	at java.base@21.0.4/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@612bb755
	at java.base@21.0.4/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
	at java.base@21.0.4/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
	at java.base@21.0.4/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
	at java.base@21.0.4/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
	at java.base@21.0.4/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1707)
	at java.base@21.0.4/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
	at app//org.spongepowered.asm.mixin.transformer.debug.RuntimeDecompilerAsync.run(RuntimeDecompilerAsync.java:66)
	...

"process reaper" daemon prio=10 Id=69 TIMED_WAITING on java.util.concurrent.SynchronousQueue$Transferer@6ba226cd
	at java.base@21.0.4/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.SynchronousQueue$Transferer@6ba226cd
	at java.base@21.0.4/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:410)
	at java.base@21.0.4/java.util.concurrent.LinkedTransferQueue$DualNode.await(LinkedTransferQueue.java:452)
	at java.base@21.0.4/java.util.concurrent.SynchronousQueue$Transferer.xferLifo(SynchronousQueue.java:194)
	at java.base@21.0.4/java.util.concurrent.SynchronousQueue.xfer(SynchronousQueue.java:233)
	at java.base@21.0.4/java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:336)
	at java.base@21.0.4/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1069)
	at java.base@21.0.4/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	...

"Java2D Disposer" daemon prio=10 Id=113 WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@62e99458
	at java.base@21.0.4/jdk.internal.misc.Unsafe.park(Native Method)
	-  waiting on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@62e99458
	at java.base@21.0.4/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
	at java.base@21.0.4/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
	at java.base@21.0.4/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
	at java.base@21.0.4/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
	at java.base@21.0.4/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1707)
	at java.base@21.0.4/java.lang.ref.ReferenceQueue.await(ReferenceQueue.java:67)
	at java.base@21.0.4/java.lang.ref.ReferenceQueue.remove0(ReferenceQueue.java:158)
	...

```