### PR TITLE
feat: select prop and creature animations

### DIFF
--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/CreaturePanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/CreaturePanel.java
@@ -28,6 +28,7 @@ import javax.swing.SwingUtilities;
 public class CreaturePanel extends PropertyPanel {
   public static final String WALK_SPRITE_TOKEN = "walk";
   private final JComboBox<JLabel> comboBoxSpriteSheets;
+  private final JComboBox<JLabel> comboBoxAnimations;
   private final JComboBox<Direction> comboBoxDirection;
   private final JCheckBox checkBoxScale;
   private final JCheckBox checkBoxStartDead;
@@ -42,6 +43,8 @@ public class CreaturePanel extends PropertyPanel {
     super("panel_creature", Icons.CREATURE_16);
     this.comboBoxSpriteSheets = new SearchableSpriteComboBox();
     this.comboBoxSpriteSheets.setRenderer(new LabelListCellRenderer());
+    this.comboBoxAnimations = new JComboBox<>();
+    this.comboBoxAnimations.setRenderer(new LabelListCellRenderer());
     this.animationPreview = new SpriteAnimationPreview(editAction);
 
     this.comboBoxDirection = new JComboBox<>();
@@ -52,10 +55,11 @@ public class CreaturePanel extends PropertyPanel {
 
     setLayout(this.createLayout());
     setupChangedListeners();
-    this.comboBoxSpriteSheets.addActionListener(e -> updateSpritePreview());
+    this.comboBoxSpriteSheets.addActionListener(e -> refreshAnimationChoices());
+    this.comboBoxAnimations.addActionListener(e -> updateSpritePreview());
     this.comboBoxDirection.addActionListener(
-        e -> SwingUtilities.invokeLater(this::updateSpritePreview));
-    this.checkBoxStartDead.addActionListener(e -> updateSpritePreview());
+        e -> SwingUtilities.invokeLater(this::refreshAnimationChoices));
+    this.checkBoxStartDead.addActionListener(e -> refreshAnimationChoices());
 
     // if images are cleared (e.g. resource reload), repopulate on next bind
     Resources.images().addClearedListener(() -> this.creaturesLoaded = false);
@@ -64,6 +68,7 @@ public class CreaturePanel extends PropertyPanel {
   private void clearSpriteCache() {
     this.creaturesLoaded = false;
     this.comboBoxSpriteSheets.removeAllItems();
+    this.comboBoxAnimations.removeAllItems();
   }
 
   public static String getCreatureSpriteName(String name) {
@@ -111,7 +116,7 @@ public class CreaturePanel extends PropertyPanel {
   protected void setControlValues(IMapObject mapObject) {
     // first try regular selection by stored property (base name expected)
     selectSpriteSheet(this.comboBoxSpriteSheets, mapObject);
-    updateSpritePreview();
+    refreshAnimationChoices();
 
     // fallback: if nothing selected and a full spritesheet name was stored earlier, try its base
     if (this.comboBoxSpriteSheets.getSelectedItem() == null) {
@@ -192,6 +197,7 @@ public class CreaturePanel extends PropertyPanel {
     LayoutItem[] layoutItems = new LayoutItem[] {
       new LayoutItem(this.animationPreview, 140),
       new LayoutItem("panel_sprite", this.comboBoxSpriteSheets),
+      new LayoutItem("panel_animation", this.comboBoxAnimations),
       new LayoutItem("panel_direction", this.comboBoxDirection),
     };
     return this.createLayout(layoutItems, this.checkBoxScale, this.checkBoxStartDead);
@@ -200,11 +206,45 @@ public class CreaturePanel extends PropertyPanel {
   private void updateSpritePreview() {
     String name = SearchableSpriteComboBox.selectedText(this.comboBoxSpriteSheets);
     Direction direction = (Direction) this.comboBoxDirection.getSelectedItem();
-    String source = selectPreviewSpriteName(
-        name, direction, this.checkBoxStartDead.isSelected(), Resources.spritesheets().getAll());
+    String source = SearchableSpriteComboBox.selectedText(this.comboBoxAnimations);
+    if (source == null) {
+      source = selectPreviewSpriteName(name, direction, this.checkBoxStartDead.isSelected(), Resources.spritesheets().getAll());
+    }
     Spritesheet spritesheet = source != null ? Resources.spritesheets().get(source) : null;
     SpritesheetResource resource = resolveOriginalResource(source);
     this.animationPreview.setSpritesheet(spritesheet, resource);
+  }
+
+  private void refreshAnimationChoices() {
+    String name = SearchableSpriteComboBox.selectedText(this.comboBoxSpriteSheets);
+    Map<String, String> animations = getAnimationSpriteNames(name, Resources.spritesheets().getAll());
+    populateComboBoxWithSprites(this.comboBoxAnimations, animations);
+    Direction direction = (Direction) this.comboBoxDirection.getSelectedItem();
+    selectAnimation(selectPreviewSpriteName(name, direction, this.checkBoxStartDead.isSelected(), Resources.spritesheets().getAll()));
+    updateSpritePreview();
+  }
+
+  static Map<String, String> getAnimationSpriteNames(String base, java.util.Collection<Spritesheet> spritesheets) {
+    Map<String, String> animations = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    if (base == null) {
+      return animations;
+    }
+    for (Spritesheet spritesheet : spritesheets) {
+      if (base.equalsIgnoreCase(getCreatureSpriteName(spritesheet.getName()))) {
+        animations.put(spritesheet.getName(), spritesheet.getName());
+      }
+    }
+    return animations;
+  }
+
+  private void selectAnimation(String name) {
+    for (int i = 0; i < this.comboBoxAnimations.getItemCount(); i++) {
+      JLabel item = this.comboBoxAnimations.getItemAt(i);
+      if (item != null && item.getText().equalsIgnoreCase(name)) {
+        this.comboBoxAnimations.setSelectedItem(item);
+        return;
+      }
+    }
   }
 
   @Override

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/PropPanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/PropPanel.java
@@ -4,6 +4,7 @@ import de.gurkenlabs.litiengine.entities.Material;
 import de.gurkenlabs.litiengine.entities.Rotation;
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 import de.gurkenlabs.litiengine.environment.tilemap.MapObjectProperty;
+import de.gurkenlabs.litiengine.graphics.Spritesheet;
 import de.gurkenlabs.litiengine.graphics.animation.PropAnimationController;
 import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.utiliti.controller.SpriteVariantSelector;
@@ -13,6 +14,7 @@ import java.awt.FlowLayout;
 import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.awt.LayoutManager;
+import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.swing.DefaultComboBoxModel;
@@ -23,6 +25,7 @@ import javax.swing.JPanel;
 
 public class PropPanel extends PropertyPanel {
   private final JComboBox<JLabel> comboBoxSpriteSheets;
+  private final JComboBox<JLabel> comboBoxAnimations;
   private final JComboBox<Material> comboBoxMaterial;
   private final JCheckBox chckbxShadow;
   private final JComboBox<Rotation> comboBoxRotation;
@@ -42,6 +45,8 @@ public class PropPanel extends PropertyPanel {
 
     this.comboBoxSpriteSheets = new SearchableSpriteComboBox();
     this.comboBoxSpriteSheets.setRenderer(new LabelListCellRenderer());
+    this.comboBoxAnimations = new JComboBox<>();
+    this.comboBoxAnimations.setRenderer(new LabelListCellRenderer());
     this.animationPreview = new SpriteAnimationPreview();
 
     this.comboBoxMaterial = new JComboBox<>();
@@ -59,12 +64,14 @@ public class PropPanel extends PropertyPanel {
 
     setLayout(this.createLayout());
     setupChangedListeners();
-    this.comboBoxSpriteSheets.addActionListener(e -> updateSpritePreview());
+    this.comboBoxSpriteSheets.addActionListener(e -> refreshAnimationChoices());
+    this.comboBoxAnimations.addActionListener(e -> updateSpritePreview());
   }
 
   private void clearSpriteCache() {
     this.propsLoaded = false;
     this.comboBoxSpriteSheets.removeAllItems();
+    this.comboBoxAnimations.removeAllItems();
   }
 
   public static String getIdentifierBySpriteName(String spriteName) {
@@ -98,7 +105,7 @@ public class PropPanel extends PropertyPanel {
   @Override
   protected void setControlValues(IMapObject mapObject) {
     selectSpriteSheet(this.comboBoxSpriteSheets, mapObject);
-    updateSpritePreview();
+    refreshAnimationChoices();
 
     var material = Material.UNDEFINED;
     if(mapObject.hasCustomProperty(MapObjectProperty.PROP_MATERIAL)){
@@ -158,9 +165,46 @@ public class PropPanel extends PropertyPanel {
 
   private void updateSpritePreview() {
     String name = SearchableSpriteComboBox.selectedText(this.comboBoxSpriteSheets);
-    String source = name != null ? SpriteVariantSelector.selectBasePropSpriteNames(Resources.spritesheets().getAll()).get(name) : null;
+    String source = SearchableSpriteComboBox.selectedText(this.comboBoxAnimations);
+    if (source == null && name != null) {
+      source = SpriteVariantSelector.selectBasePropSpriteNames(Resources.spritesheets().getAll()).get(name);
+    }
     var spritesheet = source != null ? Resources.spritesheets().get(source) : null;
     this.animationPreview.setSpritesheet(spritesheet, source);
+  }
+
+  private void refreshAnimationChoices() {
+    String name = SearchableSpriteComboBox.selectedText(this.comboBoxSpriteSheets);
+    Map<String, String> animations = getAnimationSpriteNames(name, Resources.spritesheets().getAll());
+    populateComboBoxWithSprites(this.comboBoxAnimations, animations);
+    String defaultAnimation = name != null
+        ? SpriteVariantSelector.selectBasePropSpriteNames(Resources.spritesheets().getAll()).get(name)
+        : null;
+    selectAnimation(defaultAnimation);
+    updateSpritePreview();
+  }
+
+  static Map<String, String> getAnimationSpriteNames(String identifier, Collection<Spritesheet> spritesheets) {
+    Map<String, String> animations = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    if (identifier == null) {
+      return animations;
+    }
+    for (var spritesheet : spritesheets) {
+      if (identifier.equalsIgnoreCase(getIdentifierBySpriteName(spritesheet.getName()))) {
+        animations.put(spritesheet.getName(), spritesheet.getName());
+      }
+    }
+    return animations;
+  }
+
+  private void selectAnimation(String name) {
+    for (int i = 0; i < this.comboBoxAnimations.getItemCount(); i++) {
+      JLabel item = this.comboBoxAnimations.getItemAt(i);
+      if (item != null && item.getText().equalsIgnoreCase(name)) {
+        this.comboBoxAnimations.setSelectedItem(item);
+        return;
+      }
+    }
   }
 
   private LayoutManager createLayout() {
@@ -168,6 +212,7 @@ public class PropPanel extends PropertyPanel {
       new LayoutItem[] {
         new LayoutItem(this.animationPreview, 140),
         new LayoutItem("panel_sprite", this.comboBoxSpriteSheets),
+        new LayoutItem("panel_animation", this.comboBoxAnimations),
         new LayoutItem("panel_material", this.comboBoxMaterial),
         new LayoutItem("panel_rotation", this.comboBoxRotation),
       };

--- a/utiliti/src/main/localization/strings.properties
+++ b/utiliti/src/main/localization/strings.properties
@@ -136,6 +136,7 @@ panel_name=Name
 panel_value=Value
 
 panel_sprite=Sprite
+panel_animation=Animation
 panel_rotation=Rotation
 
 panel_creature=Creature

--- a/utiliti/src/main/localization/strings_de_DE.properties
+++ b/utiliti/src/main/localization/strings_de_DE.properties
@@ -136,6 +136,7 @@ panel_name=Name
 panel_value=Wert
 
 panel_sprite=Sprite
+panel_animation=Animation
 panel_rotation=Drehung
 
 panel_creature=Kreatur

--- a/utiliti/src/main/localization/strings_es_ES.properties
+++ b/utiliti/src/main/localization/strings_es_ES.properties
@@ -136,6 +136,7 @@ panel_name=Nombre
 panel_value=Valor
 
 panel_sprite=Sprite
+panel_animation=Animacion
 panel_rotation=Rotación
 
 panel_creature=Criatura

--- a/utiliti/src/main/localization/strings_fr_FR.properties
+++ b/utiliti/src/main/localization/strings_fr_FR.properties
@@ -136,6 +136,7 @@ panel_name=Nom
 panel_value=Valeur
 
 panel_sprite=Sprite
+panel_animation=Animation
 panel_rotation=Rotation
 
 panel_creature=Créature

--- a/utiliti/src/test/java/de/gurkenlabs/utiliti/view/components/CreaturePanelTest.java
+++ b/utiliti/src/test/java/de/gurkenlabs/utiliti/view/components/CreaturePanelTest.java
@@ -104,6 +104,21 @@ class CreaturePanelTest {
   }
 
   @Test
+  void animationPickerIncludesAllCreatureStatesIncludingDeath() {
+    List<Spritesheet> sheets = List.of(
+        new Spritesheet(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "goblin-idle-down.png", 1, 1),
+        new Spritesheet(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "goblin-move-down.png", 1, 1),
+        new Spritesheet(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "goblin-dead.png", 1, 1));
+
+    assertEquals(List.of("goblin-dead", "goblin-idle-down", "goblin-move-down"),
+        List.copyOf(CreaturePanel.getAnimationSpriteNames("goblin", sheets).keySet()));
+
+    Resources.spritesheets().remove("goblin-idle-down");
+    Resources.spritesheets().remove("goblin-move-down");
+    Resources.spritesheets().remove("goblin-dead");
+  }
+
+  @Test
   @ResourceLock("default-locale")
   void previewSpriteLookupIsLocaleIndependent() {
     Locale originalLocale = Locale.getDefault();

--- a/utiliti/src/test/java/de/gurkenlabs/utiliti/view/components/PropPanelTest.java
+++ b/utiliti/src/test/java/de/gurkenlabs/utiliti/view/components/PropPanelTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import de.gurkenlabs.litiengine.graphics.Spritesheet;
 import de.gurkenlabs.litiengine.resources.Resources;
 import java.awt.image.BufferedImage;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class PropPanelTest {
@@ -19,5 +20,20 @@ class PropPanelTest {
     assertEquals(1, panel.getSpriteItemCountForTest());
     Resources.spritesheets().clear();
     assertEquals(0, panel.getSpriteItemCountForTest());
+  }
+
+  @Test
+  void animationPickerIncludesAllPropStates() {
+    List<Spritesheet> sheets = List.of(
+        new Spritesheet(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "prop-crate-intact.png", 1, 1),
+        new Spritesheet(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "prop-crate-damaged.png", 1, 1),
+        new Spritesheet(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), "prop-crate-destroyed.png", 1, 1));
+
+    assertEquals(List.of("prop-crate-damaged", "prop-crate-destroyed", "prop-crate-intact"),
+        List.copyOf(PropPanel.getAnimationSpriteNames("crate", sheets).keySet()));
+
+    Resources.spritesheets().remove("prop-crate-intact");
+    Resources.spritesheets().remove("prop-crate-damaged");
+    Resources.spritesheets().remove("prop-crate-destroyed");
   }
 }


### PR DESCRIPTION
Adds prop and creature animation pickers in Utiliti, including creature death sprites. Preserves base sprite persistence and adds coverage for all state variants.