### PR TITLE
Fix: Graceful exception handling for resource loading (#317)

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -108,16 +108,26 @@ public class ResourceBundle implements Serializable {
       URL fileUrl = filePath.toUri().toURL();
 
       for (Tileset tileset : gameFile.getTilesets()) {
-        tileset.finish(fileUrl);
+        try {
+          tileset.finish(fileUrl);
+        } catch (Exception e) {
+          log.log(Level.WARNING, "Failed to finish tileset: {0} - {1}",
+            new Object[] {tileset.getName(), e.getMessage()});
+        }
       }
 
       for (TmxMap map : gameFile.getMaps()) {
-        for (final ITileset tileset : map.getTilesets()) {
-          if (tileset instanceof Tileset ts) {
-            ts.load(gameFile.getTilesets());
+        try {
+          for (final ITileset tileset : map.getTilesets()) {
+            if (tileset instanceof Tileset ts) {
+              ts.load(gameFile.getTilesets());
+            }
           }
+          map.finish(fileUrl);
+        } catch (Exception e) {
+          log.log(Level.WARNING, "Failed to load map: {0} - {1}",
+            new Object[] {map.getName(), e.getMessage()});
         }
-        map.finish(fileUrl);
       }
 
       return gameFile;
@@ -155,16 +165,26 @@ public class ResourceBundle implements Serializable {
       }
 
       for (Tileset tileset : gameFile.getTilesets()) {
-        tileset.finish(fileUrl);
+        try {
+          tileset.finish(fileUrl);
+        } catch (Exception e) {
+          log.log(Level.WARNING, "Failed to finish tileset: {0} - {1}",
+            new Object[] {tileset.getName(), e.getMessage()});
+        }
       }
 
       for (TmxMap map : gameFile.getMaps()) {
-        for (final ITileset tileset : map.getTilesets()) {
-          if (tileset instanceof Tileset ts) {
-            ts.load(gameFile.getTilesets());
+        try {
+          for (final ITileset tileset : map.getTilesets()) {
+            if (tileset instanceof Tileset ts) {
+              ts.load(gameFile.getTilesets());
+            }
           }
+          map.finish(fileUrl);
+        } catch (Exception e) {
+          log.log(Level.WARNING, "Failed to load map: {0} - {1}",
+            new Object[] {map.getName(), e.getMessage()});
         }
-        map.finish(fileUrl);
       }
 
       return gameFile;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resources.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resources.java
@@ -163,38 +163,69 @@ public final class Resources {
       return;
     }
 
-    file.getMaps().parallelStream().forEach(m -> Resources.maps().add(m.getName(), m));
+    final List<String> failures = Collections.synchronizedList(new ArrayList<>());
+
+    file.getMaps().parallelStream().forEach(m -> {
+      try {
+        Resources.maps().add(m.getName(), m);
+      } catch (Exception e) {
+        failures.add("Map '%s': %s".formatted(m.getName(), e.getMessage()));
+        log.log(Level.WARNING, "Failed to load map: {0} - {1}", new Object[] {m.getName(), e.getMessage()});
+      }
+    });
 
     log.log(Level.INFO, "{0} maps loaded from {1}", new Object[] {file.getMaps().size(), gameResourceFile});
 
-    file.getBluePrints().parallelStream().forEach(m -> Resources.blueprints().add(m.getName(), m));
+    file.getBluePrints().parallelStream().forEach(m -> {
+      try {
+        Resources.blueprints().add(m.getName(), m);
+      } catch (Exception e) {
+        failures.add("Blueprint '%s': %s".formatted(m.getName(), e.getMessage()));
+        log.log(Level.WARNING, "Failed to load blueprint: {0} - {1}", new Object[] {m.getName(), e.getMessage()});
+      }
+    });
 
     log.log(Level.INFO, "{0} blueprints loaded from {1}", new Object[] {file.getBluePrints().size(), gameResourceFile});
 
     int tileCnt = 0;
     for (final Tileset tileset : file.getTilesets()) {
-      if (Resources.tilesets().contains(tileset.getName())) {
-        continue;
-      }
+      try {
+        if (Resources.tilesets().contains(tileset.getName())) {
+          continue;
+        }
 
-      Resources.tilesets().add(tileset.getName(), tileset);
-      tileCnt++;
+        Resources.tilesets().add(tileset.getName(), tileset);
+        tileCnt++;
+      } catch (Exception e) {
+        failures.add("Tileset '%s': %s".formatted(tileset.getName(), e.getMessage()));
+        log.log(Level.WARNING, "Failed to load tileset: {0} - {1}", new Object[] {tileset.getName(), e.getMessage()});
+      }
     }
 
     log.log(Level.INFO, "{0} tilesets loaded from {1}", new Object[] {tileCnt, gameResourceFile});
 
     final List<Spritesheet> loadedSprites = Collections.synchronizedList(new ArrayList<>());
     file.getSpriteSheets().parallelStream().forEach(spriteSheetInfo -> {
-      final Spritesheet sprite = Resources.spritesheets().load(spriteSheetInfo);
-      loadedSprites.add(sprite);
+      try {
+        final Spritesheet sprite = Resources.spritesheets().load(spriteSheetInfo);
+        loadedSprites.add(sprite);
+      } catch (Exception e) {
+        failures.add("Spritesheet '%s': %s".formatted(spriteSheetInfo.getName(), e.getMessage()));
+        log.log(Level.WARNING, "Failed to load spritesheet: {0} - {1}", new Object[] {spriteSheetInfo.getName(), e.getMessage()});
+      }
     });
 
     log.log(Level.INFO, "{0} spritesheets loaded from {1}", new Object[] {loadedSprites.size(), gameResourceFile});
 
     final List<Sound> loadedSounds = Collections.synchronizedList(new ArrayList<>());
     file.getSounds().parallelStream().forEach(soundResource -> {
-      final Sound sound = Resources.sounds().load(soundResource);
-      loadedSounds.add(sound);
+      try {
+        final Sound sound = Resources.sounds().load(soundResource);
+        loadedSounds.add(sound);
+      } catch (Exception e) {
+        failures.add("Sound '%s': %s".formatted(soundResource.getName(), e.getMessage()));
+        log.log(Level.WARNING, "Failed to load sound: {0} - {1}", new Object[] {soundResource.getName(), e.getMessage()});
+      }
     });
 
     log.log(Level.INFO, "{0} sounds loaded from {1}", new Object[] {loadedSounds.size(), gameResourceFile});
@@ -212,7 +243,17 @@ public final class Resources {
     log.log(Level.INFO, "{0} sprites loaded to memory", new Object[] {spriteload});
 
     for (final EmitterData emitter : file.getEmitters()) {
-      EmitterLoader.load(emitter);
+      try {
+        EmitterLoader.load(emitter);
+      } catch (Exception e) {
+        failures.add("Emitter: %s".formatted(e.getMessage()));
+        log.log(Level.WARNING, "Failed to load emitter: {0}", e.getMessage());
+      }
+    }
+
+    if (!failures.isEmpty()) {
+      log.log(Level.SEVERE, "{0} resource(s) failed to load from {1}:\n{2}",
+        new Object[] {failures.size(), gameResourceFile, String.join("\n", failures)});
     }
 
     final double loadTime = TimeUtilities.nanoToMs(System.nanoTime() - loadStart);

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/resources/ResourceLoadResilienceTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/resources/ResourceLoadResilienceTests.java
@@ -1,0 +1,182 @@
+package de.gurkenlabs.litiengine.resources;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import de.gurkenlabs.litiengine.graphics.Spritesheet;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that resource loading is resilient to individual failures.
+ * When a single resource fails to load, the remaining resources should still be loaded successfully.
+ */
+class ResourceLoadResilienceTests {
+
+  @BeforeEach
+  void setUp() {
+    Resources.spritesheets().clear();
+  }
+
+  @Test
+  void testSpritesheetLoadContinuesAfterFailure() {
+    // Arrange: create a valid spritesheet resource
+    BufferedImage validImage = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+    SpritesheetResource validResource = new SpritesheetResource(validImage, "valid-sprite.png", 16, 16);
+
+    // Create an invalid spritesheet resource with corrupt image data
+    SpritesheetResource invalidResource = new SpritesheetResource();
+    invalidResource.setName("corrupt-sprite");
+    invalidResource.setImage("this-is-not-valid-base64-image-data!!!");
+    invalidResource.setWidth(16);
+    invalidResource.setHeight(16);
+
+    // Create another valid resource
+    BufferedImage validImage2 = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+    SpritesheetResource validResource2 = new SpritesheetResource(validImage2, "valid-sprite2.png", 32, 32);
+
+    List<SpritesheetResource> resources = List.of(validResource, invalidResource, validResource2);
+
+    // Act: load all resources using the same pattern as Resources.load()
+    final List<Spritesheet> loadedSprites = Collections.synchronizedList(new ArrayList<>());
+    final List<String> failures = Collections.synchronizedList(new ArrayList<>());
+
+    assertDoesNotThrow(() -> {
+      resources.forEach(spriteSheetInfo -> {
+        try {
+          final Spritesheet sprite = Resources.spritesheets().load(spriteSheetInfo);
+          if (sprite != null) {
+            loadedSprites.add(sprite);
+          }
+        } catch (Exception e) {
+          failures.add("Spritesheet '%s': %s".formatted(spriteSheetInfo.getName(), e.getMessage()));
+        }
+      });
+    });
+
+    // Assert: valid resources were loaded despite the invalid one
+    assertTrue(loadedSprites.size() >= 1, "At least one valid spritesheet should have been loaded");
+    assertTrue(failures.size() <= 1, "At most one failure should have been recorded");
+  }
+
+  @Test
+  void testSpritesheetLoadWithNullImage() {
+    // A SpritesheetResource with null image should not throw and not interrupt loading
+    SpritesheetResource nullImageResource = new SpritesheetResource();
+    nullImageResource.setName("null-image-sprite");
+    nullImageResource.setImage(null);
+    nullImageResource.setWidth(16);
+    nullImageResource.setHeight(16);
+
+    BufferedImage validImage = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+    SpritesheetResource validResource = new SpritesheetResource(validImage, "valid-after-null.png", 16, 16);
+
+    List<SpritesheetResource> resources = List.of(nullImageResource, validResource);
+
+    final List<Spritesheet> loadedSprites = Collections.synchronizedList(new ArrayList<>());
+    final List<String> failures = Collections.synchronizedList(new ArrayList<>());
+
+    assertDoesNotThrow(() -> {
+      resources.forEach(spriteSheetInfo -> {
+        try {
+          final Spritesheet sprite = Resources.spritesheets().load(spriteSheetInfo);
+          if (sprite != null) {
+            loadedSprites.add(sprite);
+          }
+        } catch (Exception e) {
+          failures.add("Spritesheet '%s': %s".formatted(spriteSheetInfo.getName(), e.getMessage()));
+        }
+      });
+    });
+
+    // The valid resource should still have loaded
+    assertTrue(loadedSprites.size() >= 1, "Valid spritesheet should have loaded after null-image resource");
+  }
+
+  @Test
+  void testParallelStreamLoadContinuesAfterFailure() {
+    // Simulate the exact pattern from Resources.load() with parallelStream
+    BufferedImage validImage1 = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+    BufferedImage validImage2 = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+    BufferedImage validImage3 = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+
+    SpritesheetResource valid1 = new SpritesheetResource(validImage1, "parallel-valid1.png", 16, 16);
+    SpritesheetResource valid2 = new SpritesheetResource(validImage2, "parallel-valid2.png", 16, 16);
+    SpritesheetResource valid3 = new SpritesheetResource(validImage3, "parallel-valid3.png", 16, 16);
+
+    // Corrupt resource in the middle
+    SpritesheetResource corrupt = new SpritesheetResource();
+    corrupt.setName("parallel-corrupt");
+    corrupt.setImage("DEFINITELY_NOT_A_VALID_IMAGE_ENCODING");
+    corrupt.setWidth(16);
+    corrupt.setHeight(16);
+
+    List<SpritesheetResource> resources = List.of(valid1, corrupt, valid2, valid3);
+
+    final List<Spritesheet> loadedSprites = Collections.synchronizedList(new ArrayList<>());
+    final List<String> failures = Collections.synchronizedList(new ArrayList<>());
+
+    // This should NOT throw - the try/catch in the forEach prevents stream abort
+    assertDoesNotThrow(() -> {
+      resources.parallelStream().forEach(spriteSheetInfo -> {
+        try {
+          final Spritesheet sprite = Resources.spritesheets().load(spriteSheetInfo);
+          if (sprite != null) {
+            loadedSprites.add(sprite);
+          }
+        } catch (Exception e) {
+          failures.add("Spritesheet '%s': %s".formatted(spriteSheetInfo.getName(), e.getMessage()));
+        }
+      });
+    });
+
+    // At least the valid ones should have been loaded
+    assertTrue(loadedSprites.size() >= 2, 
+        "Expected at least 2 valid spritesheets loaded but got " + loadedSprites.size());
+  }
+
+  @Test
+  void testWithoutTryCatchParallelStreamAborts() {
+    // This test demonstrates that WITHOUT the fix, a parallelStream WOULD abort.
+    // We verify that an exception in a parallelStream().forEach() propagates up
+    // when there's no try/catch (i.e., the original buggy behavior).
+
+    List<Integer> items = List.of(1, 2, 0, 3, 4);
+    final List<Integer> results = Collections.synchronizedList(new ArrayList<>());
+
+    // Without try/catch - this WILL throw (demonstrating the original bug)
+    boolean threwException = false;
+    try {
+      items.parallelStream().forEach(item -> {
+        int result = 10 / item; // will throw ArithmeticException for item=0
+        results.add(result);
+      });
+    } catch (Exception e) {
+      threwException = true;
+    }
+
+    // With try/catch - this will NOT throw (demonstrating the fix)
+    final List<Integer> safeResults = Collections.synchronizedList(new ArrayList<>());
+    final List<String> errors = Collections.synchronizedList(new ArrayList<>());
+
+    assertDoesNotThrow(() -> {
+      items.parallelStream().forEach(item -> {
+        try {
+          int result = 10 / item;
+          safeResults.add(result);
+        } catch (Exception e) {
+          errors.add("Division by " + item + ": " + e.getMessage());
+        }
+      });
+    });
+
+    // The safe version should have processed all non-zero items
+    assertTrue(safeResults.size() >= 3,
+        "Expected at least 3 results with try/catch but got " + safeResults.size());
+    assertTrue(errors.size() == 1, "Expected exactly 1 error for division by zero");
+  }
+}


### PR DESCRIPTION
## Context
This PR addresses the issue where the entire resource importing process (like loading Spritesheets) is aborted if a single resource throws a `ResourceLoadException`. 
Closes #317.

## Summary
To solve this, I modified the resource loading logic (specifically targeting areas like `Resources.java` and `ResourceBundle.java`). Instead of letting unhandled runtime exceptions break the parallel streams and sequential loops, the individual load operations are now wrapped in `try-catch` blocks. 

If a specific resource fails to load, the exception is caught, the failure is recorded, and the loop continues processing the remaining resources. This ensures that a single corrupted or missing file doesn't crash the entire engine's startup or loading phase.

## Additional thoughts
This is my first open-source contribution as part of a high school technical practice. I tried to follow the "load as much as possible and report at the end" approach. Any feedback on the code style, concurrency handling, or implementation details is highly appreciated!

## Quality assurance
Make sure your code holds up to quality standards. 
- [ ] Wrote unit tests for new behaviour
- [x] Documented new code thoroughly
- [x] Fixed issues that would be regarded as code smells by sonarcloud
- [x] Ensured integrity of the build pipeline