### PR TITLE
feat: select overlapping utiliti objects

### DIFF
--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/controller/MapComponent.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/controller/MapComponent.java
@@ -512,6 +512,39 @@ public class MapComponent extends GuiComponent {
       canvasLocation.getY() / renderScale));
   }
 
+  public List<IMapObject> getMapObjectsAt(Point2D canvasLocation) {
+    if (canvasLocation == null || mapIsNull() || Game.world().camera() == null) {
+      return List.of();
+    }
+
+    return mapObjectsAt(
+      Game.world().environment().getMap(),
+      toMapLocation(canvasLocation, Game.world().camera()));
+  }
+
+  static List<IMapObject> mapObjectsAt(IMap map, Point2D location) {
+    if (map == null || location == null) {
+      return List.of();
+    }
+
+    Rectangle2D point = new Rectangle2D.Double(location.getX(), location.getY(), 0, 0);
+    List<IMapObject> matches = new ArrayList<>();
+    for (IMapObjectLayer layer : map.getMapObjectLayers()) {
+      if (layer == null || !isLayerEffectivelyVisible(map, layer)) {
+        continue;
+      }
+
+      for (IMapObject mapObject : layer.getMapObjects()) {
+        if (mapObject != null
+          && MapObjectType.get(mapObject.getType()) != null
+          && GeometricUtilities.intersects(point, mapObject.getBoundingBox())) {
+          matches.add(mapObject);
+        }
+      }
+    }
+    return matches;
+  }
+
   public boolean addMapObjectFromAsset(Object asset, Point2D location) {
     if (asset == null || location == null || UI.getLayerController() == null
       || UI.getLayerController().getCurrentLayer() == null) {
@@ -928,6 +961,9 @@ public class MapComponent extends GuiComponent {
       final IMapObject currentFocus = getFocusedMapObject();
       if (mapObject != null && mapObject.equals(currentFocus)
         || mapObject == null && currentFocus == null) {
+        if (mapObject != null) {
+          this.setSelection(mapObject, clearSelection);
+        }
         return;
       }
 
@@ -1856,6 +1892,9 @@ public class MapComponent extends GuiComponent {
       active.mouseDragged(e);
       return;
     }
+    if (e == null || e.getEvent() == null || !isPrimaryButtonDown(e.getEvent())) {
+      return;
+    }
     if (!this.hasFocus() || mapIsNull()) {
       return;
     }
@@ -1888,6 +1927,10 @@ public class MapComponent extends GuiComponent {
       default -> {
       }
     }
+  }
+
+  static boolean isPrimaryButtonDown(MouseEvent event) {
+    return event != null && (event.getModifiersEx() & InputEvent.BUTTON1_DOWN_MASK) != 0;
   }
 
   void handleMouseReleased(ComponentMouseEvent e) {

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/UI.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/UI.java
@@ -7,7 +7,9 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.GameListener;
 import de.gurkenlabs.litiengine.environment.tilemap.ILayer;
 import de.gurkenlabs.litiengine.environment.tilemap.IMap;
+import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.ITileLayer;
+import de.gurkenlabs.litiengine.environment.tilemap.MapObjectType;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.Tileset;
 import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap;
 import de.gurkenlabs.litiengine.resources.SpritesheetResource;
@@ -47,6 +49,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.KeyboardFocusManager;
 import java.awt.RenderingHints;
 import java.awt.Toolkit;
 import java.awt.dnd.DnDConstants;
@@ -77,6 +80,7 @@ import javax.swing.JComponent;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
@@ -99,6 +103,10 @@ public final class UI {
 
   private static final List<JComponent> orphanComponents = new CopyOnWriteArrayList<>();
   private static JPopupMenu canvasPopup;
+  private static JPopupMenu objectSelectionPopup;
+  private static Canvas objectSelectionPopupInvoker;
+  private static int objectSelectionPopupX;
+  private static int objectSelectionPopupY;
   private static AssetList assetComponent;
 
   private static MapObjectInspector mapObjectPanel;
@@ -942,22 +950,67 @@ public final class UI {
   private static void initPopupMenu(Canvas canvas) {
     canvasPopup = new CanvasPopupMenu();
     addOrphanComponent(canvasPopup);
+    objectSelectionPopup = new JPopupMenu();
+    addOrphanComponent(objectSelectionPopup);
+    KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(event -> {
+      if (event.getID() == KeyEvent.KEY_RELEASED
+        && event.getKeyCode() == KeyEvent.VK_ALT
+        && objectSelectionPopup.isVisible()) {
+        SwingUtilities.invokeLater(() -> {
+          if (!objectSelectionPopup.isVisible() && objectSelectionPopupInvoker != null) {
+            objectSelectionPopup.show(
+              objectSelectionPopupInvoker, objectSelectionPopupX, objectSelectionPopupY);
+          }
+        });
+      }
+      return false;
+    });
 
     canvas.addMouseListener(new MouseAdapter() {
       @Override public void mousePressed(MouseEvent e) {
-        if (e.isPopupTrigger()) {
-          Editor.instance().getMapComponent().setTransformMode(TransformMode.NONE);
-          canvasPopup.show(canvas, e.getX(), e.getY());
-        }
+        showCanvasPopup(canvas, e);
       }
 
       @Override public void mouseReleased(MouseEvent e) {
-        if (e.isPopupTrigger()) {
-          Editor.instance().getMapComponent().setTransformMode(TransformMode.NONE);
-          canvasPopup.show(canvas, e.getX(), e.getY());
-        }
+        showCanvasPopup(canvas, e);
       }
     });
+  }
+
+  private static void showCanvasPopup(Canvas canvas, MouseEvent event) {
+    if (!event.isPopupTrigger()) {
+      return;
+    }
+
+    var mapComponent = Editor.instance().getMapComponent();
+    mapComponent.setTransformMode(TransformMode.NONE);
+    if (!event.isAltDown()) {
+      canvasPopup.show(canvas, event.getX(), event.getY());
+      return;
+    }
+
+    List<IMapObject> mapObjects = mapComponent.getMapObjectsAt(event.getPoint());
+    if (mapObjects.size() == 1) {
+      mapComponent.setFocus(mapObjects.getFirst(), true);
+    } else if (mapObjects.size() > 1) {
+      objectSelectionPopup.removeAll();
+      for (IMapObject mapObject : mapObjects) {
+        MapObjectType type = MapObjectType.get(mapObject.getType());
+        String name = mapObject.getName() == null || mapObject.getName().isBlank()
+          ? type.name() : mapObject.getName();
+        JMenuItem item = new JMenuItem(name + " (#" + mapObject.getId() + ")", Icons.forMapObjectType(type));
+        item.addActionListener(e -> {
+          objectSelectionPopupInvoker = null;
+          mapComponent.setFocus(mapObject, true);
+        });
+        objectSelectionPopup.add(item);
+      }
+      objectSelectionPopupInvoker = canvas;
+      objectSelectionPopupX = event.getX();
+      objectSelectionPopupY = event.getY();
+      objectSelectionPopup.show(canvas, event.getX(), event.getY());
+    }
+    event.consume();
   }
 
   public static void initLookAndFeel() {

--- a/utiliti/src/test/java/de/gurkenlabs/utiliti/controller/MapComponentTest.java
+++ b/utiliti/src/test/java/de/gurkenlabs/utiliti/controller/MapComponentTest.java
@@ -164,6 +164,16 @@ class MapComponentTest {
   }
 
   @Test
+  void onlyPrimaryButtonDragsCanTransformMapObjects() {
+    MouseEvent event = mock(MouseEvent.class);
+    when(event.getModifiersEx()).thenReturn(InputEvent.BUTTON1_DOWN_MASK);
+    assertTrue(MapComponent.isPrimaryButtonDown(event));
+
+    when(event.getModifiersEx()).thenReturn(InputEvent.BUTTON3_DOWN_MASK | InputEvent.ALT_DOWN_MASK);
+    assertTrue(!MapComponent.isPrimaryButtonDown(event));
+  }
+
+  @Test
   void altArrowDoesNotTransformMapObjects() {
     assertTrue(MapComponent.shouldHandleArrowTransform(0));
     assertTrue(!MapComponent.shouldHandleArrowTransform(InputEvent.ALT_DOWN_MASK));
@@ -178,6 +188,33 @@ class MapComponentTest {
     map.addLayer(group);
 
     assertTrue(MapComponent.containsLayer(map, child));
+  }
+
+  @Test
+  void findsOverlappingVisibleMapObjectsAtLocation() {
+    TmxMap map = new TmxMap(MapOrientations.ORTHOGONAL);
+    MapObject first = mapObject(1, 0, 0, 10, 10);
+    MapObject second = mapObject(2, 5, 5, 10, 10);
+    MapObject outside = mapObject(3, 20, 20, 10, 10);
+    MapObjectLayer layer = new MapObjectLayer();
+    layer.addMapObject(first);
+    layer.addMapObject(second);
+    layer.addMapObject(outside);
+    map.addLayer(layer);
+
+    assertEquals(List.of(first, second), MapComponent.mapObjectsAt(map, new Point2D.Double(7, 7)));
+  }
+
+  @Test
+  void excludesObjectsOnHiddenLayersAtLocation() {
+    TmxMap map = new TmxMap(MapOrientations.ORTHOGONAL);
+    MapObject mapObject = mapObject(1, 0, 0, 10, 10);
+    MapObjectLayer layer = new MapObjectLayer();
+    layer.addMapObject(mapObject);
+    layer.setVisible(false);
+    map.addLayer(layer);
+
+    assertTrue(MapComponent.mapObjectsAt(map, new Point2D.Double(5, 5)).isEmpty());
   }
 
   @Test
@@ -219,5 +256,16 @@ class MapComponentTest {
     layer.addMapObject(object);
     map.addLayer(layer);
     return map;
+  }
+
+  private static MapObject mapObject(int id, float x, float y, float width, float height) {
+    MapObject mapObject = new MapObject();
+    mapObject.setId(id);
+    mapObject.setType(MapObjectType.PROP.name());
+    mapObject.setX(x);
+    mapObject.setY(y);
+    mapObject.setWidth(width);
+    mapObject.setHeight(height);
+    return mapObject;
   }
 }


### PR DESCRIPTION
- Add Alt + right-click selection for overlapping map objects.
- Preserve the chooser when Alt is released.
- Prevent right-button drags from starting object transforms.
- Add regression tests for overlap detection and mouse-button handling.