### PR TITLE
Restrict GUI mouse events to topmost components

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 /**
  * The abstract Class GuiComponent provides all properties and methods needed for screens, built-in,
@@ -88,6 +90,7 @@ public abstract class GuiComponent
 
   private boolean isHovered;
   private boolean isPressed;
+  private boolean clickPending;
   private boolean isSelected;
   private String name;
   private boolean suspended;
@@ -103,6 +106,7 @@ public abstract class GuiComponent
   private boolean visible;
   private Point2D location;
   private Rectangle2D boundingBox;
+  private GuiComponent parent;
 
   private double relativeX;
   private double relativeY;
@@ -130,7 +134,7 @@ public abstract class GuiComponent
    * @param height the height
    */
   protected GuiComponent(final double x, final double y, final double width, final double height) {
-    this.components = new CopyOnWriteArrayList<>();
+    this.components = new ChildComponentList();
     this.clickConsumer = new CopyOnWriteArrayList<>();
     this.hoverConsumer = new CopyOnWriteArrayList<>();
     this.mousePressedConsumer = new CopyOnWriteArrayList<>();
@@ -242,7 +246,9 @@ public abstract class GuiComponent
   }
 
   /**
-   * Gets the child components of this GuiComponent.
+   * Gets the child components of this GuiComponent. Components are rendered in list order. A later
+   * component is therefore above an earlier component and receives mouse input first where their
+   * bounds overlap.
    *
    * @return the child components
    */
