### PR TITLE
Refactor File I/O handling

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameLog.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameLog.java
@@ -1,6 +1,7 @@
 package de.gurkenlabs.litiengine;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
@@ -26,7 +27,7 @@ final class GameLog {
 
   void init() {
     LogManager.getLogManager().reset();
-    if (new File(LOGGING_CONFIG_FILE).exists()) {
+    if (Files.exists(Paths.get(LOGGING_CONFIG_FILE))) {
       System.setProperty("java.util.logging.config.file", LOGGING_CONFIG_FILE);
 
       try {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Configuration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Configuration.java
@@ -2,13 +2,12 @@ package de.gurkenlabs.litiengine.configuration;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.resources.Resources;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -122,10 +121,10 @@ public class Configuration {
    * exists, it creates a new configuration file in the application folder.
    */
   public void load() {
-    final File settingsFile = new File(this.getFileName());
+    final Path settingsFile = Paths.get(this.getFileName());
     try (InputStream settingsStream = Resources.get(this.getFileName())) {
-      if (!settingsFile.exists() && settingsStream == null || !settingsFile.isFile()) {
-        try (OutputStream out = new FileOutputStream(settingsFile)) {
+      if (!Files.exists(settingsFile) && settingsStream == null || !Files.isRegularFile(settingsFile)) {
+        try (OutputStream out = Files.newOutputStream(settingsFile)) {
           this.createDefaultSettingsFile(out);
         }
 
@@ -136,8 +135,8 @@ public class Configuration {
       log.log(Level.SEVERE, e.getMessage(), e);
     }
 
-    if (settingsFile.exists()) {
-      try (InputStream settingsStream = new FileInputStream(settingsFile)) {
+    if (Files.exists(settingsFile)) {
+      try (InputStream settingsStream = Files.newInputStream(settingsFile)) {
 
         final Properties properties = new Properties();
         BufferedInputStream stream;
@@ -161,8 +160,8 @@ public class Configuration {
    * @see Configuration#DEFAULT_CONFIGURATION_FILE_NAME
    */
   public void save() {
-    final File settingsFile = new File(this.getFileName());
-    try (OutputStream out = new FileOutputStream(settingsFile, false)) {
+    final Path settingsFile = Paths.get(this.getFileName());
+    try (OutputStream out = Files.newOutputStream(settingsFile, StandardOpenOption.CREATE_NEW)) {
       for (final ConfigurationGroup group : this.getConfigurationGroups()) {
         if (!Game.isDebug() && group.isDebug()) {
           continue;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Configuration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Configuration.java
@@ -3,7 +3,10 @@ package de.gurkenlabs.litiengine.configuration;
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.resources.Resources;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderComponent.java
@@ -5,6 +5,7 @@ import de.gurkenlabs.litiengine.gui.screens.Screen;
 import de.gurkenlabs.litiengine.resources.ImageFormat;
 import de.gurkenlabs.litiengine.util.TimeUtilities;
 import de.gurkenlabs.litiengine.util.io.ImageSerializer;
+
 import java.awt.Canvas;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -15,19 +16,25 @@ import java.awt.RenderingHints;
 import java.awt.Toolkit;
 import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The {@code RenderComponent} class extends {@link Canvas} and handles the rendering of the game screen, including managing fade effects, capturing
  * screenshots, and rendering the game cursor.
  */
 public class RenderComponent extends Canvas {
+  private static final Logger log = Logger.getLogger(RenderComponent.class.getName());
   /**
    * The default background color for the rendering component.
    */
@@ -287,13 +294,15 @@ public class RenderComponent extends Canvas {
   private void saveScreenshot(BufferedImage img) {
     try {
       String timeStamp = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
-      File folder = new File("./screenshots/");
-      if (!folder.exists()) {
-        folder.mkdirs();
+      Path folder = Paths.get("./screenshots/");
+      if (!Files.exists(folder)) {
+        Files.createDirectories(folder);
       }
       String path = "./screenshots/" + timeStamp + ImageFormat.PNG.toFileExtension();
       ImageSerializer.saveImage(path, img);
-    } finally {
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, e.getMessage(), e);
+    } finally{
       takeScreenShot = false;
     }
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ImageFormat.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ImageFormat.java
@@ -1,10 +1,10 @@
 package de.gurkenlabs.litiengine.resources;
 
-import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Contains all known image file-formats supported by the engine.
- * 
+ *
  * @see SoundFormat
  */
 public enum ImageFormat {
@@ -16,7 +16,7 @@ public enum ImageFormat {
 
   /**
    * Gets the {@code ImageFormat} of the specified format string.
-   * 
+   *
    * @param imageFormat
    *          The format string from which to extract the format.
    * @return The format of the specified string or {@code UNDEFINED} if not supported.
@@ -27,22 +27,22 @@ public enum ImageFormat {
 
   /**
    * Determines whether the extension of the specified file is supported by the engine.
-   * 
+   *
    * @param file
    *          The file to check for.
-   * 
+   *
    * @return True if the extension is part of this enum; otherwise false.
    */
-  public static boolean isSupported(File file) {
+  public static boolean isSupported(Path file) {
     return isSupported(file.toString());
   }
 
   /**
    * Determines whether the extension of the specified file is supported by the engine.
-   * 
+   *
    * @param fileName
    *          The name of the file to check for.
-   * 
+   *
    * @return True if the extension is part of this enum; otherwise false.
    */
   public static boolean isSupported(String fileName) {
@@ -56,7 +56,7 @@ public enum ImageFormat {
   /**
    * Converts this format instance to a file format string that can be used as an extension (e.g. .png).<br>
    * It adds a leading '.' to the lower-case string representation of this instance.
-   * 
+   *
    * @return The file extension string for this instance.
    */
   public String toFileExtension() {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -15,7 +15,6 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -15,16 +15,19 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -202,10 +205,10 @@ public class ResourceBundle implements Serializable {
       fileNameWithExtension += "." + FILE_EXTENSION;
     }
 
-    final File newFile = new File(fileNameWithExtension);
-    if (newFile.exists()) {
+    final Path newFile = Paths.get(fileNameWithExtension);
+    if (!Files.exists(newFile)) {
       try {
-        Files.delete(newFile.toPath().toAbsolutePath());
+        Files.delete(newFile);
       } catch (IOException e) {
         log.log(Level.WARNING, e.getMessage(), e);
       }
@@ -218,7 +221,7 @@ public class ResourceBundle implements Serializable {
     Collections.sort(this.getBluePrints());
     Collections.sort(this.getSounds());
 
-    try (FileOutputStream fileOut = new FileOutputStream(newFile, false)) {
+    try (OutputStream fileOut = Files.newOutputStream(newFile, StandardOpenOption.CREATE_NEW)) {
       final JAXBContext jaxbContext = XmlUtilities.getContext(ResourceBundle.class);
       final Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
       // output pretty printed

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resources.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resources.java
@@ -11,13 +11,13 @@ import de.gurkenlabs.litiengine.util.TimeUtilities;
 import java.awt.Font;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -330,7 +330,7 @@ public final class Resources {
       return new URL(name);
     } catch (MalformedURLException e) {
       try {
-        return (new File(name)).toURI().toURL();
+        return (Paths.get(name).toUri().toURL());
       } catch (MalformedURLException e1) {
         return null;
       }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SoundFormat.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SoundFormat.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.resources;
 
-import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Contains all known audio file-formats supported by the engine.
@@ -29,8 +29,8 @@ public enum SoundFormat {
    * @param file The file to check for.
    * @return True if the extension is part of this enum; otherwise false.
    */
-  public static boolean isSupported(File file) {
-    return isSupported(file.getName());
+  public static boolean isSupported(Path file) {
+    return isSupported(file.getFileName().toString());
   }
 
   /**

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Spritesheets.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Spritesheets.java
@@ -9,11 +9,11 @@ import de.gurkenlabs.litiengine.util.io.ImageSerializer;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -281,8 +281,10 @@ public final class Spritesheets {
         writer.write("\n");
 
         if (!metadataOnly) {
-          ImageSerializer.saveImage(Paths.get(new File(spriteInfoFile).getParentFile().getAbsolutePath(),
-              spritesheet.getName() + spritesheet.getImageFormat().toFileExtension()).toString(), spritesheet.getImage(),
+          Path spriteInfoPath = Paths.get(spriteInfoFile);
+          ImageSerializer.saveImage(
+            spriteInfoPath.resolveSibling(spritesheet.getName() + spritesheet.getImageFormat().toFileExtension()).toString(),
+            spritesheet.getImage(),
             spritesheet.getImageFormat());
         }
       }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/FileUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/FileUtilities.java
@@ -1,11 +1,14 @@
 package de.gurkenlabs.litiengine.util.io;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.*;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -46,28 +49,6 @@ public final class FileUtilities {
       return false;
     }
   }
-
-  public static boolean deleteDir(final File dir) {
-    if (dir.isDirectory()) {
-      final String[] children = dir.list();
-      for (int i = 0; i < children.length; i++) {
-        final boolean success = deleteDir(new File(dir, children[i]));
-        if (!success) {
-          return false;
-        }
-      }
-    }
-
-    try {
-      Files.delete(dir.toPath().toAbsolutePath());
-    } catch (IOException e) {
-      log.log(Level.SEVERE, e.getMessage(), e);
-      return false;
-    }
-
-    return true;
-  }
-
 
   public static List<String> findFilesByExtension(
       final List<String> fileNames, final Path dir, final String extension) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/FileUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/FileUtilities.java
@@ -5,13 +5,13 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 public final class FileUtilities {
   private static final Logger log = Logger.getLogger(FileUtilities.class.getName());
@@ -21,6 +21,30 @@ public final class FileUtilities {
 
   private FileUtilities() {
     throw new UnsupportedOperationException();
+  }
+
+  public static boolean deleteDir(final Path dir) {
+    //Support existing behavior for Paths.get("");
+    if(dir.toString().isBlank()){
+      try {
+        Files.delete(dir.toAbsolutePath());
+        return true;
+      } catch (IOException e) {
+        log.log(Level.SEVERE, e.getMessage(), e);
+        return false;
+      }
+    }
+
+    try (Stream<Path> paths = Files.walk(dir)) {
+      List<Path> toDelete = paths.sorted(Comparator.reverseOrder()).toList();
+      for(Path p : toDelete) {
+        Files.delete(p);
+      }
+      return true;
+    }catch (IOException e) {
+      log.log(Level.SEVERE, e.getMessage(), e);
+      return false;
+    }
   }
 
   public static boolean deleteDir(final File dir) {
@@ -44,11 +68,12 @@ public final class FileUtilities {
     return true;
   }
 
+
   public static List<String> findFilesByExtension(
       final List<String> fileNames, final Path dir, final String extension) {
     try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
       for (final Path path : stream) {
-        if (path.toFile().isDirectory()) {
+        if (Files.isDirectory(path)) {
           if (isBlackListedDirectory(path)) {
             continue;
           }
@@ -69,7 +94,7 @@ public final class FileUtilities {
       final List<String> fileNames, final Path dir, final String... files) {
     try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
       for (final Path path : stream) {
-        if (path.toFile().isDirectory()) {
+        if (Files.isDirectory(path)) {
           if (isBlackListedDirectory(path)) {
             continue;
           }
@@ -91,8 +116,8 @@ public final class FileUtilities {
     return fileNames;
   }
 
-  public static String getExtension(final File file) {
-    return getExtension(file.getAbsolutePath());
+  public static String getExtension(final Path file) {
+    return getExtension(file.toAbsolutePath().toString());
   }
 
   public static String getExtension(final String path) {
@@ -153,8 +178,8 @@ public final class FileUtilities {
     try {
       return getParentDirPath(new URI(uri));
     } catch (URISyntaxException e) {
-      String parent = new File(uri).getParent();
-      parent += File.separator;
+      String parent = Paths.get(uri).getParent().toAbsolutePath().toString();
+      parent += FileSystems.getDefault().getSeparator();
       return parent;
     }
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/ImageSerializer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/ImageSerializer.java
@@ -3,8 +3,11 @@ package de.gurkenlabs.litiengine.util.io;
 import de.gurkenlabs.litiengine.resources.ImageFormat;
 import de.gurkenlabs.litiengine.util.Imaging;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,14 +25,14 @@ public final class ImageSerializer {
   }
 
   public static BufferedImage loadImage(final String fileName) {
-    final File file = new File(fileName);
-    if (!file.exists()) {
+    final Path file = Paths.get(fileName);
+    if (!Files.exists(file)) {
       return null;
     }
 
     BufferedImage img;
-    try {
-      img = ImageIO.read(file);
+    try(InputStream is = Files.newInputStream(file)) {
+      img = ImageIO.read(is);
       if (img == null) {
         return null;
       }
@@ -53,7 +56,7 @@ public final class ImageSerializer {
   public static void saveImage(
       final String fileName, final BufferedImage image, ImageFormat imageFormat) {
     try {
-      final File file = new File(fileName);
+      final Path file = Paths.get(fileName);
       final String extension = FileUtilities.getExtension(fileName);
       Iterator<ImageWriter> iter = null;
       if (canWriteFormat(extension)) {
@@ -65,8 +68,8 @@ public final class ImageSerializer {
       final ImageWriter writer = iter.next();
       final ImageWriteParam iwp = writer.getDefaultWriteParam();
 
-      file.getParentFile().mkdirs();
-      try (final FileImageOutputStream output = new FileImageOutputStream(file.getAbsoluteFile())) {
+      Files.createDirectories(file.getParent());
+      try (final FileImageOutputStream output = new FileImageOutputStream(file.toAbsolutePath().toFile())) {
         writer.setOutput(output);
         final IIOImage outimage = new IIOImage(image, null, null);
         writer.write(null, outimage, iwp);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/StreamUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/StreamUtilities.java
@@ -1,12 +1,11 @@
 package de.gurkenlabs.litiengine.util.io;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -17,16 +16,12 @@ public final class StreamUtilities {
     throw new UnsupportedOperationException();
   }
 
-  public static void copy(final File file, final OutputStream out) throws IOException {
-    try (InputStream in = new FileInputStream(file)) {
-      copy(in, out);
-    }
+  public static void copy(final Path file, final OutputStream out) throws IOException {
+    Files.copy(file, out);
   }
 
-  public static void copy(final InputStream in, final File file) throws IOException {
-    try (OutputStream out = new FileOutputStream(file)) {
-      copy(in, out);
-    }
+  public static void copy(final InputStream in, final Path file) throws IOException {
+    Files.copy(in, file);
   }
 
   public static void copy(final InputStream in, final OutputStream out) throws IOException {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
@@ -1,11 +1,10 @@
 package de.gurkenlabs.litiengine.util.io;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -49,7 +48,7 @@ public final class XmlUtilities {
    *          The indentation with which the XML should be saved.
    */
   public static void saveWithCustomIndentation(
-      ByteArrayInputStream input, FileOutputStream fos, int indentation) {
+      ByteArrayInputStream input, OutputStream fos, int indentation) {
     try {
       TransformerFactory transformerFactory = TransformerFactory.newInstance();
       transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
@@ -98,14 +97,14 @@ public final class XmlUtilities {
     return cls.cast(um.unmarshal(path));
   }
 
-  public static File save(Object object, String fileName) {
+  public static Path save(Object object, String fileName) {
     if (fileName == null || fileName.isEmpty()) {
       return null;
     }
 
-    File newFile = new File(fileName);
+    Path newFile = Paths.get(fileName);
 
-    try (FileOutputStream fileOut = new FileOutputStream(newFile)) {
+    try (OutputStream fileOut = Files.newOutputStream(newFile)) {
       JAXBContext jaxbContext = getContext(object.getClass());
       if (jaxbContext == null) {
         return null;
@@ -132,7 +131,7 @@ public final class XmlUtilities {
     return newFile;
   }
 
-  public static File save(Object object, String fileName, String extension) {
+  public static Path save(Object object, String fileName, String extension) {
     String fileNameWithExtension = fileName;
     if (!fileNameWithExtension.endsWith("." + extension)) {
       fileNameWithExtension += "." + extension;

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/GameTest.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/GameTest.java
@@ -8,7 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import de.gurkenlabs.litiengine.test.GameTestSuite;
 
 import java.awt.AWTError;
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 
 import org.junit.jupiter.api.AfterEach;
@@ -23,11 +26,11 @@ public class GameTest {
   }
 
   @AfterEach
-  public void cleanup() {
-    final File configFile = new File(Game.config().getFileName());
-    if (configFile.exists()) {
-      configFile.delete();
-    }
+  public void cleanup() throws IOException {
+    final Path configFile = Paths.get(Game.config().getFileName());
+
+    Files.deleteIfExists(configFile);
+
 
     terminateGame();
   }

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/configuration/ConfigurationTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/configuration/ConfigurationTests.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.gurkenlabs.litiengine.util.io.FileUtilities;
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.AfterEach;
@@ -23,12 +26,10 @@ class ConfigurationTests {
   }
 
   @AfterEach
-  public void deleteConfigFile() {
+  public void deleteConfigFile() throws IOException {
     if (config != null) {
-      final File configFile = new File(config.getFileName());
-      if (configFile.exists()) {
-        assertTrue(configFile.delete());
-      }
+      final Path configFile = Paths.get(config.getFileName());
+      Files.deleteIfExists(configFile);
     }
   }
 
@@ -54,7 +55,7 @@ class ConfigurationTests {
     config.load();
 
     // act, assert
-    assertTrue(new File(config.getFileName()).exists());
+    assertTrue(Files.exists(Paths.get(config.getFileName())));
   }
 
   @Test
@@ -67,7 +68,7 @@ class ConfigurationTests {
     config.load();
 
     // assert
-    assertTrue(new File(testFileName).exists());
+    assertTrue(Files.exists(Paths.get(testFileName)));
   }
 
   @Test

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -23,14 +24,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class FileUtilitiesTests {
 
   @TempDir
-  File tempDir;
+  Path tempDir;
 
   @TempDir
   Path tempPath;
 
   @Test
   void testDeleteNoneDir() {
-    File dir = new File("/test/test2/");
+    Path dir = Paths.get("/test/test2/");
     assertFalse(FileUtilities.deleteDir(dir));
   }
 
@@ -41,20 +42,20 @@ class FileUtilitiesTests {
 
   @Test
   void testDeleteExistingDir() throws IOException {
-    File file1 = new File(tempDir, "file1.txt");
-    file1.createNewFile();
+    Path file1 = tempDir.resolve("file1.txt");
+    Files.createFile(file1);
     assertTrue(FileUtilities.deleteDir(tempDir));
   }
 
   @Test
   void testDeleteExistingDirNewFiles() throws IOException {
     // arrange
-    File file1 = new File(tempDir, "file1.txt");
-    File file2 = new File(tempDir, "file2.txt");
+    Path file1 = tempDir.resolve("file1.txt");
+    Path file2 = tempDir.resolve("file2.txt");
 
     // act
-    file1.createNewFile();
-    file2.createNewFile();
+    Files.createFile(file1);
+    Files.createFile(file2);
 
     // assert
     assertTrue(FileUtilities.deleteDir(tempDir));

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/util/io/FileUtilitiesTests.java
@@ -63,7 +63,7 @@ class FileUtilitiesTests {
 
   @Test
   void testDeleteExistingDirNoChildren() {
-    assertFalse(FileUtilities.deleteDir(new File("")));
+    assertFalse(FileUtilities.deleteDir(Paths.get("")));
   }
 
   @Test

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/Program.java
@@ -7,9 +7,9 @@ import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.utiliti.components.Editor;
 import de.gurkenlabs.utiliti.handlers.DebugCrasher;
 import de.gurkenlabs.utiliti.swing.UI;
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class Program {
@@ -56,7 +56,7 @@ public class Program {
             handleArgs(args);
             String gameFile = Editor.preferences().getLastGameFile();
             if (!Editor.instance().fileLoaded() && gameFile != null && !gameFile.isEmpty()) {
-              Editor.instance().load(new File(gameFile.trim()), false);
+              Editor.instance().load(Paths.get(gameFile.trim()), false);
             }
           },
           args);
@@ -92,7 +92,7 @@ public class Program {
       return;
     }
 
-    File f = new File(gameFile);
+    Path f = Paths.get(gameFile);
     Editor.instance().load(f, false);
   }
 }

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/FileDrop.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/FileDrop.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.Serial;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.List;
@@ -241,7 +243,7 @@ public class FileDrop {
           List<File> fileList = (List<File>) tr.getTransferData(DataFlavor.javaFileListFlavor);
 
           // Convert list to array
-          File[] filesTemp = new File[fileList.size()];
+          Path[] filesTemp = new Path[fileList.size()];
           fileList.toArray(filesTemp);
 
           // Alert listener to drop.
@@ -333,27 +335,27 @@ public class FileDrop {
       return ok;
     }
 
-    private static File[] createFileArray(BufferedReader bReader) {
+    private static Path[] createFileArray(BufferedReader bReader) {
       try {
-        List<File> list = new ArrayList<>();
+        List<Path> list = new ArrayList<>();
         String line;
         while ((line = bReader.readLine()) != null) {
           try {
             // kde seems to append a 0 char to the end of the reader
             if (ZERO_CHAR_STRING.equals(line))
               continue;
-            File file = new File(new URI(line));
+            Path file = Paths.get(new URI(line));
             list.add(file);
           } catch (Exception ex) {
             LOG.log(Level.SEVERE, "Error with {0}: {1}", new String[] {line, ex.getMessage()});
           }
         }
 
-        return list.toArray(new File[list.size()]);
+        return list.toArray(new Path[list.size()]);
       } catch (IOException ex) {
         LOG.log(Level.SEVERE, "FileDrop: IOException");
       }
-      return new File[0];
+      return new Path[0];
     }
   }
 
@@ -373,7 +375,7 @@ public class FileDrop {
      *          An array of {@code File}s that were dropped.
      * @since 1.0
      */
-    void filesDropped(File[] files);
+    void filesDropped(Path[] files);
   }
 
   /**

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/controllers/AssetList.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/controllers/AssetList.java
@@ -7,6 +7,7 @@ import de.gurkenlabs.utiliti.swing.AssetPanel;
 import de.gurkenlabs.utiliti.swing.AssetTree;
 import de.gurkenlabs.utiliti.swing.FileDrop;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JScrollPane;
@@ -28,8 +29,8 @@ public class AssetList extends JSplitPane implements Controller {
     new FileDrop(
         assetPanel,
         files -> {
-          List<File> droppedImages = new ArrayList<>();
-          for (File file : files) {
+          List<Path> droppedImages = new ArrayList<>();
+          for (Path file : files) {
             // handle dropped image
             if (ImageFormat.isSupported(file)) {
               droppedImages.add(file);
@@ -37,7 +38,7 @@ public class AssetList extends JSplitPane implements Controller {
           }
 
           if (!droppedImages.isEmpty()) {
-            Editor.instance().importSpriteSheets(droppedImages.toArray(new File[droppedImages.size()]));
+            Editor.instance().importSpriteSheets(droppedImages.toArray(new Path[0]));
           }
         });
 

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/SpritesheetImportPanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/SpritesheetImportPanel.java
@@ -8,6 +8,7 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -76,9 +77,9 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
     this.initModel();
   }
 
-  public SpritesheetImportPanel(File... files) {
+  public SpritesheetImportPanel(Path... files) {
     this();
-    for (File file : files) {
+    for (Path file : files) {
       fileListModel.addElement(new SpriteFileWrapper(file));
     }
 
@@ -575,9 +576,9 @@ public class SpritesheetImportPanel extends JPanel implements IUpdateable {
       this.updateSprite();
     }
 
-    public SpriteFileWrapper(File file) {
+    public SpriteFileWrapper(Path file) {
       this(
-        Resources.images().get(file.getAbsolutePath()),
+        Resources.images().get(file),
         FileUtilities.getFileName(file.getName()));
       this.spriteWidth = this.width;
       this.spriteHeight = this.height;

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/XmlExportDialog.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/XmlExportDialog.java
@@ -6,6 +6,7 @@ import de.gurkenlabs.litiengine.util.io.XmlUtilities;
 import de.gurkenlabs.utiliti.components.Editor;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,8 +44,8 @@ public final class XmlExportDialog {
 
       int result = chooser.showSaveDialog(Game.window().getRenderComponent());
       if (result == JFileChooser.APPROVE_OPTION) {
-        File newFile = XmlUtilities.save(object, chooser.getSelectedFile().toString(), extension);
-        String dir = FileUtilities.getParentDirPath(newFile.getAbsolutePath());
+        Path newFile = XmlUtilities.save(object, chooser.getSelectedFile().toString(), extension);
+        String dir = FileUtilities.getParentDirPath(newFile.toAbsolutePath().toString());
         consumer.accept(dir);
         log.log(Level.INFO, "Exported {0} {1} to {2}", new Object[] {name, filename, newFile});
       }

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/XmlImportDialog.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/dialogs/XmlImportDialog.java
@@ -2,17 +2,19 @@ package de.gurkenlabs.utiliti.swing.dialogs;
 
 import de.gurkenlabs.utiliti.swing.UI;
 import java.io.File;
+import java.nio.file.Path;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.swing.JFileChooser;
 
 public final class XmlImportDialog {
   private XmlImportDialog() {}
 
-  public static void importXml(String name, Consumer<File> consumer) {
+  public static void importXml(String name, Consumer<Path> consumer) {
     importXml(name, consumer, "xml");
   }
 
-  public static void importXml(String name, Consumer<File> consumer, String... extensions) {
+  public static void importXml(String name, Consumer<Path> consumer, String... extensions) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < extensions.length; i++) {
       String extension = extensions[i];
@@ -26,7 +28,7 @@ public final class XmlImportDialog {
 
     sb.append(" - " + name + " XML");
     if (EditorFileChooser.showFileDialog(sb.toString(), "Import " + name + " XML", true, extensions) == JFileChooser.APPROVE_OPTION) {
-      for (File file : EditorFileChooser.instance().getSelectedFiles()) {
+      for (Path file : Stream.of(EditorFileChooser.instance().getSelectedFiles()).map(File::toPath).toList()) {
         consumer.accept(file);
       }
 

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/menus/FileMenu.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/swing/menus/FileMenu.java
@@ -6,6 +6,7 @@ import de.gurkenlabs.utiliti.components.Editor;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JMenu;
@@ -74,7 +75,7 @@ public final class FileMenu extends JMenu {
         fileButton.addActionListener(
             a -> {
               log.log(Level.INFO, "load {0}", fileButton.getText());
-              Editor.instance().load(new File(fileButton.getText()), false);
+              Editor.instance().load(Paths.get(fileButton.getText()), false);
             });
 
         recentFiles.add(fileButton);


### PR DESCRIPTION
This resolves  [Issue 817](https://github.com/gurkenlabs/litiengine/issues/817)

I have replaced all of the references of java.io.File with java.nio.Path where applicable. Some of the Java AWT methods and classes still use java.io.File so those were left in place.

Additionally I have replaced new FileInputStream(File) references with Files.newInputStream(Path)