### PR TITLE
Add context menu and keyboard shortcuts to utiLITI Resources tab

### DIFF
--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/AssetPanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/AssetPanel.java
@@ -12,6 +12,9 @@ import de.gurkenlabs.litiengine.resources.SoundResource;
 import de.gurkenlabs.litiengine.resources.SpritesheetResource;
 import de.gurkenlabs.utiliti.controller.WrapLayout;
 import de.gurkenlabs.utiliti.model.Icons;
+import de.gurkenlabs.utiliti.view.menus.AssetPanelPopupMenu;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.util.Collections;
 import java.util.List;
 import javax.swing.Icon;
@@ -21,6 +24,12 @@ import javax.swing.border.EmptyBorder;
 
 public class AssetPanel extends JPanel {
 
+  public enum AssetType {
+    SPRITESHEET, TILESET, EMITTER, BLUEPRINT, SOUND
+  }
+
+  private AssetType currentType;
+
   public AssetPanel() {
     WrapLayout layout = new WrapLayout();
     layout.setVgap(5);
@@ -29,9 +38,32 @@ public class AssetPanel extends JPanel {
     this.setLayout(layout);
 
     this.setBorder(new EmptyBorder(5, 5, 5, 5));
+
+    MouseAdapter popupHandler = new MouseAdapter() {
+      @Override public void mousePressed(MouseEvent e) {
+        maybeShowPopup(e);
+      }
+
+      @Override public void mouseReleased(MouseEvent e) {
+        maybeShowPopup(e);
+      }
+    };
+    this.addMouseListener(popupHandler);
+  }
+
+  public AssetType getCurrentType() {
+    return currentType;
+  }
+
+  private void maybeShowPopup(MouseEvent e) {
+    if (!e.isPopupTrigger()) {
+      return;
+    }
+    new AssetPanelPopupMenu(currentType).show(this, e.getX(), e.getY());
   }
 
   public void loadSprites(List<SpritesheetResource> infos) {
+    this.currentType = AssetType.SPRITESHEET;
     this.load(
       () -> {
         for (SpritesheetResource info : infos.stream().sorted().toList()) {
@@ -52,6 +84,7 @@ public class AssetPanel extends JPanel {
   }
 
   public void loadTilesets(List<Tileset> tilesets) {
+    this.currentType = AssetType.TILESET;
     this.load(
       () -> {
         Collections.sort(tilesets);
@@ -65,6 +98,7 @@ public class AssetPanel extends JPanel {
   }
 
   public void loadEmitters(List<EmitterData> emitters) {
+    this.currentType = AssetType.EMITTER;
     this.load(
       () -> {
         Collections.sort(emitters);
@@ -78,6 +112,7 @@ public class AssetPanel extends JPanel {
   }
 
   public void loadBlueprints(List<Blueprint> blueprints) {
+    this.currentType = AssetType.BLUEPRINT;
     this.load(
       () -> {
         Collections.sort(blueprints);
@@ -91,6 +126,7 @@ public class AssetPanel extends JPanel {
   }
 
   public void loadSounds(List<SoundResource> sounds) {
+    this.currentType = AssetType.SOUND;
     this.load(
       () -> {
         Collections.sort(sounds);

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/AssetPanelItem.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/AssetPanelItem.java
@@ -358,7 +358,11 @@ public class AssetPanelItem extends JPanel {
     return details;
   }
 
-  private void deleteAsset() {
+  public Object getOrigin() {
+    return origin;
+  }
+
+  public void deleteAsset() {
     if (origin == null) {
       return;
     }
@@ -413,7 +417,7 @@ public class AssetPanelItem extends JPanel {
     return JOptionPane.OK_OPTION == getDeleteDialog(assetType, assetName);
   }
 
-  private void addEntity() {
+  public void addEntity() {
     if (Game.world().environment() == null || Game.world().camera() == null) {
       return;
     }
@@ -474,7 +478,7 @@ public class AssetPanelItem extends JPanel {
     }
   }
 
-  private void editAsset() {
+  public void editAsset() {
     if (!(origin instanceof SpritesheetResource)) {
       return;
     }
@@ -495,7 +499,7 @@ public class AssetPanelItem extends JPanel {
     Editor.instance().loadSpriteSheets(Editor.instance().getGameFile().getSpriteSheets(), true);
   }
 
-  private void exportAsset() {
+  public void exportAsset() {
     if (origin instanceof Tileset tileset) {
       exportTileset(tileset);
     } else if (origin instanceof SpritesheetResource spritesheetResource) {
@@ -589,7 +593,7 @@ public class AssetPanelItem extends JPanel {
     return chooser;
   }
 
-  private boolean canAdd() {
+  public boolean canAdd() {
     if (origin instanceof SpritesheetResource spritesheetResource) {
       return PropPanel.getIdentifierBySpriteName(spritesheetResource.getName()) != null
         || CreaturePanel.getCreatureSpriteName(spritesheetResource.getName()) != null;

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/AssetPanelItem.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/AssetPanelItem.java
@@ -21,6 +21,7 @@ import de.gurkenlabs.utiliti.controller.Editor;
 import de.gurkenlabs.utiliti.controller.UndoManager;
 import de.gurkenlabs.utiliti.model.Icons;
 import de.gurkenlabs.utiliti.view.dialogs.XmlExportDialog;
+import de.gurkenlabs.utiliti.view.menus.AssetPanelItemPopupMenu;
 import java.awt.BasicStroke;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -30,10 +31,12 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -229,6 +232,29 @@ public class AssetPanelItem extends JPanel {
         deleteAsset();
       }
     });
+
+    getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "addAsset");
+    getActionMap().put("addAsset", new AbstractAction() {
+      @Override public void actionPerformed(ActionEvent ae) {
+        if (canAdd()) {
+          addEntity();
+        }
+      }
+    });
+
+    getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_F2, 0), "editAsset");
+    getActionMap().put("editAsset", new AbstractAction() {
+      @Override public void actionPerformed(ActionEvent ae) {
+        editAsset();
+      }
+    });
+
+    getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_DOWN_MASK), "exportAsset");
+    getActionMap().put("exportAsset", new AbstractAction() {
+      @Override public void actionPerformed(ActionEvent ae) {
+        exportAsset();
+      }
+    });
   }
 
   private void setupFocusHandling() {
@@ -260,6 +286,15 @@ public class AssetPanelItem extends JPanel {
         repaint();
       }
 
+      @Override public void mousePressed(MouseEvent e) {
+        requestFocus();
+        maybeShowPopup(e);
+      }
+
+      @Override public void mouseReleased(MouseEvent e) {
+        maybeShowPopup(e);
+      }
+
       @Override public void mouseClicked(MouseEvent e) {
         requestFocus();
         if (e.getClickCount() == 2 && SwingUtilities.isLeftMouseButton(e)) {
@@ -271,6 +306,15 @@ public class AssetPanelItem extends JPanel {
     addMouseListener(mouseHandler);
     iconLabel.addMouseListener(mouseHandler);
     nameLabel.addMouseListener(mouseHandler);
+  }
+
+  private void maybeShowPopup(MouseEvent e) {
+    if (!e.isPopupTrigger()) {
+      return;
+    }
+    AssetPanelItemPopupMenu menu = new AssetPanelItemPopupMenu(this);
+    Point p = SwingUtilities.convertPoint(e.getComponent(), e.getPoint(), this);
+    menu.show(this, p.x, p.y);
   }
 
   private void setupButtonActions() {

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/menus/AssetPanelItemPopupMenu.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/menus/AssetPanelItemPopupMenu.java
@@ -1,0 +1,69 @@
+package de.gurkenlabs.utiliti.view.menus;
+
+import de.gurkenlabs.litiengine.environment.tilemap.xml.Blueprint;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.MapObject;
+import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
+import de.gurkenlabs.litiengine.graphics.emitters.xml.EmitterData;
+import de.gurkenlabs.litiengine.resources.Resources;
+import de.gurkenlabs.litiengine.resources.SoundResource;
+import de.gurkenlabs.litiengine.resources.SpritesheetResource;
+import de.gurkenlabs.utiliti.model.Icons;
+import de.gurkenlabs.utiliti.view.components.AssetPanelItem;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.KeyStroke;
+
+@SuppressWarnings("serial")
+public final class AssetPanelItemPopupMenu extends JPopupMenu {
+
+  public AssetPanelItemPopupMenu(AssetPanelItem item) {
+    Object origin = item.getOrigin();
+    String typeKey = getTypeKey(origin);
+
+    JMenuItem add = new JMenuItem(Resources.strings().get("contextmenu_resource_add"), Icons.ADD_16);
+    add.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
+    add.addActionListener(e -> item.addEntity());
+    add.setEnabled(item.canAdd());
+
+    JMenuItem edit = new JMenuItem(Resources.strings().get("contextmenu_resource_edit_" + typeKey), Icons.PENCIL_16);
+    edit.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F2, 0));
+    edit.addActionListener(e -> item.editAsset());
+    edit.setEnabled(origin instanceof SpritesheetResource);
+
+    JMenuItem export = new JMenuItem(Resources.strings().get("contextmenu_resource_export_" + typeKey), Icons.EXPORT_16);
+    export.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_DOWN_MASK));
+    export.addActionListener(e -> item.exportAsset());
+
+    JMenuItem delete = new JMenuItem(Resources.strings().get("contextmenu_resource_delete_" + typeKey), Icons.DELETE_16);
+    delete.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
+    delete.addActionListener(e -> item.deleteAsset());
+    delete.setEnabled(!(origin instanceof Tileset));
+
+    add(add);
+    add(edit);
+    add(export);
+    addSeparator();
+    add(delete);
+  }
+
+  private static String getTypeKey(Object origin) {
+    if (origin instanceof SpritesheetResource) {
+      return "spritesheet";
+    }
+    if (origin instanceof Tileset) {
+      return "tileset";
+    }
+    if (origin instanceof EmitterData) {
+      return "emitter";
+    }
+    if (origin instanceof Blueprint || origin instanceof MapObject) {
+      return "blueprint";
+    }
+    if (origin instanceof SoundResource) {
+      return "sound";
+    }
+    return "asset";
+  }
+}

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/menus/AssetPanelPopupMenu.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/menus/AssetPanelPopupMenu.java
@@ -1,0 +1,57 @@
+package de.gurkenlabs.utiliti.view.menus;
+
+import de.gurkenlabs.litiengine.resources.Resources;
+import de.gurkenlabs.utiliti.controller.Editor;
+import de.gurkenlabs.utiliti.view.components.AssetPanel;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+
+@SuppressWarnings("serial")
+public final class AssetPanelPopupMenu extends JPopupMenu {
+
+  public AssetPanelPopupMenu(AssetPanel.AssetType currentType) {
+    boolean projectLoaded = Editor.instance().getCurrentResourceFile() != null;
+
+    if (currentType != null) {
+      switch (currentType) {
+        case SPRITESHEET -> {
+          addImportItem("menu_assets_importSprite", Editor.instance()::importSpriteSheets, projectLoaded);
+          addImportItem("menu_assets_importTextureAtlas", Editor.instance()::importTextureAtlas, projectLoaded);
+          addImportItem("menu_assets_importSpriteFile", Editor.instance()::importSpriteFile, projectLoaded);
+        }
+        case TILESET -> addImportItem("menu_assets_importTilesets", Editor.instance()::importTilesets, projectLoaded);
+        case EMITTER -> addImportItem("menu_assets_importEmitters", Editor.instance()::importEmitters, projectLoaded);
+        case BLUEPRINT -> addImportItem("menu_assets_importBlueprints", Editor.instance()::importBlueprints, projectLoaded);
+        case SOUND -> addImportItem("menu_assets_importSounds", Editor.instance()::importSounds, projectLoaded);
+      }
+      addSeparator();
+    }
+
+    JMenu importAll = new JMenu(Resources.strings().get("menu_assets_import"));
+    addToMenu(importAll, "menu_assets_importSprite", Editor.instance()::importSpriteSheets, projectLoaded);
+    addToMenu(importAll, "menu_assets_importTextureAtlas", Editor.instance()::importTextureAtlas, projectLoaded);
+    addToMenu(importAll, "menu_assets_importSpriteFile", Editor.instance()::importSpriteFile, projectLoaded);
+    importAll.addSeparator();
+    addToMenu(importAll, "menu_assets_importSounds", Editor.instance()::importSounds, projectLoaded);
+    importAll.addSeparator();
+    addToMenu(importAll, "menu_assets_importEmitters", Editor.instance()::importEmitters, projectLoaded);
+    addToMenu(importAll, "menu_assets_importBlueprints", Editor.instance()::importBlueprints, projectLoaded);
+    addToMenu(importAll, "menu_assets_importTilesets", Editor.instance()::importTilesets, projectLoaded);
+    add(importAll);
+  }
+
+  private void addImportItem(String key, Runnable action, boolean enabled) {
+    JMenuItem item = new JMenuItem(Resources.strings().get(key));
+    item.addActionListener(e -> action.run());
+    item.setEnabled(enabled);
+    add(item);
+  }
+
+  private static void addToMenu(JMenu menu, String key, Runnable action, boolean enabled) {
+    JMenuItem item = new JMenuItem(Resources.strings().get(key));
+    item.addActionListener(e -> action.run());
+    item.setEnabled(enabled);
+    menu.add(item);
+  }
+}

--- a/utiliti/src/main/localization/strings.properties
+++ b/utiliti/src/main/localization/strings.properties
@@ -298,6 +298,26 @@ assetpanel_confirmdelete_blueprint_title=Delete Blueprint?
 assetpanel_confirmdelete_sound=Do you really want to delete the sound [{0}]?
 assetpanel_confirmdelete_sound_title=Delete Sound?
 
+contextmenu_resource_add=Add to environment
+contextmenu_resource_edit_spritesheet=Edit Spritesheet
+contextmenu_resource_edit_tileset=Edit Tileset
+contextmenu_resource_edit_emitter=Edit Emitter
+contextmenu_resource_edit_blueprint=Edit Blueprint
+contextmenu_resource_edit_sound=Edit Sound
+contextmenu_resource_edit_asset=Edit
+contextmenu_resource_delete_spritesheet=Delete Spritesheet
+contextmenu_resource_delete_tileset=Delete Tileset
+contextmenu_resource_delete_emitter=Delete Emitter
+contextmenu_resource_delete_blueprint=Delete Blueprint
+contextmenu_resource_delete_sound=Delete Sound
+contextmenu_resource_delete_asset=Delete
+contextmenu_resource_export_spritesheet=Export Spritesheet
+contextmenu_resource_export_tileset=Export Tileset
+contextmenu_resource_export_emitter=Export Emitter
+contextmenu_resource_export_blueprint=Export Blueprint
+contextmenu_resource_export_sound=Export Sound
+contextmenu_resource_export_asset=Export
+
 hud_saveProject=Save project
 hud_saveProjectMessage=Save pending changes to game project
 hud_revertChanges=Revert changes


### PR DESCRIPTION
Closes #770

  ## Context
  The utiLITI Resources tab currently exposes per-resource actions only
  through icon buttons that appear on hover, and import actions only
  through the top-level `Resources → Import` menu. Issue #770 requests a
  right-click context menu — context-sensitive to the resource type —
  that surfaces these existing actions in-place, plus keyboard shortcuts
  for the same actions.

  ## Summary
  Implemented in three layered commits so the diff is easy to review:

  **1. `Expose AssetPanelItem action methods and origin for popup wiring`**
  Pure refactor. Changes `addEntity`, `editAsset`, `deleteAsset`,
  `exportAsset`, and `canAdd` from `private` to `public` and adds a
  `getOrigin()` accessor so external view code can drive per-item actions
  without duplicating logic. No behavior change.

  **2. `Add per-item context menu and keyboard shortcuts to Resources tab`**
  Right-click on a resource item opens a new `AssetPanelItemPopupMenu`
  (`view/menus/AssetPanelItemPopupMenu.java`) with:

  | Action | Shortcut | Enabled for |
  |---|---|---|
  | Add to environment | `Enter` | Spritesheets, Emitters, Blueprints |
  | Edit | `F2` | Spritesheets (where `editAsset` is implemented) |
  | Export | `Ctrl+E` | All types |
  | Delete | `Delete` | All except Tilesets |

  The keyboard shortcuts are wired via `InputMap`/`ActionMap` on
  `AssetPanelItem`, matching the existing `Delete` binding. Right-click
  detection uses `MouseEvent.isPopupTrigger()` in both `mousePressed` and
  `mouseReleased` for cross-platform correctness, matching the pattern
  used by `CanvasPopupMenu` in `UI.java`.

  Per-type i18n keys (`contextmenu_resource_{edit,delete,export}_<type>`)
  are added so menu labels read e.g. "Edit Spritesheet" / "Delete Sound"
  rather than generic ones, as suggested in the issue.

  **3. `Add context-sensitive import menu to Resources panel background`**
  Right-click on the empty area of the Resources panel opens a new
  `AssetPanelPopupMenu`. To know which imports to highlight, `AssetPanel`
  now tracks the active resource category via a new `AssetType` enum
  updated inside each `load*()` method. The popup shows the matching
  import action(s) as primary entries (e.g. Sprites / Texture Atlas /
  Sprite Info when viewing Spritesheets), plus a full `Import →` submenu
  mirroring the existing `ResourcesMenu` for discoverability.

  All new code follows the patterns already present in the codebase:
  `JPopupMenu` subclasses, `Resources.strings().get(key)` for labels,
  `Icons.*` for icons, and `Editor.instance().*` for action wiring.

  ## Additional thoughts
  - No unit tests are included. The new code is pure Swing UI wiring
    (`JPopupMenu`, `MouseListener`, `InputMap`); the codebase has no
    existing harness for Swing component testing and adding one felt out
    of scope. Manual verification covered: right-click on each resource
    type, every shortcut, empty-area right-click for each category, and
    enable/disable states.
  - The existing `btnEdit` toolbar button is still hidden in code
    (`AssetPanelItem.java`). I intentionally did not change that; the
    context menu now provides the only entry point to `editAsset()`,
    matching the prior intent of hiding the button while keeping the
    underlying functionality available.
  - `MapObject` is used in `getTypeKey` as a fallback alias for
    `Blueprint` because `AssetPanel.loadBlueprints` declares the loop
    variable as `MapObject` (Blueprint extends MapObject).

  ## Quality assurance
  - [ ] Wrote unit tests for new behaviour
  - [x] Documented new code thoroughly
  - [x] Fixed issues that would be regarded as code smells by sonarcloud
  - [x] Ensured integrity of the build pipeline (`./gradlew :utiliti:compileJava` and `:utiliti:test` both pass)