@@ -557,12 +563,15 @@ public abstract class GuiComponent
   @Override
   public void mouseClicked(final MouseEvent e) {
     if (!mouseEventShouldBeForwarded(e)) {
+      this.clickPending = false;
+      this.isPressed = false;
       return;
     }
 
-    if (isPressed()) {
+    if (this.clickPending) {
       final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
       getClickConsumer().forEach(consumer -> consumer.accept(event));
+      this.clickPending = false;
       this.isPressed = false;
     }
   }
@@ -600,20 +609,23 @@ public abstract class GuiComponent
 
   @Override
   public void mouseExited(final MouseEvent e) {
+    this.isHovered = false;
+    this.isPressed = false;
+    this.clickPending = false;
     if (!isForwardMouseEvents()) {
       return;
     }
 
-    this.isHovered = false;
-    this.isPressed = false;
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
     getMouseLeaveConsumer().forEach(consumer -> consumer.accept(event));
   }
 
   @Override
   public void mouseMoved(final MouseEvent e) {
-    if (!mouseEventShouldBeForwarded(e) && isHovered()) {
-      mouseExited(e);
+    if (!mouseEventShouldBeForwarded(e)) {
+      if (isHovered()) {
+        mouseExited(e);
+      }
       return;
     }
 
@@ -634,6 +646,7 @@ public abstract class GuiComponent
     }
 
     this.isPressed = true;
+    this.clickPending = true;
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
     getMousePressedConsumer().forEach(consumer -> consumer.accept(event));
   }
@@ -641,6 +654,8 @@ public abstract class GuiComponent
   @Override
   public void mouseReleased(final MouseEvent e) {
     if (!mouseEventShouldBeForwarded(e)) {
+      this.isPressed = false;
+      this.clickPending = false;
       return;
     }
 
@@ -648,13 +663,15 @@ public abstract class GuiComponent
 
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
 
-    // TODO: check if this should really call the clicked consumers...
-    getClickConsumer().forEach(consumer -> consumer.accept(event));
     getMouseReleasedConsumer().forEach(consumer -> consumer.accept(event));
   }
 
   @Override
   public void mouseWheelMoved(final MouseWheelEvent e) {
+    if (!mouseEventShouldBeForwarded(e)) {
+      return;
+    }
+
     getMouseWheelConsumer().forEach(
       consumer -> consumer.accept(new ComponentMouseWheelEvent(e, this)));
   }
@@ -1509,12 +1526,193 @@ public abstract class GuiComponent
    * @return true, if the Mouse event should be forwarded
    */
   protected boolean mouseEventShouldBeForwarded(final MouseEvent e) {
+    return acceptsMouseEvent(e) && isTopmostComponentAt(e);
+  }
+
+  private boolean acceptsMouseEvent(final MouseEvent e) {
     return isForwardMouseEvents()
       && isVisible()
       && isEnabled()
       && !isSuspended()
+      && isVisibleInHierarchy()
       && e != null
       && getBoundingBox().contains(e.getPoint());
+  }
+
+  private boolean isVisibleInHierarchy() {
+    GuiComponent ancestor = this.parent;
+    while (ancestor != null) {
+      if (!ancestor.isVisible() || ancestor.isSuspended()) {
+        return false;
+      }
+      ancestor = ancestor.parent;
+    }
+
+    return true;
+  }
+
+  private boolean isTopmostComponentAt(final MouseEvent e) {
+    if (hasEligibleDescendantAt(this, e)) {
+      return false;
+    }
+
+    GuiComponent component = this;
+    GuiComponent componentParent = this.parent;
+    while (componentParent != null) {
+      final List<GuiComponent> siblings = componentParent.getComponents();
+      final int componentIndex = siblings.lastIndexOf(component);
+      if (componentIndex < 0) {
+        component.parent = null;
+        break;
+      }
+      for (int i = siblings.size() - 1; i > componentIndex; i--) {
+        if (hasEligibleComponentAt(siblings.get(i), e)) {
+          return false;
+        }
+      }
+
+      component = componentParent;
+      componentParent = componentParent.parent;
+    }
+
+    return true;
+  }
+
+  private static boolean hasEligibleDescendantAt(
+    final GuiComponent component, final MouseEvent e) {
+    final List<GuiComponent> children = component.getComponents();
+    for (int i = children.size() - 1; i >= 0; i--) {
+      if (hasEligibleComponentAt(children.get(i), e)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private static boolean hasEligibleComponentAt(
+    final GuiComponent component, final MouseEvent e) {
+    if (!component.isVisible() || component.isSuspended()) {
+      return false;
+    }
+    return component.acceptsMouseEvent(e) || hasEligibleDescendantAt(component, e);
+  }
+
+  private final class ChildComponentList extends CopyOnWriteArrayList<GuiComponent> {
+    @Override
+    public boolean add(final GuiComponent component) {
+      final boolean added = super.add(component);
+      if (added) {
+        component.parent = GuiComponent.this;
+      }
+      return added;
+    }
+
+    @Override
+    public void add(final int index, final GuiComponent component) {
+      super.add(index, component);
+      component.parent = GuiComponent.this;
+    }
+
+    @Override
+    public boolean addAll(final Collection<? extends GuiComponent> components) {
+      final boolean added = super.addAll(components);
+      if (added) {
+        for (final GuiComponent component : components) {
+          component.parent = GuiComponent.this;
+        }
+      }
+      return added;
+    }
+
+    @Override
+    public boolean addAll(
+      final int index, final Collection<? extends GuiComponent> components) {
+      final boolean added = super.addAll(index, components);
+      if (added) {
+        for (final GuiComponent component : components) {
+          component.parent = GuiComponent.this;
+        }
+      }
+      return added;
+    }
+
+    @Override
+    public GuiComponent set(final int index, final GuiComponent component) {
+      final GuiComponent replaced = super.set(index, component);
+      component.parent = GuiComponent.this;
+      detach(replaced);
+      return replaced;
+    }
+
+    @Override
+    public GuiComponent remove(final int index) {
+      final GuiComponent removed = super.remove(index);
+      detach(removed);
+      return removed;
+    }
+
+    @Override
+    public boolean remove(final Object component) {
+      final boolean removed = super.remove(component);
+      if (removed && component instanceof GuiComponent removedComponent) {
+        detach(removedComponent);
+      }
+      return removed;
+    }
+
+    @Override
+    public boolean removeAll(final Collection<?> components) {
+      final List<GuiComponent> previousComponents = List.copyOf(this);
+      final boolean removed = super.removeAll(components);
+      if (removed) {
+        previousComponents.forEach(this::detach);
+      }
+      return removed;
+    }
+
+    @Override
+    public boolean retainAll(final Collection<?> components) {
+      final List<GuiComponent> previousComponents = List.copyOf(this);
+      final boolean removed = super.retainAll(components);
+      if (removed) {
+        previousComponents.forEach(this::detach);
+      }
+      return removed;
+    }
+
+    @Override
+    public boolean removeIf(final Predicate<? super GuiComponent> filter) {
+      final List<GuiComponent> previousComponents = List.copyOf(this);
+      final boolean removed = super.removeIf(filter);
+      if (removed) {
+        previousComponents.forEach(this::detach);
+      }
+      return removed;
+    }
+
+    @Override
+    public void replaceAll(final UnaryOperator<GuiComponent> operator) {
+      final List<GuiComponent> previousComponents = List.copyOf(this);
+      super.replaceAll(operator);
+      for (final GuiComponent component : this) {
+        component.parent = GuiComponent.this;
+      }
+      previousComponents.forEach(this::detach);
+    }
+
+    @Override
+    public void clear() {
+      final List<GuiComponent> removed = List.copyOf(this);
+      super.clear();
+      removed.forEach(this::detach);
+    }
+
+    private void detach(final GuiComponent component) {
+      if (!contains(component) && component.parent == GuiComponent.this) {
+        component.parent = null;
+      }
+    }
   }
 
   /**

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
@@ -568,6 +568,7 @@ public abstract class GuiComponent
       return;
     }
 
+    e.consume();
     if (this.clickPending) {
       final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
       getClickConsumer().forEach(consumer -> consumer.accept(event));
@@ -582,6 +583,7 @@ public abstract class GuiComponent
       return;
     }
 
+    e.consume();
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
     getMouseDraggedConsumer().forEach(consumer -> consumer.accept(event));
   }
@@ -597,6 +599,7 @@ public abstract class GuiComponent
       return;
     }
 
+    e.consume();
     this.isHovered = true;
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
     getHoverConsumer().forEach(consumer -> consumer.accept(event));
@@ -633,6 +636,8 @@ public abstract class GuiComponent
     // before
     if (!isHovered()) {
       mouseEntered(e);
+    } else {
+      e.consume();
     }
 
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
@@ -645,6 +650,7 @@ public abstract class GuiComponent
       return;
     }
 
+    e.consume();
     this.isPressed = true;
     this.clickPending = true;
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
@@ -659,6 +665,7 @@ public abstract class GuiComponent
       return;
     }
 
+    e.consume();
     this.isPressed = false;
 
     final ComponentMouseEvent event = new ComponentMouseEvent(e, this);
@@ -672,6 +679,7 @@ public abstract class GuiComponent
       return;
     }
 
+    e.consume();
     getMouseWheelConsumer().forEach(
       consumer -> consumer.accept(new ComponentMouseWheelEvent(e, this)));
   }
@@ -1536,6 +1544,7 @@ public abstract class GuiComponent
       && !isSuspended()
       && isVisibleInHierarchy()
       && e != null
+      && !e.isConsumed()
       && getBoundingBox().contains(e.getPoint());
   }
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/MouseDrawComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/MouseDrawComponent.java
@@ -106,6 +106,10 @@ public class MouseDrawComponent extends ImageComponent {
    */
   @Override
   public void mouseDragged(MouseEvent e) {
+    if (!mouseEventShouldBeForwarded(e)) {
+      return;
+    }
+
     super.mouseDragged(e);
 
     double brushX = e.getX();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Mouse.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Mouse.java
@@ -249,7 +249,8 @@ public final class Mouse
 
   @Override
   public void mouseWheelMoved(final MouseWheelEvent e) {
-    this.mouseWheelListeners.forEach(listener -> listener.mouseWheelMoved(e));
+    final MouseWheelEvent wrappedEvent = this.createWheelEvent(e);
+    this.mouseWheelListeners.forEach(listener -> listener.mouseWheelMoved(wrappedEvent));
   }
 
   @Override
@@ -428,6 +429,24 @@ public final class Mouse
       original.getClickCount(),
       original.isPopupTrigger(),
       original.getButton());
+  }
+
+  private MouseWheelEvent createWheelEvent(final MouseWheelEvent original) {
+    return new MouseWheelEvent(
+      original.getComponent(),
+      original.getID(),
+      original.getWhen(),
+      original.getModifiersEx(),
+      (int) getLocation().getX(),
+      (int) getLocation().getY(),
+      original.getXOnScreen(),
+      original.getYOnScreen(),
+      original.getClickCount(),
+      original.isPopupTrigger(),
+      original.getScrollType(),
+      original.getScrollAmount(),
+      original.getWheelRotation(),
+      original.getPreciseWheelRotation());
   }
 
   /**

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/CheckBoxTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/CheckBoxTests.java
@@ -4,9 +4,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.input.Input;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(GameTestSuite.class)
 class CheckBoxTests {
+  @BeforeAll
+  static void initialize() {
+    Game.init(Game.COMMANDLINE_ARG_NOGUI);
+    Input.InputGameAdapter adapter = new Input.InputGameAdapter();
+    adapter.initialized();
+  }
+
   @Test
   void testSetChecked() {
     // arrange

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
@@ -21,6 +21,7 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
 import java.awt.geom.RectangularShape;
 import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
@@ -138,7 +139,7 @@ class GuiComponentTests {
     assertNull(component.getTag());
 
     component.mouseMoved(createTestEvent(50, 25));
-    assertNotNull(component.getTag());
+    assertNull(component.getTag());
 
     component.setVisible(true);
 
@@ -167,6 +168,144 @@ class GuiComponentTests {
     assertFalse(component.isPressed());
     assertTrue(component.isHovered());
     assertEquals(moved, component.getTag());
+  }
+
+  @Test
+  void onlyTopmostOverlappingComponentReceivesMouseEvents() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    TestComponent lower = new TestComponent(0, 0, 100, 100);
+    TestComponent upper = new TestComponent(25, 25, 100, 100);
+    parent.getComponents().add(lower);
+    parent.getComponents().add(upper);
+    parent.setVisible(true);
+
+    lower.onMousePressed(event -> lower.setTag("pressed"));
+    upper.onMousePressed(event -> upper.setTag("pressed"));
+
+    MouseEvent overlap = createTestEvent(50, 50);
+    lower.mousePressed(overlap);
+    upper.mousePressed(overlap);
+
+    assertNull(lower.getTag());
+    assertEquals("pressed", upper.getTag());
+  }
+
+  @Test
+  void releaseAndClickNotifyOnlyTheirMatchingConsumers() {
+    TestComponent component = new TestComponent(0, 0, 100, 100);
+    component.setVisible(true);
+    int[] clicks = {0};
+    int[] releases = {0};
+    component.onClicked(event -> clicks[0]++);
+    component.onMouseReleased(event -> releases[0]++);
+
+    MouseEvent event = createTestEvent(50, 50);
+    component.mousePressed(event);
+    component.mouseReleased(event);
+
+    assertEquals(0, clicks[0]);
+    assertEquals(1, releases[0]);
+
+    component.mouseClicked(event);
+
+    assertEquals(1, clicks[0]);
+    assertEquals(1, releases[0]);
+  }
+
+  @Test
+  void topmostHitTestingFollowsNestedRenderOrder() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    TestComponent lower = new TestComponent(0, 0, 100, 100);
+    TestComponent lowerChild = new TestComponent(25, 25, 50, 50);
+    TestComponent upper = new TestComponent(25, 25, 100, 100);
+    lower.getComponents().add(lowerChild);
+    parent.getComponents().add(lower);
+    parent.getComponents().add(upper);
+    parent.setVisible(true);
+
+    lowerChild.onClicked(event -> lowerChild.setTag("clicked"));
+    upper.onClicked(event -> upper.setTag("clicked"));
+
+    MouseEvent overlap = createTestEvent(50, 50);
+    lowerChild.mousePressed(overlap);
+    lowerChild.mouseClicked(overlap);
+    upper.mousePressed(overlap);
+    upper.mouseClicked(overlap);
+
+    assertNull(lowerChild.getTag());
+    assertEquals("clicked", upper.getTag());
+  }
+
+  @Test
+  void childReceivesMouseEventInsteadOfItsParent() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    TestComponent child = new TestComponent(25, 25, 100, 100);
+    parent.getComponents().add(child);
+    parent.setVisible(true);
+    parent.onMousePressed(event -> parent.setTag("pressed"));
+    child.onMousePressed(event -> child.setTag("pressed"));
+
+    MouseEvent event = createTestEvent(50, 50);
+    parent.mousePressed(event);
+    child.mousePressed(event);
+
+    assertNull(parent.getTag());
+    assertEquals("pressed", child.getTag());
+  }
+
+  @Test
+  void ineligibleTopComponentDoesNotBlockLowerComponent() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    TestComponent lower = new TestComponent(0, 0, 100, 100);
+    TestComponent upper = new TestComponent(25, 25, 100, 100);
+    parent.getComponents().add(lower);
+    parent.getComponents().add(upper);
+    parent.setVisible(true);
+    upper.setEnabled(false);
+    lower.onMousePressed(event -> lower.setTag("pressed"));
+
+    lower.mousePressed(createTestEvent(50, 50));
+
+    assertEquals("pressed", lower.getTag());
+  }
+
+  @Test
+  void mouseMovedRequiresAnEligibleTopmostHit() {
+    TestComponent component = new TestComponent(0, 0, 100, 100);
+    component.onMouseMoved(event -> component.setTag("moved"));
+
+    component.mouseMoved(createTestEvent(50, 50));
+    assertNull(component.getTag());
+
+    component.setVisible(true);
+    component.mouseMoved(createTestEvent(150, 150));
+    assertNull(component.getTag());
+
+    component.mouseMoved(createTestEvent(50, 50));
+    assertEquals("moved", component.getTag());
+  }
+
+  @Test
+  void mouseWheelRequiresAnEligibleTopmostHit() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    TestComponent lower = new TestComponent(0, 0, 100, 100);
+    TestComponent upper = new TestComponent(25, 25, 100, 100);
+    parent.getComponents().add(lower);
+    parent.getComponents().add(upper);
+    parent.setVisible(true);
+    lower.onMouseWheelScrolled(event -> lower.setTag("scrolled"));
+    upper.onMouseWheelScrolled(event -> upper.setTag("scrolled"));
+
+    MouseWheelEvent overlap = createTestWheelEvent(50, 50);
+    lower.mouseWheelMoved(overlap);
+    upper.mouseWheelMoved(overlap);
+
+    assertNull(lower.getTag());
+    assertEquals("scrolled", upper.getTag());
+
+    upper.setTag(null);
+    upper.mouseWheelMoved(createTestWheelEvent(150, 150));
+    assertNull(upper.getTag());
   }
 
   @Test
@@ -415,6 +554,12 @@ class GuiComponentTests {
 
   private static MouseEvent createTestEvent(int x, int y) {
     return new MouseEvent(new JLabel(), 0, 0, 0, x, y, 0, false);
+  }
+
+  private static MouseWheelEvent createTestWheelEvent(int x, int y) {
+    return new MouseWheelEvent(
+      new JLabel(), 0, 0, 0, x, y, 0, false,
+      MouseWheelEvent.WHEEL_UNIT_SCROLL, 1, 1);
   }
 
   private static class TestComponent extends GuiComponent {

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/GuiComponentTests.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.input.Input;
+import de.gurkenlabs.litiengine.input.Mouse;
 import de.gurkenlabs.litiengine.test.GameTestSuite;
 import de.gurkenlabs.litiengine.tweening.TweenType;
 import de.gurkenlabs.litiengine.util.ColorHelper;
@@ -191,6 +192,35 @@ class GuiComponentTests {
   }
 
   @Test
+  void removingTopmostComponentDuringDispatchDoesNotForwardSameEventToLowerComponent() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    TestComponent lower = new TestComponent(0, 0, 100, 100);
+    TestComponent upper = new TestComponent(25, 25, 100, 100);
+    parent.getComponents().add(lower);
+    parent.getComponents().add(upper);
+    lower.onMousePressed(event -> lower.setTag("pressed"));
+    upper.onMousePressed(
+      event -> {
+        upper.setTag("pressed");
+        parent.getComponents().remove(upper);
+      });
+    parent.prepare();
+    Mouse mouse = (Mouse) Input.mouse();
+    mouse.setLocation(50, 50);
+
+    try {
+      mouse.mousePressed(createTestEvent(50, 50));
+    } finally {
+      parent.suspend();
+      upper.suspend();
+      mouse.mouseReleased(createTestEvent(50, 50));
+    }
+
+    assertNull(lower.getTag());
+    assertEquals("pressed", upper.getTag());
+  }
+
+  @Test
   void releaseAndClickNotifyOnlyTheirMatchingConsumers() {
     TestComponent component = new TestComponent(0, 0, 100, 100);
     component.setVisible(true);
@@ -199,14 +229,13 @@ class GuiComponentTests {
     component.onClicked(event -> clicks[0]++);
     component.onMouseReleased(event -> releases[0]++);
 
-    MouseEvent event = createTestEvent(50, 50);
-    component.mousePressed(event);
-    component.mouseReleased(event);
+    component.mousePressed(createTestEvent(50, 50));
+    component.mouseReleased(createTestEvent(50, 50));
 
     assertEquals(0, clicks[0]);
     assertEquals(1, releases[0]);
 
-    component.mouseClicked(event);
+    component.mouseClicked(createTestEvent(50, 50));
 
     assertEquals(1, clicks[0]);
     assertEquals(1, releases[0]);
@@ -226,11 +255,10 @@ class GuiComponentTests {
     lowerChild.onClicked(event -> lowerChild.setTag("clicked"));
     upper.onClicked(event -> upper.setTag("clicked"));
 
-    MouseEvent overlap = createTestEvent(50, 50);
-    lowerChild.mousePressed(overlap);
-    lowerChild.mouseClicked(overlap);
-    upper.mousePressed(overlap);
-    upper.mouseClicked(overlap);
+    lowerChild.mousePressed(createTestEvent(50, 50));
+    lowerChild.mouseClicked(createTestEvent(50, 50));
+    upper.mousePressed(createTestEvent(50, 50));
+    upper.mouseClicked(createTestEvent(50, 50));
 
     assertNull(lowerChild.getTag());
     assertEquals("clicked", upper.getTag());

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/MouseDrawComponentTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/gui/MouseDrawComponentTests.java
@@ -1,0 +1,57 @@
+package de.gurkenlabs.litiengine.gui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.input.Input;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import javax.swing.JLabel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(GameTestSuite.class)
+class MouseDrawComponentTests {
+  @BeforeAll
+  static void initialize() {
+    Game.init(Game.COMMANDLINE_ARG_NOGUI);
+    Input.InputGameAdapter adapter = new Input.InputGameAdapter();
+    adapter.initialized();
+  }
+
+  @Test
+  void obscuredComponentDoesNotDraw() {
+    TestComponent parent = new TestComponent(0, 0, 200, 200);
+    MouseDrawComponent lower = new MouseDrawComponent(0, 0, 100, 100, null, null, null);
+    TestComponent upper = new TestComponent(25, 25, 100, 100);
+    parent.getComponents().add(lower);
+    parent.getComponents().add(upper);
+    parent.setVisible(true);
+    int previousColor = lower.getDrawingSpace().getRGB(49, 49);
+
+    MouseEvent dragEvent = createLeftDragEvent(50, 50);
+    lower.mouseDragged(dragEvent);
+
+    assertEquals(previousColor, lower.getDrawingSpace().getRGB(49, 49));
+
+    parent.getComponents().remove(upper);
+    lower.mouseDragged(dragEvent);
+
+    assertNotEquals(previousColor, lower.getDrawingSpace().getRGB(49, 49));
+  }
+
+  private static MouseEvent createLeftDragEvent(int x, int y) {
+    return new MouseEvent(
+      new JLabel(), MouseEvent.MOUSE_DRAGGED, 0, InputEvent.BUTTON1_DOWN_MASK,
+      x, y, 0, false);
+  }
+
+  private static class TestComponent extends GuiComponent {
+    private TestComponent(double x, double y, double width, double height) {
+      super(x, y, width, height);
+    }
+  }
+}

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/input/MouseTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/input/MouseTests.java
@@ -1,0 +1,67 @@
+package de.gurkenlabs.litiengine.input;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import de.gurkenlabs.litiengine.Game;
+import de.gurkenlabs.litiengine.test.GameTestSuite;
+import java.awt.Canvas;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(GameTestSuite.class)
+class MouseTests {
+  @BeforeAll
+  static void initialize() {
+    Game.init(Game.COMMANDLINE_ARG_NOGUI);
+    new Input.InputGameAdapter().initialized();
+  }
+
+  @Test
+  void wheelEventUsesLogicalMouseLocationAndPreservesWheelData() {
+    Mouse mouse = (Mouse) Input.mouse();
+    mouse.setLocation(800, 400);
+    AtomicReference<MouseWheelEvent> receivedEvent = new AtomicReference<>();
+    MouseWheelListener listener = receivedEvent::set;
+    mouse.onWheelMoved(listener);
+    MouseWheelEvent physicalEvent =
+      new MouseWheelEvent(
+        new Canvas(),
+        MouseWheelEvent.MOUSE_WHEEL,
+        123,
+        0,
+        640,
+        360,
+        1640,
+        1360,
+        2,
+        true,
+        MouseWheelEvent.WHEEL_BLOCK_SCROLL,
+        3,
+        -2,
+        -1.5);
+
+    try {
+      mouse.mouseWheelMoved(physicalEvent);
+    } finally {
+      mouse.removeMouseWheelListener(listener);
+    }
+
+    MouseWheelEvent event = receivedEvent.get();
+    assertNotNull(event);
+    assertEquals(800, event.getX());
+    assertEquals(400, event.getY());
+    assertEquals(1640, event.getXOnScreen());
+    assertEquals(1360, event.getYOnScreen());
+    assertEquals(123, event.getWhen());
+    assertEquals(2, event.getClickCount());
+    assertEquals(MouseWheelEvent.WHEEL_BLOCK_SCROLL, event.getScrollType());
+    assertEquals(3, event.getScrollAmount());
+    assertEquals(-2, event.getWheelRotation());
+    assertEquals(-1.5, event.getPreciseWheelRotation());
+  }
+}


### PR DESCRIPTION
Addresses the remaining mouse-input inconsistencies from #31.

- Uses component render order for deterministic topmost hit testing.
- Prevents obscured parents and siblings from receiving pointer events.
- Applies consistent filtering to move, wheel, press, release, click, and drag handling.
- Separates click and release callbacks.
- Adds overlap, hierarchy, wheel, movement, and `MouseDrawComponent` regression tests.
- Fixes missing input initialization in `CheckBoxTests`.

### Testing

- `./gradlew :litiengine:test`
- `./gradlew spotlessCheck`