### PR TITLE
Feature/native markdown javadocs

### DIFF
--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/Align.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/Align.java
@@ -3,38 +3,26 @@ package de.gurkenlabs.litiengine;
 import jakarta.xml.bind.annotation.XmlEnum;
 import jakarta.xml.bind.annotation.XmlEnumValue;
 
-/**
- * The enum {@code Align} defines a range of horizontal alignments.
- */
+/// The enum `Align` defines a range of horizontal alignments.
 @XmlEnum
 public enum Align {
-  /**
-   * Center alignment with a portion value of 0.5.
-   */
+  /// Center alignment with a portion value of 0.5.
   @XmlEnumValue("CENTER")
   CENTER(0.5f),
 
-  /**
-   * Left alignment with a portion value of 0.0.
-   */
+  /// Left alignment with a portion value of 0.0.
   @XmlEnumValue("LEFT")
   LEFT(0f),
 
-  /**
-   * Right alignment with a portion value of 1.0.
-   */
+  /// Right alignment with a portion value of 1.0.
   @XmlEnumValue("RIGHT")
   RIGHT(1f),
 
-  /**
-   * Center-left alignment with a portion value of 0.25.
-   */
+  /// Center-left alignment with a portion value of 0.25.
   @XmlEnumValue("CENTER_LEFT")
   CENTER_LEFT(0.25f),
 
-  /**
-   * Center-right alignment with a portion value of 0.75.
-   */
+  /// Center-right alignment with a portion value of 0.75.
   @XmlEnumValue("CENTER_RIGHT")
   CENTER_RIGHT(0.75f);
 
@@ -44,12 +32,10 @@ public enum Align {
     this.portion = portion;
   }
 
-  /**
-   * Gets the align enumeration value for the specified string.
-   *
-   * @param alignString The string representing the enum value.
-   * @return The enum value represented by the specified string or {@link Align#CENTER} if the specified string is invalid.
-   */
+  /// Gets the align enumeration value for the specified string.
+  ///
+  /// @param alignString The string representing the enum value.
+  /// @return The enum value represented by the specified string or [Align#CENTER] if the specified string is invalid.
   public static Align get(final String alignString) {
     if (alignString == null || alignString.isEmpty()) {
       return Align.CENTER;
@@ -62,67 +48,58 @@ public enum Align {
     }
   }
 
-  /**
-   * Gets the proportional value of this instance.
-   *
-   * @param width The width to calculate the relative value from.
-   * @return The proportional value for the specified height.
-   */
+  /// Gets the proportional value of this instance.
+  ///
+  /// @param width The width to calculate the relative value from.
+  /// @return The proportional value for the specified height.
   public float getValue(float width) {
     return width * this.portion;
   }
 
-  /**
-   * Gets the proportional value of this instance.
-   *
-   * @param width The width to calculate the relative value from.
-   * @return The proportional value for the specified height.
-   */
+  /// Gets the proportional value of this instance.
+  ///
+  /// @param width The width to calculate the relative value from.
+  /// @return The proportional value for the specified height.
   public double getValue(double width) {
     return width * this.portion;
   }
 
-  /**
-   * Gets the proportional value of this instance.
-   *
-   * @param width The width to calculate the relative value from.
-   * @return The proportional value for the specified height.
-   */
+  /// Gets the proportional value of this instance.
+  ///
+  /// @param width The width to calculate the relative value from.
+  /// @return The proportional value for the specified height.
   public int getValue(int width) {
     return (int) (width * this.portion);
   }
 
-  /**
-   * Gets the location for the specified object width to be horizontally aligned relatively to the bounds of the specified width.<br> Suitable for
-   * <b>entity</b> alignment. The return value might be negative or exceed the right boundary which is
-   * <i>{@code width} - {@code objectWidth}</i>. <br>
-   * For <b>text</b> alignment {@link #getLocation(double, double, boolean)} should be used with
-   * <i>{@code preventOverflow}</i> set to {@code true}.
-   *
-   * @param width       The width, limiting the horizontal alignment.
-   * @param objectWidth The width of the object for which to calculate the horizontally aligned location.
-   * @return The x-coordinate for the location of the object with the specified width.
-   */
+  /// Gets the location for the specified object width to be horizontally aligned relatively to the bounds of the specified width.
+  /// Suitable for
+  /// **entity** alignment. The return value might be negative or exceed the right boundary which is
+  /// *`width` - `objectWidth`*.
+  ///
+  /// For **text** alignment [double, boolean)][#getLocation(double,] should be used with
+  /// *`preventOverflow`* set to `true`.
+  ///
+  /// @param width       The width, limiting the horizontal alignment.
+  /// @param objectWidth The width of the object for which to calculate the horizontally aligned location.
+  /// @return The x-coordinate for the location of the object with the specified width.
   public double getLocation(final double width, final double objectWidth) {
     return getLocation(width, objectWidth, false);
   }
 
-  /**
-   * Gets the location for the specified object width to be horizontally aligned relatively to the bounds of the specified width. An overflow behavior
-   * (whenever <i>{@code objectWidth} > {@code width}</i>) can be controlled using
-   * <b>{@code preventOverflow}</b> parameter:
-   * <ul>
-   * <li><i>false</i>: the return value might be negative or exceed the right boundary which is <i>{@code width} -
-   * {@code objectWidth}</i> (good for <b>entity</b> alignment).</li>
-   * <li><i>true</i>: the return value will always be clamped within the bounds (good for <b>text</b> alignment).</li>
-   * </ul>
-   *
-   * @param width           The width, limiting the horizontal alignment.
-   * @param objectWidth     The width of the object for which to calculate the horizontally aligned location.
-   * @param preventOverflow A flag indicating whether the return value should be clamped to keep it within the bounds (prevent values that are
-   *                        negative or beyond the right boundary).
-   * @return The x-coordinate for the location of the object with the specified width.
-   */
+  /// Gets the location for the specified object width to be horizontally aligned relatively to the bounds of the specified width. An overflow behavior
+  /// (whenever *`objectWidth` > `width`*) can be controlled using
+  /// **`preventOverflow`** parameter:
+  ///
+  /// - *false*: the return value might be negative or exceed the right boundary which is *`width` -
+  /// `objectWidth`* (good for **entity** alignment).
+  /// - *true*: the return value will always be clamped within the bounds (good for **text** alignment).
+  ///
+  /// @param width           The width, limiting the horizontal alignment.
+  /// @param objectWidth     The width of the object for which to calculate the horizontally aligned location.
+  /// @param preventOverflow A flag indicating whether the return value should be clamped to keep it within the bounds (prevent values that are
+  /// negative or beyond the right boundary).
+  /// @return The x-coordinate for the location of the object with the specified width.
   public double getLocation(final double width, final double objectWidth, final boolean preventOverflow) {
     double value = this.getValue(width);
     double location = value - objectWidth / 2.0;
@@ -133,11 +110,9 @@ public enum Align {
     return Math.max(0, Math.min(width - objectWidth, location));
   }
 
-  /**
-   * Gets the portion value of the alignment.
-   *
-   * @return The portion value of the alignment.
-   */
+  /// Gets the portion value of the alignment.
+  ///
+  /// @return The portion value of the alignment.
   public float getPortion() {
     return portion;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/DefaultUncaughtExceptionHandler.java
@@ -17,19 +17,16 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Handles the uncaught exceptions that might occur while running a game or application with the
- * LITIENGINE.
- * <p>
- * It provides proper logging of the exception in a {@code crash.txt} file in the game's root
- * directory that can be further used to report the issue if it's a generic one.
- * </p>
- * <p>
- * Depending on the configuration, the default behavior might force the game to exit upon an
- * unexpected exception which can be useful to detect problems in your game early.
- *
- * @see ClientConfiguration#exitOnError()
- */
+/// Handles the uncaught exceptions that might occur while running a game or application with the
+/// LITIENGINE.
+///
+/// It provides proper logging of the exception in a `crash.txt` file in the game's root
+/// directory that can be further used to report the issue if it's a generic one.
+///
+/// Depending on the configuration, the default behavior might force the game to exit upon an
+/// unexpected exception which can be useful to detect problems in your game early.
+///
+/// @see ClientConfiguration#exitOnError()
 public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler {
 
   private static final Logger log = Logger.getLogger(
@@ -38,24 +35,20 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
   private volatile boolean exitOnException;
   private volatile boolean dumpThreads;
 
-  /**
-   * Initializes a new instance of the {@code DefaultUncaughtExceptionHandler} class.
-   *
-   * @param exitOnException A flag indicating whether the game should exit when an unexpected
-   *                        exception occurs. The game will still exit if it encounters an Error.
-   */
+  /// Initializes a new instance of the `DefaultUncaughtExceptionHandler` class.
+  ///
+  /// @param exitOnException A flag indicating whether the game should exit when an unexpected
+  /// exception occurs. The game will still exit if it encounters an Error.
   public DefaultUncaughtExceptionHandler(boolean exitOnException) {
     this(exitOnException, false);
   }
 
-  /**
-   * Initializes a new instance of the {@code DefaultUncaughtExceptionHandler} class.
-   *
-   * @param exitOnException A flag indicating whether the game should exit when an unexpected
-   *                        exception occurs. The game will still exit if it encounters an Error
-   * @param dumpThreads     A flag indicating whether the crash report should contain an additional
-   *                        thread dump.
-   */
+  /// Initializes a new instance of the `DefaultUncaughtExceptionHandler` class.
+  ///
+  /// @param exitOnException A flag indicating whether the game should exit when an unexpected
+  /// exception occurs. The game will still exit if it encounters an Error
+  /// @param dumpThreads     A flag indicating whether the crash report should contain an additional
+  /// thread dump.
   public DefaultUncaughtExceptionHandler(boolean exitOnException, boolean dumpThreads) {
     this.exitOnException = exitOnException;
     this.dumpThreads = dumpThreads;
@@ -83,38 +76,30 @@ public class DefaultUncaughtExceptionHandler implements UncaughtExceptionHandler
     }
   }
 
-  /**
-   * Indicates whether this hander currently exits the game upon an unhandled exception.
-   * <p>
-   * Note that this handler will still exit if it encounters an unhandled Error.
-   *
-   * @return True if the game will exit upon an unhandled exception; otherwise false.
-   */
+  /// Indicates whether this hander currently exits the game upon an unhandled exception.
+  ///
+  /// Note that this handler will still exit if it encounters an unhandled Error.
+  ///
+  /// @return True if the game will exit upon an unhandled exception; otherwise false.
   public boolean exitOnException() {
     return this.exitOnException;
   }
 
-  /**
-   * @return true if the generated crash report will contain a thread dump
-   */
+  /// @return true if the generated crash report will contain a thread dump
   public boolean dumpsThreads() {
     return this.dumpThreads;
   }
 
-  /**
-   * Set whether the game will exit upon an unhandled exception.
-   *
-   * @param exit The flag that defines whether the game will exit upon an unhandled exception.
-   */
+  /// Set whether the game will exit upon an unhandled exception.
+  ///
+  /// @param exit The flag that defines whether the game will exit upon an unhandled exception.
   public void setExitOnException(boolean exit) {
     this.exitOnException = exit;
   }
 
-  /**
-   * Set whether the generated crash report will contain an additional thread dump
-   *
-   * @param dumpThreads The flag that defines whether crash report will contain a thread dump.
-   */
+  /// Set whether the generated crash report will contain an additional thread dump
+  ///
+  /// @param dumpThreads The flag that defines whether crash report will contain a thread dump.
   public void dumpThreads(boolean dumpThreads) {
     this.dumpThreads = dumpThreads;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/Direction.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/Direction.java
@@ -2,74 +2,57 @@ package de.gurkenlabs.litiengine;
 
 import de.gurkenlabs.litiengine.util.geom.GeometricUtilities;
 
-/**
- * This enum defines the four dimensional directions in 2D space.
- * <p>
- * It can provide a simplified way to look at a rotation or angle which is particularly useful in tile based games.
- * </p>
- * <p>
- * Directions can be converted to or constructed from angles (specified in degrees).<br> The directions also specify a flag that can be used to
- * exchange the information in an size-optimized manner (e.g. for network communication).
- * </p>
- *
- * @see #toFlagValue()
- */
+/// This enum defines the four dimensional directions in 2D space.
+///
+/// It can provide a simplified way to look at a rotation or angle which is particularly useful in tile based games.
+///
+/// Directions can be converted to or constructed from angles (specified in degrees).
+/// The directions also specify a flag that can be used to
+/// exchange the information in an size-optimized manner (e.g. for network communication).
+///
+/// @see #toFlagValue()
 public enum Direction {
-  /**
-   * Direction pointing down with a flag value of 1 and an angle of 360 degrees.
-   */
+  /// Direction pointing down with a flag value of 1 and an angle of 360 degrees.
   DOWN((byte) 1, 360f),
 
-  /**
-   * Direction pointing left with a flag value of 2 and an angle of 270 degrees.
-   */
+  /// Direction pointing left with a flag value of 2 and an angle of 270 degrees.
   LEFT((byte) 2, 270f),
 
-  /**
-   * Direction pointing right with a flag value of 4 and an angle of 90 degrees.
-   */
+  /// Direction pointing right with a flag value of 4 and an angle of 90 degrees.
   RIGHT((byte) 4, 90f),
 
-  /**
-   * Undefined direction with a flag value of 8 and an angle of 0 degrees.
-   */
+  /// Undefined direction with a flag value of 8 and an angle of 0 degrees.
   UNDEFINED((byte) 8, 0f),
 
-  /**
-   * Direction pointing up with a flag value of 16 and an angle of 180 degrees.
-   */
+  /// Direction pointing up with a flag value of 16 and an angle of 180 degrees.
   UP((byte) 16, 180f);
 
   private final byte flagValue;
   private final float angle;
 
-  /**
-   * Constructs a new direction with the specified flag value and angle.
-   *
-   * @param flagValue the flag value representing the direction
-   * @param angle     the angle in degrees representing the direction
-   */
+  /// Constructs a new direction with the specified flag value and angle.
+  ///
+  /// @param flagValue the flag value representing the direction
+  /// @param angle     the angle in degrees representing the direction
   Direction(final byte flagValue, float angle) {
     this.flagValue = flagValue;
     this.angle = angle;
   }
 
-  /**
-   * Gets a direction corresponding to the specified angle. Every direction translates to 1/4th (90°) of a full circle.
-   *
-   * <pre>
-   *     o 180 o        DOWN = [0-45[ &amp; [315-360]
-   *   o         o
-   *  o           o     RIGHT = [45-135[
-   * 270          90
-   *  o           o     UP = [135-225[
-   *   o         o
-   *     o  0  o        LEFT = [225-315[
-   * </pre>
-   *
-   * @param angle The angle by which the direction will be determined.
-   * @return The direction that corresponds to the specified angle.
-   */
+  /// Gets a direction corresponding to the specified angle. Every direction translates to 1/4th (90°) of a full circle.
+  ///
+  /// ```
+  ///     o 180 o        DOWN = [0-45[ & [315-360]
+  ///   o         o
+  ///  o           o     RIGHT = [45-135[
+  /// 270          90
+  ///  o           o     UP = [135-225[
+  ///   o         o
+  ///     o  0  o        LEFT = [225-315[
+  /// ```
+  ///
+  /// @param angle The angle by which the direction will be determined.
+  /// @return The direction that corresponds to the specified angle.
   public static Direction fromAngle(final double angle) {
     double actual = GeometricUtilities.normalizeAngle(angle);
 
@@ -93,12 +76,10 @@ public enum Direction {
     return Direction.UNDEFINED;
   }
 
-  /**
-   * Get a value of this enumeration that corresponds to the specified flagValue.
-   *
-   * @param flagValue The flag value to convert to a direction.
-   * @return A direction that corresponds to the specified flag value or {@code UNDEFINED}.
-   */
+  /// Get a value of this enumeration that corresponds to the specified flagValue.
+  ///
+  /// @param flagValue The flag value to convert to a direction.
+  /// @return A direction that corresponds to the specified flag value or `UNDEFINED`.
   public static Direction fromFlagValue(final byte flagValue) {
     for (final Direction dir : Direction.values()) {
       if (dir.toFlagValue() == flagValue) {
@@ -109,16 +90,14 @@ public enum Direction {
     return UNDEFINED;
   }
 
-  /**
-   * Get the opposite value of this direction.
-   *
-   * <pre>
-   * UP - DOWN
-   * LEFT - RIGHT
-   * </pre>
-   *
-   * @return The opposite direction.
-   */
+  /// Get the opposite value of this direction.
+  ///
+  /// ```
+  /// UP - DOWN
+  /// LEFT - RIGHT
+  /// ```
+  ///
+  /// @return The opposite direction.
   public Direction getOpposite() {
     switch (this) {
       case RIGHT:
@@ -134,24 +113,20 @@ public enum Direction {
     }
   }
 
-  /**
-   * Converts this direction to the median angle of the range that is described by this direction.
-   *
-   * <pre>
-   * e.g. UP 180
-   * </pre>
-   *
-   * @return The mean angle of this direction.
-   */
+  /// Converts this direction to the median angle of the range that is described by this direction.
+  ///
+  /// ```
+  /// e.g. UP 180
+  /// ```
+  ///
+  /// @return The mean angle of this direction.
   public float toAngle() {
     return this.angle;
   }
 
-  /**
-   * Gets a flag value that can be used to exchange the information of this enum value in an size-optimized manner (e.g. for network communication).
-   *
-   * @return The immutable flag value that is assigned to this direction.
-   */
+  /// Gets a flag value that can be used to exchange the information of this enum value in an size-optimized manner (e.g. for network communication).
+  ///
+  /// @return The immutable flag value that is assigned to this direction.
   public byte toFlagValue() {
     return this.flagValue;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/Game.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/Game.java
@@ -46,30 +46,23 @@ import de.gurkenlabs.litiengine.tweening.TweenEngine;
 import de.gurkenlabs.litiengine.util.ArrayUtilities;
 import de.gurkenlabs.litiengine.util.io.XmlUtilities;
 
-/***
- * <p>
- * The {@code Game} class is without any doubt one of the classes that you will call a lot when creating a game with the
- * LITIENGINE. It is designed to be the static container that provides access to all important aspects of the engine,
- * e.g. it holds the {@code GameInfo}, the {@code RenderEngine}, the {@code SoundEngine} and many other major
- * components.
- * </p>
- * <p>
- * We designed the API such that all important parts that make up the game are directly accessible via the {@code Game}
- * class in a static manner. To be a little bit more technical, it is essentially a collection of core Singleton
- * instances.
- * </p>
- * <p>
- * This class will also be your starting point when setting up a new LITIENGINE project. In order to launch your game,
- * you need to at least call {@link Game#init(String...)} and {@link Game#start()} from your programs
- * {@code main(String[])} method.
- * </p>
- * <p>
- * Additionally, it provides an interface to hook up event listeners (e.g. {@code GameListener} or
- * {@code EnvironmentLoadedListener}) for the most basic operations of a Game life cycle. 
- * </p>
- *
- * @see GameListener
- */
+/// The `Game` class is without any doubt one of the classes that you will call a lot when creating a game with the
+/// LITIENGINE. It is designed to be the static container that provides access to all important aspects of the engine,
+/// e.g. it holds the `GameInfo`, the `RenderEngine`, the `SoundEngine` and many other major
+/// components.
+///
+/// We designed the API such that all important parts that make up the game are directly accessible via the `Game`
+/// class in a static manner. To be a little bit more technical, it is essentially a collection of core Singleton
+/// instances.
+///
+/// This class will also be your starting point when setting up a new LITIENGINE project. In order to launch your game,
+/// you need to at least call [Game#init(String...)] and [Game#start()] from your programs
+/// `main(String[])` method.
+///
+/// Additionally, it provides an interface to hook up event listeners (e.g. `GameListener` or
+/// `EnvironmentLoadedListener`) for the most basic operations of a Game life cycle.
+///
+/// @see GameListener
 public final class Game {
   public static final int EXIT_GAME_CLOSED = 0;
   public static final int EXIT_GAME_CRASHED = -1;
@@ -112,351 +105,300 @@ public final class Game {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Adds the specified game listener to receive events about the basic game life-cycle.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified game listener to receive events about the basic game life-cycle.
+  ///
+  /// @param listener
+  /// The listener to add.
   public static void addGameListener(GameListener listener) {
     gameListeners.add(listener);
   }
 
-  /**
-   * Removes the specified game listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Removes the specified game listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   public static void removeGameListener(GameListener listener) {
     gameListeners.remove(listener);
   }
 
-  /**
-   * This flag indicates if the game currently supports debugging. This should be set to false for release builds.
-   * <p>
-   * The default value here is true and will allow debugging unless explicitly disabled by calling this method or
-   * providing the command line argument {@link #COMMANDLINE_ARG_RELEASE} when running the game.
-   *
-   * @param allow
-   *          If set to true, the game will be told to allow debugging.
-   */
+  /// This flag indicates if the game currently supports debugging. This should be set to false for release builds.
+  ///
+  /// The default value here is true and will allow debugging unless explicitly disabled by calling this method or
+  /// providing the command line argument [#COMMANDLINE_ARG_RELEASE] when running the game.
+  ///
+  /// @param allow
+  /// If set to true, the game will be told to allow debugging.
   public static void allowDebug(boolean allow) {
     debug = allow;
   }
 
-  /**
-   * This flag indicates whether the game should display the {@code GameWindow} or not. This can only be set before the
-   * game has been initialized with the {@code Game.init(String...)} method. Afterwards it doesn't have an effect anymore.
-   * If enabled, the {@code ScreenManager#setVisible(boolean)} method won't be set to true and the {@code RenderLoop}
-   * won't be started. Also the {@code Camera} won't be updated.
-   *
-   * @param noGui
-   *          If set to true, the GUI will be hidden.
-   * @see GameWindow
-   * @see Game#init(String...)
-   * @see Camera
-   * @see #isInNoGUIMode()
-   */
+  /// This flag indicates whether the game should display the `GameWindow` or not. This can only be set before the
+  /// game has been initialized with the `Game.init(String...)` method. Afterwards it doesn't have an effect anymore.
+  /// If enabled, the `ScreenManager#setVisible(boolean)` method won't be set to true and the `RenderLoop`
+  /// won't be started. Also the `Camera` won't be updated.
+  ///
+  /// @param noGui
+  /// If set to true, the GUI will be hidden.
+  /// @see GameWindow
+  /// @see Game#init(String...)
+  /// @see Camera
+  /// @see #isInNoGUIMode()
   public static void hideGUI(boolean noGui) {
     noGUIMode = noGui;
   }
 
-  /**
-   * This flag globally controls the game's debugging state. If enabled, debugging functionality (e.g. rendering collision
-   * boxes) can potentially be enabled in the configuration.
-   *
-   * @return True if debugging functionality is enabled; otherwise false.
-   * @see Game#allowDebug(boolean)
-   * @see GameConfiguration#debug()
-   */
+  /// This flag globally controls the game's debugging state. If enabled, debugging functionality (e.g. rendering collision
+  /// boxes) can potentially be enabled in the configuration.
+  ///
+  /// @return True if debugging functionality is enabled; otherwise false.
+  /// @see Game#allowDebug(boolean)
+  /// @see GameConfiguration#debug()
   public static boolean isDebug() {
     return debug;
   }
 
-  /**
-   * Indicates whether the game should display the {@code GameWindow} or not.
-   *
-   * @return True if the game should display visual components; otherwise false.
-   */
+  /// Indicates whether the game should display the `GameWindow` or not.
+  ///
+  /// @return True if the game should display visual components; otherwise false.
   public static boolean isInNoGUIMode() {
     return noGUIMode;
   }
 
-  /**
-   * Indicates whether the game has already been started.
-   *
-   * @return True if the game has been started; otherwise false.
-   * @see Game#start()
-   */
+  /// Indicates whether the game has already been started.
+  ///
+  /// @return True if the game has been started; otherwise false.
+  /// @see Game#start()
   public static boolean hasStarted() {
     return hasStarted;
   }
 
-  /**
-   * Gets the static meta information about this game.<br>
-   * This can be used to define meta information about your game, like it's name, version or web site.<br>
-   * <br>
-   * <i>It's also possible to provide additional custom information using the method group <br>
-   * {@code Game.getInfo().setValue("CUSTOM_STRING", "my-value")}.</i>
-   *
-   * @return The game's basic meta information.
-   * @see GameInfo
-   * @see ICustomPropertyProvider
-   * @see GameInfo#setName(String)
-   * @see GameInfo#setValue(String, String)
-   */
+  /// Gets the static meta information about this game.
+  ///
+  /// This can be used to define meta information about your game, like it's name, version or web site.
+  ///
+  /// *It's also possible to provide additional custom information using the method group
+  /// `Game.getInfo().setValue("CUSTOM_STRING", "my-value")`.*
+  ///
+  /// @return The game's basic meta information.
+  /// @see GameInfo
+  /// @see ICustomPropertyProvider
+  /// @see GameInfo#setName(String)
+  /// @see GameInfo#setValue(String, String)
   public static GameInfo info() {
     return gameInfo;
   }
 
-  /**
-   * Gets the manager for Java and runtime scripting integrations.
-   *
-   * @return The global script manager.
-   */
+  /// Gets the manager for Java and runtime scripting integrations.
+  ///
+  /// @return The global script manager.
   public static ScriptManager scripts() {
     return scriptManager;
   }
 
-  /**
-   * Gets the game's runtime configuration.<br>
-   * It contains default engine settings for the game client, graphics, audio, input and debugging.<br>
-   * Additionally, it can be used to register and manage custom settings that are specific to your game.
-   * <p>
-   * <i> Elements of this configuration are also presented in a config.properties file in the game's root directory. <br>
-   * This way its possible to adjust elements without having to recompile the game. </i>
-   * </p>
-   *
-   * @return The game's runtime configuration.
-   * @see SoundConfiguration
-   * @see GraphicConfiguration
-   * @see ClientConfiguration
-   * @see DebugConfiguration
-   * @see InputConfiguration
-   */
+  /// Gets the game's runtime configuration.
+  ///
+  /// It contains default engine settings for the game client, graphics, audio, input and debugging.
+  ///
+  /// Additionally, it can be used to register and manage custom settings that are specific to your game.
+  ///
+  /// *Elements of this configuration are also presented in a config.properties file in the game's root directory.
+  /// This way its possible to adjust elements without having to recompile the game.*
+  ///
+  /// @return The game's runtime configuration.
+  /// @see SoundConfiguration
+  /// @see GraphicConfiguration
+  /// @see ClientConfiguration
+  /// @see DebugConfiguration
+  /// @see InputConfiguration
   public static GameConfiguration config() {
     return configuration;
   }
 
-  /**
-   * Gets basic client metrics about the game's runtime. This includes information about network, the frames-per-second or
-   * the updates-per-second and the used memory.
-   *
-   * <p>
-   * <i> This information can be rendered by setting <br>
-   * {@code Game.config().client().setShowGameMetrics(boolean)} to true or <br>
-   * {@code cl_showGameMetrics=true} in the config.settings. </i>
-   * </p>
-   *
-   * @return Metrics about the game's runtime.
-   * @see GameMetrics#getFramesPerSecond()
-   * @see ClientConfiguration#setShowGameMetrics(boolean)
-   */
+  /// Gets basic client metrics about the game's runtime. This includes information about network, the frames-per-second or
+  /// the updates-per-second and the used memory.
+  ///
+  /// *This information can be rendered by setting
+  /// `Game.config().client().setShowGameMetrics(boolean)` to true or
+  /// `cl_showGameMetrics=true` in the config.settings.*
+  ///
+  /// @return Metrics about the game's runtime.
+  /// @see GameMetrics#getFramesPerSecond()
+  /// @see ClientConfiguration#setShowGameMetrics(boolean)
   public static GameMetrics metrics() {
     return metrics;
   }
 
-  /**
-   * Gets time information about the running game/environment.
-   *
-   * <p>
-   * This allow to measure the time between actions, track how long something took, evaluate cooldowns or just get
-   * information about the played game time.
-   * </p>
-   *
-   * @return The game's temporal information.
-   * @see GameTime#now()
-   */
+  /// Gets time information about the running game/environment.
+  ///
+  /// This allow to measure the time between actions, track how long something took, evaluate cooldowns or just get
+  /// information about the played game time.
+  ///
+  /// @return The game's temporal information.
+  /// @see GameTime#now()
   public static GameTime time() {
     return gameTime;
   }
 
-  /**
-   * Gets the game's window in which the {@code RenderComponent} lives.<br>
-   * This class e.g. provides the possibility to set a title, provide an icon, get information about the resolution or set
-   * a cursor.
-   *
-   * @return The window that hosts the game's {@code RenderComponent}.
-   * @see RenderComponent
-   * @see GameWindow#getResolution()
-   * @see GameWindow#setTitle(String)
-   * @see GameWindow#setIcon(java.awt.Image)
-   * @see GameWindow#cursor()
-   */
+  /// Gets the game's window in which the `RenderComponent` lives.
+  ///
+  /// This class e.g. provides the possibility to set a title, provide an icon, get information about the resolution or set
+  /// a cursor.
+  ///
+  /// @return The window that hosts the game's `RenderComponent`.
+  /// @see RenderComponent
+  /// @see GameWindow#getResolution()
+  /// @see GameWindow#setTitle(String)
+  /// @see GameWindow#setIcon(java.awt.Image)
+  /// @see GameWindow#cursor()
   public static GameWindow window() {
     return gameWindow;
   }
 
-  /**
-   * Gets the engine's {@code SoundEngine} component that can be used to play sounds and music.<br>
-   * Sound can be loaded and accessed using the {@code Resources} API and are managed by the<br>
-   * {@code Resources.sounds()} resource container.
-   *
-   * <p>
-   * <i> Upon playing a sound, the engine returns an {@code SoundPlayback} instance that can then be used to further
-   * control the audio line. </i>
-   * </p>
-   *
-   * @return The engine's {@code SoundEngine} component.
-   * @see Sound
-   * @see Resources#sounds()
-   * @see SoundPlayback
-   * @see SoundEngine#playSound(de.gurkenlabs.litiengine.sound.Sound)
-   * @see SoundEngine#playMusic(de.gurkenlabs.litiengine.sound.Sound)
-   */
+  /// Gets the engine's `SoundEngine` component that can be used to play sounds and music.
+  ///
+  /// Sound can be loaded and accessed using the `Resources` API and are managed by the
+  ///
+  /// `Resources.sounds()` resource container.
+  ///
+  /// *Upon playing a sound, the engine returns an `SoundPlayback` instance that can then be used to further
+  /// control the audio line.*
+  ///
+  /// @return The engine's `SoundEngine` component.
+  /// @see Sound
+  /// @see Resources#sounds()
+  /// @see SoundPlayback
+  /// @see SoundEngine#playSound(de.gurkenlabs.litiengine.sound.Sound)
+  /// @see SoundEngine#playMusic(de.gurkenlabs.litiengine.sound.Sound)
   public static SoundEngine audio() {
     return soundEngine;
   }
 
-  /**
-   * Gets the engine's {@code PhysicsEngine} component that can be used to detect and resolve collision and move entities
-   * with respect to all collision entities on the environment.<br>
-   * The boundaries of the loaded environment also pose a "non-walkable" area that will be taken into account when moving
-   * entities with this engine.
-   *
-   * <p>
-   * <i>It is also possible to manually register static collision {@code Rectangles} that can further restrict the game
-   * world.</i>
-   * </p>
-   *
-   * @return The engine's {@code PhysicsEngine} component.
-   * @see PhysicsEngine
-   * @see PhysicsEngine#move(IMobileEntity, float)
-   * @see ICollisionEntity
-   */
+  /// Gets the engine's `PhysicsEngine` component that can be used to detect and resolve collision and move entities
+  /// with respect to all collision entities on the environment.
+  ///
+  /// The boundaries of the loaded environment also pose a "non-walkable" area that will be taken into account when moving
+  /// entities with this engine.
+  ///
+  /// *It is also possible to manually register static collision `Rectangles` that can further restrict the game
+  /// world.*
+  ///
+  /// @return The engine's `PhysicsEngine` component.
+  /// @see PhysicsEngine
+  /// @see PhysicsEngine#move(IMobileEntity, float)
+  /// @see ICollisionEntity
   public static PhysicsEngine physics() {
     return physicsEngine;
   }
 
-  /**
-   * Gets the engine's {@code RenderEngine} component that is used to render {@code Images, Shapes or Text} with respect
-   * to the environment and the render scale and the {@code Camera}.
-   *
-   * <p>
-   * <i>In case you want to render something in a static manner that is unrelated to the environment, you can use the
-   * engine's different static {@code Renderer} implementations.</i>
-   * </p>
-   *
-   * @return The engine's {@code RenderEngine} component.
-   * @see RenderEngine#getBaseRenderScale()
-   * @see TextRenderer
-   * @see ShapeRenderer
-   * @see ImageRenderer
-   */
+  /// Gets the engine's `RenderEngine` component that is used to render `Images, Shapes or Text` with respect
+  /// to the environment and the render scale and the `Camera`.
+  ///
+  /// *In case you want to render something in a static manner that is unrelated to the environment, you can use the
+  /// engine's different static `Renderer` implementations.*
+  ///
+  /// @return The engine's `RenderEngine` component.
+  /// @see RenderEngine#getBaseRenderScale()
+  /// @see TextRenderer
+  /// @see ShapeRenderer
+  /// @see ImageRenderer
   public static RenderEngine graphics() {
     return graphicsEngine;
   }
 
-  /**
-   * Gets the game's main loop that is used to execute and manage all game logic apart from input processing.<br>
-   * You can attach any {@code Updatable} instance to this loop if you want to execute custom game logic that is executed
-   * at the configured max fps.
-   * <p>
-   * The game's loop also executes the rendering process on the GameFrame's {@code RenderComponent}.<br>
-   * This internally renders the currently active screen which passes the {@code Graphics2D} object to all
-   * {@code GuiComponents} and the Environment for rendering.
-   * <p>
-   * <i>The LITIENGINE has two separate loops for game logic/rendering and input processing. <br>
-   * This prevents them from interfering with each other and to be able to process player input independent of the game's
-   * framerate.</i>
-   * </p>
-   *
-   * @return The game's main loop.
-   * @see ClientConfiguration#getMaxFps()
-   * @see IUpdateable
-   * @see ILoop#attach(IUpdateable)
-   * @see ILoop#detach(IUpdateable)
-   */
+  /// Gets the game's main loop that is used to execute and manage all game logic apart from input processing.
+  ///
+  /// You can attach any `Updatable` instance to this loop if you want to execute custom game logic that is executed
+  /// at the configured max fps.
+  ///
+  /// The game's loop also executes the rendering process on the GameFrame's `RenderComponent`.
+  ///
+  /// This internally renders the currently active screen which passes the `Graphics2D` object to all
+  /// `GuiComponents` and the Environment for rendering.
+  ///
+  /// *The LITIENGINE has two separate loops for game logic/rendering and input processing.
+  /// This prevents them from interfering with each other and to be able to process player input independent of the game's
+  /// framerate.*
+  ///
+  /// @return The game's main loop.
+  /// @see ClientConfiguration#getMaxFps()
+  /// @see IUpdateable
+  /// @see ILoop#attach(IUpdateable)
+  /// @see ILoop#detach(IUpdateable)
   public static IGameLoop loop() {
     return gameLoop;
   }
 
-  /**
-   * Gets the game's default logger instance that can be used to quickly log messages without the need to initialize
-   * custom logger instances.
-   *
-   * @return The game's default logger instance.
-   */
+  /// Gets the game's default logger instance that can be used to quickly log messages without the need to initialize
+  /// custom logger instances.
+  ///
+  /// @return The game's default logger instance.
   public static Logger log() {
     return log.log();
   }
 
-  /**
-   * Gets the game's pseudo-random generator that enhances the default Java {@code Random} implementation with helpful
-   * additions.
-   *
-   * @return The game's pseudo random generator.
-   */
+  /// Gets the game's pseudo-random generator that enhances the default Java `Random` implementation with helpful
+  /// additions.
+  ///
+  /// @return The game's pseudo random generator.
   public static GameRandom random() {
     return random;
   }
 
-  /**
-   * Gets the game's {@code ScreenManager} that is responsible for organizing all {@code Screens} of your game and
-   * providing the currently active {@code Screen} that is used to render the current {@code Environment}.<br>
-   * Screens are the containers that allow you to organize the visible contents of your game and are identified and
-   * addressed by a unique name.
-   *
-   * <p>
-   * <i>Examples: Menu Screen, Credits Screen, Game Screen, Inventory Screen</i>
-   * </p>
-   *
-   * @return The game's screen manager.
-   * @see Screen
-   * @see GameWorld#environment()
-   * @see Game#world()
-   */
+  /// Gets the game's `ScreenManager` that is responsible for organizing all `Screens` of your game and
+  /// providing the currently active `Screen` that is used to render the current `Environment`.
+  ///
+  /// Screens are the containers that allow you to organize the visible contents of your game and are identified and
+  /// addressed by a unique name.
+  ///
+  /// *Examples: Menu Screen, Credits Screen, Game Screen, Inventory Screen*
+  ///
+  /// @return The game's screen manager.
+  /// @see Screen
+  /// @see GameWorld#environment()
+  /// @see Game#world()
   public static ScreenManager screens() {
     return screenManager;
   }
 
-  /**
-   * Gets the game's world which is a global environment manager that contains all {@code Environments} and provides the
-   * currently active {@code Environment} and {@code Camera}.<br>
-   * <p>
-   * The {@code GameWorld} returns the same instance for a particular map/mapName until the
-   * {@code GameWorld.reset(String)} method is called.
-   * </p>
-   * <p>
-   * Moreover, it provides the possibility to attach game logic via {@code EnvironmentListeners} to different events of
-   * the {@code Envrionment's} life cycle (e.g. loaded, initialized, ...).<br>
-   * <i>This is typically used to provide some per-level logic or to trigger general loading behavior.</i>
-   *
-   * @return The game's environment manager.
-   * @see GameWorld
-   * @see Environment
-   * @see Camera
-   * @see GameWorld#environment()
-   * @see GameWorld#camera()
-   * @see GameWorld#reset(String)
-   */
+  /// Gets the game's world which is a global environment manager that contains all `Environments` and provides the
+  /// currently active `Environment` and `Camera`.
+  ///
+  /// The `GameWorld` returns the same instance for a particular map/mapName until the
+  /// `GameWorld.reset(String)` method is called.
+  ///
+  /// Moreover, it provides the possibility to attach game logic via `EnvironmentListeners` to different events of
+  /// the `Envrionment's` life cycle (e.g. loaded, initialized, ...).
+  ///
+  /// *This is typically used to provide some per-level logic or to trigger general loading behavior.*
+  ///
+  /// @return The game's environment manager.
+  /// @see GameWorld
+  /// @see Environment
+  /// @see Camera
+  /// @see GameWorld#environment()
+  /// @see GameWorld#camera()
+  /// @see GameWorld#reset(String)
   public static GameWorld world() {
     return world;
   }
 
-  /**
-   * Gets the game's Tween manager that holds all currently active Tween instances.
-   *
-   * @return The game's Tween manager.
-   */
+  /// Gets the game's Tween manager that holds all currently active Tween instances.
+  ///
+  /// @return The game's Tween manager.
   public static TweenEngine tweens() {
     return tweenEngine;
   }
 
-  /**
-   *
-   * @param preInitialization
-   *          a runnable used to prepare the game for initialization. This runnable will be started in the Swing Event
-   *          Dispatch Thread.
-   * @param postInitialization
-   *          a runnable used to setup the game directly after initialization. This runnable will be started in the Swing
-   *          Event Dispatch Thread.
-   * @param args
-   *          The arguments passed to the program's entry point.
-   * @throws AWTError
-   *           if this method is called on the Swing Event Dispatcher thread
-   */
+  /// @param preInitialization
+  /// a runnable used to prepare the game for initialization. This runnable will be started in the Swing Event
+  /// Dispatch Thread.
+  /// @param postInitialization
+  /// a runnable used to setup the game directly after initialization. This runnable will be started in the Swing
+  /// Event Dispatch Thread.
+  /// @param args
+  /// The arguments passed to the program's entry point.
+  /// @throws AWTError
+  /// if this method is called on the Swing Event Dispatcher thread
   public static void init(Runnable preInitialization, Runnable postInitialization, String... args) {
     try {
       if (SwingUtilities.isEventDispatchThread()) {
@@ -476,25 +418,22 @@ public final class Game {
     }
   }
 
-  /***
-   * Initializes the infrastructure of the LITIENGINE game.
-   *
-   * The following tasks are carried out by this method:
-   * <ul>
-   * <li>load the {@code GameConfiguration}</li>
-   * <li>handle the specified program parameters</li>
-   * <li>configure the logging</li>
-   * <li>set the programs {@code Locale} according to the configured values.</li>
-   * <li>initialize and attach core components like the {@code PhysicsEngine}</li>
-   * <li>initialize the {@code ScreenManger}</li>
-   * <li>initialize the {@code Input}</li>
-   * <li>initialize the {@code GameLoop} and {@code RenderLoop}</li>
-   * <li>set a default {@code Camera}</li>
-   * </ul>
-   *
-   * @param args
-   *          The arguments passed to the programs entry point.
-   */
+  /// Initializes the infrastructure of the LITIENGINE game.
+  ///
+  /// The following tasks are carried out by this method:
+  ///
+  /// - load the `GameConfiguration`
+  /// - handle the specified program parameters
+  /// - configure the logging
+  /// - set the programs `Locale` according to the configured values.
+  /// - initialize and attach core components like the `PhysicsEngine`
+  /// - initialize the `ScreenManger`
+  /// - initialize the `Input`
+  /// - initialize the `GameLoop` and `RenderLoop`
+  /// - set a default `Camera`
+  ///
+  /// @param args
+  /// The arguments passed to the programs entry point.
   public static void init(String... args) {
     init(!SwingUtilities.isEventDispatchThread(), args);
   }
@@ -563,15 +502,13 @@ public final class Game {
     };
   }
 
-  /**
-   * Initializes the infrastructure of the LITIENGINE game.
-   *
-   * @see #init(String...)
-   * @param initInSwingThread
-   *          used to determine if the game should be launched in the swing worker thread. This should be true in most
-   *          circumstances, unless you're already in the swing worker thread, in which case you MUST supply false.
-   * @param args
-   */
+  /// Initializes the infrastructure of the LITIENGINE game.
+  ///
+  /// @see #init(String...)
+  /// @param initInSwingThread
+  /// used to determine if the game should be launched in the swing worker thread. This should be true in most
+  /// circumstances, unless you're already in the swing worker thread, in which case you MUST supply false.
+  /// @param args
   public static void init(boolean initInSwingThread, String... args) {
     if (initInSwingThread) {
       try {
@@ -584,34 +521,27 @@ public final class Game {
     }
   }
 
-  /**
-   * Sets an {@code UncaughtExceptionHandler} used to handle all unexpected exceptions happening in the game.
-   *
-   * @param uncaughtExceptionHandler
-   *          The handler to be used for uncaught exceptions.
-   */
+  /// Sets an `UncaughtExceptionHandler` used to handle all unexpected exceptions happening in the game.
+  ///
+  /// @param uncaughtExceptionHandler
+  /// The handler to be used for uncaught exceptions.
   public static void setUncaughtExceptionHandler(UncaughtExceptionHandler uncaughtExceptionHandler) {
     gameLoop.setUncaughtExceptionHandler(uncaughtExceptionHandler);
     Thread.setDefaultUncaughtExceptionHandler(uncaughtExceptionHandler);
   }
 
-  /***
-   * <p>
-   * Starts the {@code GameLoops} and other components. After this method is called, the engine will start to render
-   * contents of the current {@code Screen} of the {@code ScreenManager}, the {@code SoundEngine} will start to playback
-   * {@code Sounds} and the different input devices (e.g. {@code Mouse}, {@code Keyboard}) will start to process player
-   * input.
-   * </p>
-   * <p>
-   * When the {@code Game} has started up successfully, it'll callback to the registered {@code GameListeners}.
-   * </p>
-   *
-   * @see ScreenManager#current()
-   * @see SoundEngine
-   * @see Input
-   * @see GameListener#started()
-   * @see #hasStarted()
-   */
+  /// Starts the `GameLoops` and other components. After this method is called, the engine will start to render
+  /// contents of the current `Screen` of the `ScreenManager`, the `SoundEngine` will start to playback
+  /// `Sounds` and the different input devices (e.g. `Mouse`, `Keyboard`) will start to process player
+  /// input.
+  ///
+  /// When the `Game` has started up successfully, it'll callback to the registered `GameListeners`.
+  ///
+  /// @see ScreenManager#current()
+  /// @see SoundEngine
+  /// @see Input
+  /// @see GameListener#started()
+  /// @see #hasStarted()
   public static void start() {
     Runnable r = () -> {
       if (!SwingUtilities.isEventDispatchThread()) {
@@ -650,32 +580,27 @@ public final class Game {
     }
   }
 
-  /**
-   * Sets the {@code Game's} basic information by the specified {@code GameInfo} instance.
-   * <p>
-   * <i>Typically, this should not be called manually because the {@code Game} already provides a {@code GameInfo} object
-   * which can be adjusted.<br>
-   * If you just want to edit some of it's information, use the provided instance of {@link Game#info()}. </i>
-   * </p>
-   *
-   * @param info
-   *          The {@code GameInfo} that contains the basic information for the game.
-   * @see Game#info()
-   * @see GameInfo
-   */
+  /// Sets the `Game's` basic information by the specified `GameInfo` instance.
+  ///
+  /// *Typically, this should not be called manually because the `Game` already provides a `GameInfo` object
+  /// which can be adjusted.
+  /// If you just want to edit some of it's information, use the provided instance of [Game#info()].*
+  ///
+  /// @param info
+  /// The `GameInfo` that contains the basic information for the game.
+  /// @see Game#info()
+  /// @see GameInfo
   public static void setInfo(final GameInfo info) {
     gameInfo = info;
   }
 
-  /**
-   * Sets the {@code Game's} basic information by loading the {@code GameInfo} from the specified path to an XML file.
-   *
-   * @param gameInfoFile
-   *          The path to the XML file that contains the serialized {@code GameInfo}.
-   * @see Game#setInfo(GameInfo)
-   * @see Game#info()
-   * @see GameInfo
-   */
+  /// Sets the `Game's` basic information by loading the `GameInfo` from the specified path to an XML file.
+  ///
+  /// @param gameInfoFile
+  /// The path to the XML file that contains the serialized `GameInfo`.
+  /// @see Game#setInfo(GameInfo)
+  /// @see Game#info()
+  /// @see GameInfo
   public static void setInfo(String gameInfoFile) {
     setInfo(Resources.getLocation(gameInfoFile));
   }
@@ -707,9 +632,7 @@ public final class Game {
     return true;
   }
 
-  /**
-   * Terminates the game, releases all engine resources, saves configuration, and notifies listeners.
-   */
+  /// Terminates the game, releases all engine resources, saves configuration, and notifies listeners.
   public static void terminate() {
     if (!initialized) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameInfo.java
@@ -11,18 +11,15 @@ import jakarta.xml.bind.annotation.XmlTransient;
 
 import de.gurkenlabs.litiengine.environment.tilemap.xml.CustomPropertyProvider;
 
-/**
- * The {@code GameInfo} class contains basic information about a LITIENGINE game. The information can be accessed via
- * {@code Game.getInfo()} and the infrastructure also internally uses this information e.g. to setup the main window of
- * the Game by providing an appropriate title.
- * <p>
- * It should be the first thing that you do in you application entry point to setup or load this information. Note that
- * it's possible to keep this information in an XML file and load it up by calling {@code Game.setInfo(String)}.
- * </p>
- *
- * @see Game#info()
- * @see Game#setInfo(String)
- */
+/// The `GameInfo` class contains basic information about a LITIENGINE game. The information can be accessed via
+/// `Game.getInfo()` and the infrastructure also internally uses this information e.g. to setup the main window of
+/// the Game by providing an appropriate title.
+///
+/// It should be the first thing that you do in you application entry point to setup or load this information. Note that
+/// it's possible to keep this information in an XML file and load it up by calling `Game.setInfo(String)`.
+///
+/// @see Game#info()
+/// @see Game#setInfo(String)
 @XmlRootElement(name = "gameinfo")
 public class GameInfo extends CustomPropertyProvider {
   private static final Logger log = Logger.getLogger(GameInfo.class.getName());
@@ -51,9 +48,7 @@ public class GameInfo extends CustomPropertyProvider {
   @XmlElement(name = "developer")
   private String[] developers;
 
-  /**
-   * Initializes a new instance of the {@code GameInfo} class.
-   */
+  /// Initializes a new instance of the `GameInfo` class.
   public GameInfo() {
     this.company = "gurkenlabs";
     this.name = "LITIENGINE Game";
@@ -64,45 +59,37 @@ public class GameInfo extends CustomPropertyProvider {
     this.website = "https://litiengine.com";
   }
 
-  /**
-   * Gets the company that created the game.
-   *
-   * @return The company that created the game.
-   */
+  /// Gets the company that created the game.
+  ///
+  /// @return The company that created the game.
   @XmlTransient
   public String getCompany() {
     return this.company;
   }
 
-  /**
-   * Gets a textual description that explains what the game is all about.
-   *
-   * @return The game's description.
-   */
+  /// Gets a textual description that explains what the game is all about.
+  ///
+  /// @return The game's description.
   @XmlTransient
   public String getDescription() {
     return this.description;
   }
 
-  /**
-   * Gets the web site of this game project.
-   *
-   * @return The web site of the game.
-   */
+  /// Gets the web site of this game project.
+  ///
+  /// @return The web site of the game.
   @XmlTransient
   public String getWebsite() {
     return this.website;
   }
 
-  /**
-   * Gets the {@link #getWebsite()} as an {@code URL} object that can be used to further process the information. (e.g.
-   * the web site can be opened in the browser).
-   *
-   * @return The game's web site as {@code URL}
-   *
-   * @see URL
-   * @see #getWebsite()
-   */
+  /// Gets the [#getWebsite()] as an `URL` object that can be used to further process the information. (e.g.
+  /// the web site can be opened in the browser).
+  ///
+  /// @return The game's web site as `URL`
+  ///
+  /// @see URL
+  /// @see #getWebsite()
   @XmlTransient
   public URL getWebsiteURL() {
     if (this.getWebsite() == null || this.getWebsite().isEmpty()) {
@@ -117,162 +104,139 @@ public class GameInfo extends CustomPropertyProvider {
     }
   }
 
-  /**
-   * Gets the developers of the game. This can e.g. be used for credits.
-   *
-   * @return The game's developers.
-   */
+  /// Gets the developers of the game. This can e.g. be used for credits.
+  ///
+  /// @return The game's developers.
   @XmlTransient
   public String[] getDevelopers() {
     return this.developers;
   }
 
-  /**
-   * Gets the name of the LITIENGINE game.
-   *
-   * @return The game's name.
-   */
+  /// Gets the name of the LITIENGINE game.
+  ///
+  /// @return The game's name.
   @XmlTransient
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Gets the publisher of the game.
-   *
-   * @return The game's publisher.
-   */
+  /// Gets the publisher of the game.
+  ///
+  /// @return The game's publisher.
   @XmlTransient
   public String getPublisher() {
     return this.publisher;
   }
 
-  /**
-   * Gets the sub title of the game. It is basically an addendum to the {@link #getName()}.
-   *
-   * @return The game's sub title.
-   */
+  /// Gets the sub title of the game. It is basically an addendum to the [#getName()].
+  ///
+  /// @return The game's sub title.
   @XmlTransient
   public String getSubTitle() {
     return this.subtitle;
   }
 
-  /**
-   * Gets the version of the game.
-   *
-   * @return The game's version.
-   */
+  /// Gets the version of the game.
+  ///
+  /// @return The game's version.
   @XmlTransient
   public String getVersion() {
     return this.version;
   }
 
-  /**
-   * Gets the title of the game.<br>
-   * This will be used as the title of the game's window by default and includes the core information about the game:
-   * <ul>
-   * <li>The game's name</li>
-   * <li>The game's version</li>
-   * <li><i>opt. The game's subtitle</i></li>
-   * </ul>
-   *
-   * @return The game's title.
-   *
-   * @see #getName()
-   * @see #getSubTitle()
-   * @see #getVersion()
-   */
+  /// Gets the title of the game.
+  ///
+  /// This will be used as the title of the game's window by default and includes the core information about the game:
+  ///
+  /// - The game's name
+  /// - The game's version
+  /// - *opt. The game's subtitle*
+  ///
+  /// @return The game's title.
+  ///
+  /// @see #getName()
+  /// @see #getSubTitle()
+  /// @see #getVersion()
   public String getTitle() {
     return this.getSubTitle() != null && !this.getSubTitle().isEmpty() ? this.getName() + " " + this.getVersion() + " - " + this.getSubTitle()
         : this.getName() + " " + this.getVersion();
   }
 
-  /**
-   * Sets the company that created the game.
-   *
-   * @param company
-   *          The company that created the game.
-   */
+  /// Sets the company that created the game.
+  ///
+  /// @param company
+  /// The company that created the game.
   public void setCompany(final String company) {
     this.company = company;
   }
 
-  /**
-   * Sets the game's description. This can be seen as additional information about the game and will not be part of the
-   * game's title.
-   *
-   * @param description
-   *          The game's description.
-   *
-   * @see #getTitle()
-   */
+  /// Sets the game's description. This can be seen as additional information about the game and will not be part of the
+  /// game's title.
+  ///
+  /// @param description
+  /// The game's description.
+  ///
+  /// @see #getTitle()
   public void setDescription(final String description) {
     this.description = description;
   }
 
-  /**
-   * Sets the game's developers.
-   *
-   * @param developers
-   *          The game's developers.
-   */
+  /// Sets the game's developers.
+  ///
+  /// @param developers
+  /// The game's developers.
   public void setDevelopers(final String... developers) {
     this.developers = developers;
   }
 
-  /**
-   * Sets the game's name. <br>
-   * This is the most basic information about a game and will be part of the game's title.
-   *
-   * @param name
-   *          The game's name.
-   *
-   * @see #getTitle()
-   */
+  /// Sets the game's name.
+  ///
+  /// This is the most basic information about a game and will be part of the game's title.
+  ///
+  /// @param name
+  /// The game's name.
+  ///
+  /// @see #getTitle()
   public void setName(final String name) {
     this.name = name;
   }
 
-  /**
-   * Sets the game's sub title. <br>
-   * This is basically an addendum to the game's name and will also be part of the game's title.
-   *
-   * @param subTitle
-   *          The game's sub title.
-   *
-   * @see #getName()
-   * @see #getTitle()
-   */
+  /// Sets the game's sub title.
+  ///
+  /// This is basically an addendum to the game's name and will also be part of the game's title.
+  ///
+  /// @param subTitle
+  /// The game's sub title.
+  ///
+  /// @see #getName()
+  /// @see #getTitle()
   public void setSubTitle(final String subTitle) {
     this.subtitle = subTitle;
   }
 
-  /**
-   * Sets the game's version. <br>
-   * This is a textual representation of the game's version and will also be part of the game's title.<br>
-   * Examples for good semantic version strings:
-   * <ul>
-   * <li>v0.1.0</li>
-   * <li>0.1.5.2</li>
-   * <li>v1.0.0-RC1</li>
-   * <li>v0.0.1-alpha</li>
-   * </ul>
-   *
-   * @param version
-   *          The game's version.
-   *
-   * @see #getTitle()
-   */
+  /// Sets the game's version.
+  ///
+  /// This is a textual representation of the game's version and will also be part of the game's title.
+  ///
+  /// Examples for good semantic version strings:
+  ///
+  /// - v0.1.0
+  /// - 0.1.5.2
+  /// - v1.0.0-RC1
+  /// - v0.0.1-alpha
+  ///
+  /// @param version
+  /// The game's version.
+  ///
+  /// @see #getTitle()
   public void setVersion(final String version) {
     this.version = version;
   }
 
-  /**
-   * Sets the game's web site.
-   *
-   * @param website
-   *          The game's web site.
-   */
+  /// Sets the game's web site.
+  ///
+  /// @param website
+  /// The game's web site.
   public void setWebsite(final String website) {
     this.website = website;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameListener.java
@@ -2,40 +2,30 @@ package de.gurkenlabs.litiengine;
 
 import java.util.EventListener;
 
-/**
- * This listener interface is used for receiving events about the general life-cycle of the {@code Game} (e.g.
- * started/terminated).
- */
+/// This listener interface is used for receiving events about the general life-cycle of the `Game` (e.g.
+/// started/terminated).
 public interface GameListener extends EventListener {
 
-  /**
-   * This method gets called after the {@code Game.start} method was executed.
-   * 
-   * @see Game#start()
-   */
+  /// This method gets called after the `Game.start` method was executed.
+  ///
+  /// @see Game#start()
   default void started() {}
 
-  /**
-   * This method gets called after the {@code Game.init(String...)} method was executed.
-   * 
-   * @param args
-   *          The arguments that were passed to the application.
-   * @see Game#init(String...)
-   */
+  /// This method gets called after the `Game.init(String...)` method was executed.
+  ///
+  /// @param args
+  /// The arguments that were passed to the application.
+  /// @see Game#init(String...)
   default void initialized(String... args) {}
 
-  /**
-   * This method gets called before the {@code Game} is about to be terminated. Returning false prevents the terminate
-   * event to continue.
-   *
-   * @return Return false to interrupt the termination process.
-   */
+  /// This method gets called before the `Game` is about to be terminated. Returning false prevents the terminate
+  /// event to continue.
+  ///
+  /// @return Return false to interrupt the termination process.
   default boolean terminating() {
     return true;
   }
 
-  /**
-   * This method is called when the {@code Game} was terminated (just before {@code System.exit} is about to be called).
-   */
+  /// This method is called when the `Game` was terminated (just before `System.exit` is about to be called).
   default void terminated() {}
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameLog.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameLog.java
@@ -9,12 +9,10 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
-/**
- * The {@code GameLog} class provides a general purpose logger for games. It prevents the necessity to create custom
- * logger instances and provides a simplified way to quickly log events.
- *
- * @see Game#log()
- */
+/// The `GameLog` class provides a general purpose logger for games. It prevents the necessity to create custom
+/// logger instances and provides a simplified way to quickly log events.
+///
+/// @see Game#log()
 final class GameLog {
   private static final String LOGGING_CONFIG_FILE = "logging.properties";
   private static final Logger log = Logger.getLogger(GameLog.class.getName());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameLoop.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameLoop.java
@@ -9,24 +9,19 @@ import de.gurkenlabs.litiengine.input.Input;
 import de.gurkenlabs.litiengine.input.Keyboard;
 import de.gurkenlabs.litiengine.input.Mouse;
 
-/**
- * The main update loop that executes the game logic by calling the update functions on all registered
- * {@code IUpdatable} instances. Subsequently, it performs the rendering of the current frame and tracks some
- * performance metrics on the process.
- *
- * @see IUpdateable#update()
- * @see Game#loop()
- * @see RenderComponent#render()
- */
+/// The main update loop that executes the game logic by calling the update functions on all registered
+/// `IUpdatable` instances. Subsequently, it performs the rendering of the current frame and tracks some
+/// performance metrics on the process.
+///
+/// @see IUpdateable#update()
+/// @see Game#loop()
+/// @see RenderComponent#render()
 public final class GameLoop extends UpdateLoop implements IGameLoop {
-  /**
-   * The tick {@link #getDeltaTime()} at which we consider the game not to run fluently anymore.
-   * <ul>
-   * <li>16.6 ms: 60 FPS</li>
-   * <li>33.3 ms: 30 FPS</li>
-   * <li>66.6 ms: 15 FPS</li>
-   * </ul>
-   */
+  /// The tick [#getDeltaTime()] at which we consider the game not to run fluently anymore.
+  ///
+  /// - 16.6 ms: 60 FPS
+  /// - 33.3 ms: 30 FPS
+  /// - 66.6 ms: 15 FPS
   public static final int TICK_DELTATIME_LAG = 67;
 
   private static int executionIndex = -1;
@@ -75,10 +70,8 @@ public final class GameLoop extends UpdateLoop implements IGameLoop {
     this.actions.removeIf(x -> x.getId() == id);
   }
 
-  /**
-   * In addition to the normal base implementation, the {@code GameLoop} performs registered action at the required time
-   * and tracks some detailed metrics.
-   */
+  /// In addition to the normal base implementation, the `GameLoop` performs registered action at the required time
+  /// and tracks some detailed metrics.
   @Override
   protected void process() {
     this.updateInvariableEngineComponents();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameMetrics.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameMetrics.java
@@ -11,18 +11,14 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import de.gurkenlabs.litiengine.configuration.ClientConfiguration;
 import de.gurkenlabs.litiengine.graphics.IRenderable;
 
-/**
- * The class {@code GameMetrics} provides meta information about the game's metrics. This allows the developer to get a
- * feeling about the performance of different aspects (e.g. memory consumption, potential fps, network traffic, ...) and
- * to identify potential issues.
- * 
- * <p>
- * This information can be rendered as debug information if configured to get live data during a gameplay session.
- * </p>
- *
- * @see ClientConfiguration#showGameMetrics()
- * @see #render(Graphics2D)
- */
+/// The class `GameMetrics` provides meta information about the game's metrics. This allows the developer to get a
+/// feeling about the performance of different aspects (e.g. memory consumption, potential fps, network traffic, ...) and
+/// to identify potential issues.
+///
+/// This information can be rendered as debug information if configured to get live data during a gameplay session.
+///
+/// @see ClientConfiguration#showGameMetrics()
+/// @see #render(Graphics2D)
 public final class GameMetrics implements IRenderable {
   private static final Font TITLE_FONT = new Font(Font.MONOSPACED, Font.BOLD, 12);
   private static final Font METRIC_FONT = new Font(Font.MONOSPACED, Font.PLAIN, 12);
@@ -54,11 +50,9 @@ public final class GameMetrics implements IRenderable {
     return this.framesPerSecond;
   }
 
-  /**
-   * Gets the estimated maximum frame rate based on the latest frame processing time.
-   *
-   * @return the estimated maximum frames per second
-   */
+  /// Gets the estimated maximum frame rate based on the latest frame processing time.
+  ///
+  /// @return the estimated maximum frames per second
   public int getEstimatedMaxFramesPerSecond() {
     return this.maxFramesPerSecond;
   }
@@ -121,15 +115,13 @@ public final class GameMetrics implements IRenderable {
     this.maxFramesPerSecond = maxFrames;
   }
 
-  /**
-   * Sets the color that is used when rendering the metrics if {@code cl_showGameMetrics = true}.
-   * 
-   * @param color
-   *          The color for rendering the metrics.
-   * 
-   * @see ClientConfiguration#showGameMetrics()
-   * @see GameMetrics#render(Graphics2D)
-   */
+  /// Sets the color that is used when rendering the metrics if `cl_showGameMetrics = true`.
+  ///
+  /// @param color
+  /// The color for rendering the metrics.
+  ///
+  /// @see ClientConfiguration#showGameMetrics()
+  /// @see GameMetrics#render(Graphics2D)
   public void setRenderColor(Color color) {
     this.renderColor = color;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameRandom.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameRandom.java
@@ -14,9 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * A random number generator instance that provides enhanced functionalities for the java default {@code Random} implementation.
- */
+/// A random number generator instance that provides enhanced functionalities for the java default `Random` implementation.
 public final class GameRandom extends java.util.Random {
   private static final String INVALID_BOUNDS_ERROR = "min value is > than max value";
   private static final String ARRAY_MUST_NOT_BE_EMPTY = "array to chose an element from must not be null or empty.";
@@ -26,12 +24,10 @@ public final class GameRandom extends java.util.Random {
   GameRandom() {
   }
 
-  /**
-   * Sets the seed of this random number generator using a {@code String} seed.
-   *
-   * @param seed The initial seed.
-   * @see #setSeed(long)
-   */
+  /// Sets the seed of this random number generator using a `String` seed.
+  ///
+  /// @param seed The initial seed.
+  /// @see #setSeed(long)
   public void setSeed(String seed) {
     this.setSeed(seed.hashCode());
   }
@@ -63,16 +59,14 @@ public final class GameRandom extends java.util.Random {
     return sampled;
   }
 
-  /**
-   * Samples a specified amount of elements from the given collection.
-   *
-   * @param <T>         The type of the elements in the collection.
-   * @param collection  The collection to sample from.
-   * @param amount      The number of elements to sample.
-   * @param replacement Indicates whether sampling is with replacement.
-   * @return A collection containing the sampled elements.
-   * @throws IllegalArgumentException if the amount is greater than the collection size when sampling without replacement.
-   */
+  /// Samples a specified amount of elements from the given collection.
+  ///
+  /// @param <T>         The type of the elements in the collection.
+  /// @param collection  The collection to sample from.
+  /// @param amount      The number of elements to sample.
+  /// @param replacement Indicates whether sampling is with replacement.
+  /// @return A collection containing the sampled elements.
+  /// @throws IllegalArgumentException if the amount is greater than the collection size when sampling without replacement.
   public <T> Collection<T> sample(final Collection<T> collection, int amount, boolean replacement) {
     if (!replacement && collection.size() < amount) {
       throw new IllegalArgumentException(INVALID_AMOUNT_FOR_SAMPLING_WITHOUT_REPLACEMENT);
@@ -94,13 +88,11 @@ public final class GameRandom extends java.util.Random {
     return copied;
   }
 
-  /**
-   * Chooses a pseudo-random element from the specified array.
-   *
-   * @param <T>   The type of the elements in the array.
-   * @param array The array to choose from.
-   * @return A pseudo-random element from the array or null if the array is empty.
-   */
+  /// Chooses a pseudo-random element from the specified array.
+  ///
+  /// @param <T>   The type of the elements in the array.
+  /// @param array The array to choose from.
+  /// @return A pseudo-random element from the array or null if the array is empty.
   public <T> T choose(T[] array) {
     if (array == null || array.length == 0) {
       return null;
@@ -109,13 +101,11 @@ public final class GameRandom extends java.util.Random {
     return array[this.nextInt(array.length)];
   }
 
-  /**
-   * Chooses a pseudo-random element from the specified array.
-   *
-   * @param array The array to choose from.
-   * @return A pseudo-random element from the array.
-   * @throws IllegalArgumentException When the specified array is null or empty.
-   */
+  /// Chooses a pseudo-random element from the specified array.
+  ///
+  /// @param array The array to choose from.
+  /// @return A pseudo-random element from the array.
+  /// @throws IllegalArgumentException When the specified array is null or empty.
   public int choose(int... array) {
     if (array == null || array.length == 0) {
       throw new IllegalArgumentException(ARRAY_MUST_NOT_BE_EMPTY);
@@ -124,13 +114,11 @@ public final class GameRandom extends java.util.Random {
     return array[this.nextInt(array.length)];
   }
 
-  /**
-   * Chooses a pseudo-random element from the specified array.
-   *
-   * @param array The array to choose from.
-   * @return A pseudo-random element from the array.
-   * @throws IllegalArgumentException When the specified array is null or empty.
-   */
+  /// Chooses a pseudo-random element from the specified array.
+  ///
+  /// @param array The array to choose from.
+  /// @return A pseudo-random element from the array.
+  /// @throws IllegalArgumentException When the specified array is null or empty.
   public long choose(long... array) {
     if (array == null || array.length == 0) {
       throw new IllegalArgumentException(ARRAY_MUST_NOT_BE_EMPTY);
@@ -139,13 +127,11 @@ public final class GameRandom extends java.util.Random {
     return array[this.nextInt(array.length)];
   }
 
-  /**
-   * Chooses a pseudo-random element from the specified array.
-   *
-   * @param array The array to choose from.
-   * @return A pseudo-random element from the array.
-   * @throws IllegalArgumentException When the specified array is null or empty.
-   */
+  /// Chooses a pseudo-random element from the specified array.
+  ///
+  /// @param array The array to choose from.
+  /// @return A pseudo-random element from the array.
+  /// @throws IllegalArgumentException When the specified array is null or empty.
   public double choose(double... array) {
     if (array == null || array.length == 0) {
       throw new IllegalArgumentException(ARRAY_MUST_NOT_BE_EMPTY);
@@ -154,13 +140,11 @@ public final class GameRandom extends java.util.Random {
     return array[this.nextInt(array.length)];
   }
 
-  /**
-   * Chooses a pseudo-random element from the specified array.
-   *
-   * @param array The array to choose from.
-   * @return A pseudo-random element from the array.
-   * @throws IllegalArgumentException When the specified array is null or empty.
-   */
+  /// Chooses a pseudo-random element from the specified array.
+  ///
+  /// @param array The array to choose from.
+  /// @return A pseudo-random element from the array.
+  /// @throws IllegalArgumentException When the specified array is null or empty.
   public String choose(String... array) {
     if (array == null || array.length == 0) {
       throw new IllegalArgumentException(ARRAY_MUST_NOT_BE_EMPTY);
@@ -169,13 +153,11 @@ public final class GameRandom extends java.util.Random {
     return array[this.nextInt(array.length)];
   }
 
-  /**
-   * Chooses a pseudo-random element from the specified collection.
-   *
-   * @param <T>  The type of the elements in the collection.
-   * @param coll The collection to choose from.
-   * @return A pseudo-random element from the array or null if the collection is empty.
-   */
+  /// Chooses a pseudo-random element from the specified collection.
+  ///
+  /// @param <T>  The type of the elements in the collection.
+  /// @param coll The collection to choose from.
+  /// @return A pseudo-random element from the array or null if the collection is empty.
   public <T> T choose(Collection<T> coll) {
     if (coll == null || coll.isEmpty()) {
       return null;
@@ -191,12 +173,10 @@ public final class GameRandom extends java.util.Random {
     return null;
   }
 
-  /**
-   * Shuffles the elements in the specified array.
-   *
-   * @param <T>   The type of the elements in the collection.
-   * @param array The array to be shuffled.
-   */
+  /// Shuffles the elements in the specified array.
+  ///
+  /// @param <T>   The type of the elements in the collection.
+  /// @param array The array to be shuffled.
   public <T> void shuffle(T[] array) {
     for (int i = 0; i < array.length; i++) {
       int randomPosition = this.nextInt(array.length);
@@ -206,11 +186,9 @@ public final class GameRandom extends java.util.Random {
     }
   }
 
-  /**
-   * Shuffles the elements in the specified array.
-   *
-   * @param array The array to be shuffled.
-   */
+  /// Shuffles the elements in the specified array.
+  ///
+  /// @param array The array to be shuffled.
   public void shuffle(int[] array) {
     for (int i = 0; i < array.length; i++) {
       int randomPosition = this.nextInt(array.length);
@@ -220,11 +198,9 @@ public final class GameRandom extends java.util.Random {
     }
   }
 
-  /**
-   * Shuffles the elements in the specified array.
-   *
-   * @param array The array to be shuffled.
-   */
+  /// Shuffles the elements in the specified array.
+  ///
+  /// @param array The array to be shuffled.
   public void shuffle(long[] array) {
     for (int i = 0; i < array.length; i++) {
       int randomPosition = this.nextInt(array.length);
@@ -234,11 +210,9 @@ public final class GameRandom extends java.util.Random {
     }
   }
 
-  /**
-   * Shuffles the elements in the specified array.
-   *
-   * @param array The array to be shuffled.
-   */
+  /// Shuffles the elements in the specified array.
+  ///
+  /// @param array The array to be shuffled.
   public void shuffle(double[] array) {
     for (int i = 0; i < array.length; i++) {
       int randomPosition = this.nextInt(array.length);
@@ -248,93 +222,75 @@ public final class GameRandom extends java.util.Random {
     }
   }
 
-  /**
-   * Shuffles the elements in the specified collection.
-   *
-   * @param <T>  The type of the elements in the collection.
-   * @param coll The collection to be shuffled.
-   */
+  /// Shuffles the elements in the specified collection.
+  ///
+  /// @param <T>  The type of the elements in the collection.
+  /// @param coll The collection to be shuffled.
   public <T> void shuffle(List<T> coll) {
     Collections.shuffle(coll, this);
   }
 
-  /**
-   * Gets a random algebraic sign that can be used to multiply values with it.
-   *
-   * <p>
-   * This either returns 1 or -1 depending on the random outcome.
-   * </p>
-   *
-   * @return A random sign for algebraic operations.
-   */
+  /// Gets a random algebraic sign that can be used to multiply values with it.
+  ///
+  /// This either returns 1 or -1 depending on the random outcome.
+  ///
+  /// @return A random sign for algebraic operations.
   public int nextSign() {
     return this.nextBoolean() ? 1 : -1;
   }
 
-  /**
-   * Shuffles the algebraic sign of the specified int value.
-   *
-   * @param value The value to shuffle.
-   * @return Either the specified value; or its negative equivalent (multiplied by -1).
-   * @see #nextSign()
-   */
+  /// Shuffles the algebraic sign of the specified int value.
+  ///
+  /// @param value The value to shuffle.
+  /// @return Either the specified value; or its negative equivalent (multiplied by -1).
+  /// @see #nextSign()
   public int shuffleSign(int value) {
     return value * this.nextSign();
   }
 
-  /**
-   * Shuffles the algebraic sign of the specified float value.
-   *
-   * @param value The value to shuffle.
-   * @return Either the specified value; or its negative equivalent (multiplied by -1).
-   * @see #nextSign()
-   */
+  /// Shuffles the algebraic sign of the specified float value.
+  ///
+  /// @param value The value to shuffle.
+  /// @return Either the specified value; or its negative equivalent (multiplied by -1).
+  /// @see #nextSign()
   public float shuffleSign(float value) {
     return value * this.nextSign();
   }
 
-  /**
-   * Shuffles the algebraic sign of the specified long value.
-   *
-   * @param value The value to shuffle.
-   * @return Either the specified value; or its negative equivalent (multiplied by -1).
-   * @see #nextSign()
-   */
+  /// Shuffles the algebraic sign of the specified long value.
+  ///
+  /// @param value The value to shuffle.
+  /// @return Either the specified value; or its negative equivalent (multiplied by -1).
+  /// @see #nextSign()
   public long shuffleSign(long value) {
     return value * this.nextSign();
   }
 
-  /**
-   * Shuffles the algebraic sign of the specified double value.
-   *
-   * @param value The value to shuffle.
-   * @return Either the specified value; or its negative equivalent (multiplied by -1).
-   * @see #nextSign()
-   */
+  /// Shuffles the algebraic sign of the specified double value.
+  ///
+  /// @param value The value to shuffle.
+  /// @return Either the specified value; or its negative equivalent (multiplied by -1).
+  /// @see #nextSign()
   public double shuffleSign(double value) {
     return value * this.nextSign();
   }
 
-  /**
-   * Returns a pseudo-random {@code long} value between zero (inclusive) and the specified bound (exclusive).
-   *
-   * @param bound the upper bound (exclusive). Must be positive.
-   * @return a pseudo-random {@code long} value between zero (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code bound} is not positive
-   */
+  /// Returns a pseudo-random `long` value between zero (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param bound the upper bound (exclusive). Must be positive.
+  /// @return a pseudo-random `long` value between zero (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `bound` is not positive
   @Override
   public long nextLong(final long bound) {
     return this.nextLong(0, bound);
   }
 
-  /**
-   * Returns a pseudo-random {@code long} value between the specified origin (inclusive) and the specified bound (exclusive).
-   *
-   * @param min   the least value returned
-   * @param bound the upper bound (exclusive)
-   * @return a pseudo-random {@code long} value between the origin (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code origin} is greater than {@code bound}
-   */
+  /// Returns a pseudo-random `long` value between the specified origin (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param min   the least value returned
+  /// @param bound the upper bound (exclusive)
+  /// @return a pseudo-random `long` value between the origin (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `origin` is greater than `bound`
   @Override
   public long nextLong(final long min, final long bound) {
     if (min == bound) {
@@ -348,26 +304,22 @@ public final class GameRandom extends java.util.Random {
     return min + this.nextLong() * (bound - min);
   }
 
-  /**
-   * Returns a pseudo-random {@code double} value between zero (inclusive) and the specified bound (exclusive).
-   *
-   * @param bound the upper bound (exclusive). Must be positive.
-   * @return a pseudo-random {@code double} value between zero (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code bound} is not positive
-   */
+  /// Returns a pseudo-random `double` value between zero (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param bound the upper bound (exclusive). Must be positive.
+  /// @return a pseudo-random `double` value between zero (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `bound` is not positive
   @Override
   public double nextDouble(final double bound) {
     return this.nextDouble(0, bound);
   }
 
-  /**
-   * Returns a pseudo-random {@code double} value between the specified origin (inclusive) and the specified bound (exclusive).
-   *
-   * @param min   the least value returned
-   * @param bound the upper bound (exclusive)
-   * @return a pseudo-random {@code double} value between the origin (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code origin} is greater than {@code bound}
-   */
+  /// Returns a pseudo-random `double` value between the specified origin (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param min   the least value returned
+  /// @param bound the upper bound (exclusive)
+  /// @return a pseudo-random `double` value between the origin (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `origin` is greater than `bound`
   @Override
   public double nextDouble(final double min, final double bound) {
     if (min == bound) {
@@ -381,26 +333,22 @@ public final class GameRandom extends java.util.Random {
     return min + this.nextDouble() * (bound - min);
   }
 
-  /**
-   * Returns a pseudo-random {@code float} value between zero (inclusive) and the specified bound (exclusive).
-   *
-   * @param bound the upper bound (exclusive). Must be positive.
-   * @return a pseudo-random {@code float} value between zero (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code bound} is not positive
-   */
+  /// Returns a pseudo-random `float` value between zero (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param bound the upper bound (exclusive). Must be positive.
+  /// @return a pseudo-random `float` value between zero (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `bound` is not positive
   @Override
   public float nextFloat(final float bound) {
     return this.nextFloat(0, bound);
   }
 
-  /**
-   * Returns a pseudo-random {@code float} value between the specified origin (inclusive) and the specified bound (exclusive).
-   *
-   * @param min   the least value returned
-   * @param bound the upper bound (exclusive)
-   * @return a pseudo-random {@code float} value between the origin (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code origin} is greater than {@code bound}
-   */
+  /// Returns a pseudo-random `float` value between the specified origin (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param min   the least value returned
+  /// @param bound the upper bound (exclusive)
+  /// @return a pseudo-random `float` value between the origin (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `origin` is greater than `bound`
   @Override
   public float nextFloat(final float min, final float bound) {
     if (min == bound) {
@@ -414,14 +362,12 @@ public final class GameRandom extends java.util.Random {
     return min + this.nextFloat() * (bound - min);
   }
 
-  /**
-   * Returns a pseudo-random {@code int} value between the specified origin (inclusive) and the specified bound (exclusive).
-   *
-   * @param min   the least value returned
-   * @param bound the upper bound (exclusive)
-   * @return a pseudo-random {@code int} value between the origin (inclusive) and the bound (exclusive)
-   * @throws IllegalArgumentException if {@code origin} is greater than {@code bound}
-   */
+  /// Returns a pseudo-random `int` value between the specified origin (inclusive) and the specified bound (exclusive).
+  ///
+  /// @param min   the least value returned
+  /// @param bound the upper bound (exclusive)
+  /// @return a pseudo-random `int` value between the origin (inclusive) and the bound (exclusive)
+  /// @throws IllegalArgumentException if `origin` is greater than `bound`
   @Override
   public int nextInt(final int min, final int bound) {
     if (min == bound) {
@@ -435,40 +381,32 @@ public final class GameRandom extends java.util.Random {
     return this.nextInt(bound - min) + min;
   }
 
-  /**
-   * Returns a pseudo-random enum constant of the specified enum class.
-   *
-   * @param <T>   The type of the enum.
-   * @param clazz The class of the enum.
-   * @return A pseudo-random enum constant of the specified enum class.
-   */
+  /// Returns a pseudo-random enum constant of the specified enum class.
+  ///
+  /// @param <T>   The type of the enum.
+  /// @param clazz The class of the enum.
+  /// @return A pseudo-random enum constant of the specified enum class.
   public <T extends Enum<?>> T next(Class<T> clazz) {
     int x = this.nextInt(clazz.getEnumConstants().length);
     return clazz.getEnumConstants()[x];
   }
 
-  /**
-   * Probes a pseudo-random value between 0.0 and 1.0 and checks whether it matches the specified probability.
-   *
-   * <p>
-   * Example: if the specified probability is 0.5, the sampled value needs to be less than or equal to the specified value in order for this method to
-   * return true.
-   * </p>
-   *
-   * @param probability The probability to check.
-   * @return True if the sampled value matches the probability; otherwise false.
-   */
+  /// Probes a pseudo-random value between 0.0 and 1.0 and checks whether it matches the specified probability.
+  ///
+  /// Example: if the specified probability is 0.5, the sampled value needs to be less than or equal to the specified value in order for this method to
+  /// return true.
+  ///
+  /// @param probability The probability to check.
+  /// @return True if the sampled value matches the probability; otherwise false.
   public boolean probe(final double probability) {
     double rnd = this.nextDouble();
     return rnd <= probability;
   }
 
-  /**
-   * Returns a pseudo-random index that is distributed by the weights of the defined probability array. The index probabilities must sum up to 1;
-   *
-   * @param indexProbabilities The index with the probabilities for the related index.
-   * @return A random index within the range of the specified array.
-   */
+  /// Returns a pseudo-random index that is distributed by the weights of the defined probability array. The index probabilities must sum up to 1;
+  ///
+  /// @param indexProbabilities The index with the probabilities for the related index.
+  /// @return A random index within the range of the specified array.
   public int getIndex(final double[] indexProbabilities) {
     final double rnd = this.nextDouble();
     double probSum = 0;
@@ -484,15 +422,13 @@ public final class GameRandom extends java.util.Random {
     return 0;
   }
 
-  /**
-   * Gets a pseudo-random location within the specified boundaries.
-   *
-   * @param x      The min-x coordinate of the boundaries.
-   * @param y      The min-y coordinate of the boundaries.
-   * @param width  The width of the boundaries.
-   * @param height The height of the boundaries.
-   * @return A pseudo-random location within the specified bounds.
-   */
+  /// Gets a pseudo-random location within the specified boundaries.
+  ///
+  /// @param x      The min-x coordinate of the boundaries.
+  /// @param y      The min-y coordinate of the boundaries.
+  /// @param width  The width of the boundaries.
+  /// @param height The height of the boundaries.
+  /// @return A pseudo-random location within the specified bounds.
   public Point2D getLocation(final double x, final double y, final double width, final double height) {
     final double xOffset = this.nextDouble(width);
     final double yOffset = this.nextDouble(height);
@@ -500,44 +436,36 @@ public final class GameRandom extends java.util.Random {
     return new Point2D.Double(x + xOffset, y + yOffset);
   }
 
-  /**
-   * Gets a pseudo-random location within the specified boundaries.
-   *
-   * @param rect The rectangle that defines the boundaries.
-   * @return A pseudo-random location within the specified bounds.
-   */
+  /// Gets a pseudo-random location within the specified boundaries.
+  ///
+  /// @param rect The rectangle that defines the boundaries.
+  /// @return A pseudo-random location within the specified bounds.
   public Point2D getLocation(final Rectangle2D rect) {
     return this.getLocation(rect.getX(), rect.getY(), rect.getWidth(), rect.getHeight());
   }
 
-  /**
-   * Gets a pseudo-random location within the specified entity boundaries.
-   *
-   * @param entity The entity that defines the boundaries.
-   * @return A pseudo-random location within the specified bounds.
-   * @see IEntity#getBoundingBox()
-   */
+  /// Gets a pseudo-random location within the specified entity boundaries.
+  ///
+  /// @param entity The entity that defines the boundaries.
+  /// @return A pseudo-random location within the specified bounds.
+  /// @see IEntity#getBoundingBox()
   public Point2D getLocation(final IEntity entity) {
     return this.getLocation(entity.getBoundingBox());
   }
 
-  /**
-   * Gets a pseudo-random location within the specified map boundaries.
-   *
-   * @param map The map that defines the boundaries.
-   * @return A pseudo-random location within the specified bounds.
-   * @see IMap#getBounds()
-   */
+  /// Gets a pseudo-random location within the specified map boundaries.
+  ///
+  /// @param map The map that defines the boundaries.
+  /// @return A pseudo-random location within the specified bounds.
+  /// @see IMap#getBounds()
   public Point2D getLocation(final IMap map) {
     return this.getLocation(map.getBounds());
   }
 
-  /**
-   * Gets a pseudo-random location in the specified circle.
-   *
-   * @param circle The circle that defines the boundaries.
-   * @return A pseudo-random location on the specified circle.
-   */
+  /// Gets a pseudo-random location in the specified circle.
+  ///
+  /// @param circle The circle that defines the boundaries.
+  /// @return A pseudo-random location on the specified circle.
   public Point2D getLocation(final Ellipse2D circle) {
     double radius = circle.getWidth() / 2.0;
 
@@ -549,70 +477,56 @@ public final class GameRandom extends java.util.Random {
     return new Point2D.Double(circle.getX() + x, circle.getY() + y);
   }
 
-  /**
-   * Gets a pseudo-random location on the specified line.
-   *
-   * @param line The line that defines the boundaries.
-   * @return A pseudo-random location on the specified line.
-   * @see Line2D#getP1()
-   * @see Line2D#getP2()
-   */
+  /// Gets a pseudo-random location on the specified line.
+  ///
+  /// @param line The line that defines the boundaries.
+  /// @return A pseudo-random location on the specified line.
+  /// @see Line2D#getP1()
+  /// @see Line2D#getP2()
   public Point2D getLocation(final Line2D line) {
     return this.getLocation(line.getP1(), line.getP2());
   }
 
-  /**
-   * Gets a pseudo-random location on the line connecting the two specified points.
-   *
-   * @param start The start point.
-   * @param end   The end point.
-   * @return A pseudo-random location on the line connecting the two specified points.
-   */
+  /// Gets a pseudo-random location on the line connecting the two specified points.
+  ///
+  /// @param start The start point.
+  /// @param end   The end point.
+  /// @return A pseudo-random location on the line connecting the two specified points.
   public Point2D getLocation(final Point2D start, final Point2D end) {
     double rnd = this.nextDouble(start.distance(end));
     return GeometricUtilities.project(start, end, rnd);
   }
 
-  /**
-   * Gets a pseudo-random char value.
-   *
-   * @return A pseudo-random character.
-   */
+  /// Gets a pseudo-random char value.
+  ///
+  /// @return A pseudo-random character.
   public char nextChar() {
     char start = '\u0000';
     char end = '\uFFFF';
     return (char) (start + this.nextDouble() * (end - start + 1));
   }
 
-  /**
-   * Gets a pseudo-random char value from the specified alphabet.
-   *
-   * @param alphabet The alphabet to chose the character from.
-   * @return A pseudo-random character from the specified alphabet.
-   */
+  /// Gets a pseudo-random char value from the specified alphabet.
+  ///
+  /// @param alphabet The alphabet to chose the character from.
+  /// @return A pseudo-random character from the specified alphabet.
   public char nextChar(final String alphabet) {
     return alphabet.charAt(this.nextInt(alphabet.length()));
   }
 
-  /**
-   * Gets a pseudo-random char value.
-   *
-   * @return A pseudo-random character.
-   */
+  /// Gets a pseudo-random char value.
+  ///
+  /// @return A pseudo-random character.
   public char nextAscii() {
     return (char) (32 + this.nextDouble() * (126 - 32 + 1));
   }
 
-  /**
-   * Gets a pseudo-random String of the specified length.
-   *
-   * <p>
-   * Characters will be chosen from the set of characters whose ASCII value is between 32 and 126 (inclusive)
-   * </p>
-   *
-   * @param length The length of the String.
-   * @return A pseudo-random ASCII String.
-   */
+  /// Gets a pseudo-random String of the specified length.
+  ///
+  /// Characters will be chosen from the set of characters whose ASCII value is between 32 and 126 (inclusive)
+  ///
+  /// @param length The length of the String.
+  /// @return A pseudo-random ASCII String.
   public String nextAscii(int length) {
     StringBuilder sb = new StringBuilder(length);
     for (int i = 0; i < length; i++) {
@@ -622,35 +536,29 @@ public final class GameRandom extends java.util.Random {
     return sb.toString();
   }
 
-  /**
-   * Gets a pseudo-random alphanumeric String of the specified length.
-   *
-   * @param length The length of the String.
-   * @return A pseudo-random alphanumeric String.
-   */
+  /// Gets a pseudo-random alphanumeric String of the specified length.
+  ///
+  /// @param length The length of the String.
+  /// @return A pseudo-random alphanumeric String.
   public String nextAlphanumeric(final int length) {
     return this.nextAlphanumeric(length, false);
   }
 
-  /**
-   * Gets a pseudo-random alphanumeric String of the specified length.
-   *
-   * @param length    The length of the String.
-   * @param lowerCase Indicates whether lower-case letters will be included in the String.
-   * @return A pseudo-random alphanumeric String.
-   */
+  /// Gets a pseudo-random alphanumeric String of the specified length.
+  ///
+  /// @param length    The length of the String.
+  /// @param lowerCase Indicates whether lower-case letters will be included in the String.
+  /// @return A pseudo-random alphanumeric String.
   public String nextAlphanumeric(final int length, final boolean lowerCase) {
     return this.nextAlphanumeric(length, true, lowerCase);
   }
 
-  /**
-   * Gets a pseudo-random alphanumeric String of the specified length.
-   *
-   * @param length    The length of the String.
-   * @param digit     Indicates whether digits will be included in the string.
-   * @param lowerCase Indicates whether lower-case letters will be included in the String.
-   * @return A pseudo-random alphanumeric String.
-   */
+  /// Gets a pseudo-random alphanumeric String of the specified length.
+  ///
+  /// @param length    The length of the String.
+  /// @param digit     Indicates whether digits will be included in the string.
+  /// @param lowerCase Indicates whether lower-case letters will be included in the String.
+  /// @return A pseudo-random alphanumeric String.
   public String nextAlphanumeric(final int length, final boolean digit, final boolean lowerCase) {
     final String digits = "0123456789";
     final String upperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -673,35 +581,29 @@ public final class GameRandom extends java.util.Random {
     return sb.toString();
   }
 
-  /**
-   * Gets a pseudo-random alphabetic String of the specified length.
-   *
-   * @param length The length of the String.
-   * @return A pseudo-random alphabetic String.
-   */
+  /// Gets a pseudo-random alphabetic String of the specified length.
+  ///
+  /// @param length The length of the String.
+  /// @return A pseudo-random alphabetic String.
   public String nextAlphabetic(final int length) {
     return this.nextAlphanumeric(length, false, false);
   }
 
-  /**
-   * Gets a pseudo-random alphabetic String of the specified length.
-   *
-   * @param length    The length of the String.
-   * @param lowerCase Indicates whether lower-case letters will be included in the String.
-   * @return A pseudo-random alphabetic String.
-   */
+  /// Gets a pseudo-random alphabetic String of the specified length.
+  ///
+  /// @param length    The length of the String.
+  /// @param lowerCase Indicates whether lower-case letters will be included in the String.
+  /// @return A pseudo-random alphabetic String.
   public String nextAlphabetic(final int length, final boolean lowerCase) {
     return this.nextAlphanumeric(length, false, lowerCase);
   }
 
-  /**
-   * Returns a randomized variant of a given color.
-   *
-   * @param originalColor The original color to be modified.
-   * @param colorVariance The float value between 0 and 1 defining how strong the new Color's RGB values will deviate from the original Color.
-   * @param alphaVariance The float value between 0 and 1 defining how strong the new Color's Alpha will deviate from the original Color.
-   * @return A pseudo-randomized variant of the original Color.
-   */
+  /// Returns a randomized variant of a given color.
+  ///
+  /// @param originalColor The original color to be modified.
+  /// @param colorVariance The float value between 0 and 1 defining how strong the new Color's RGB values will deviate from the original Color.
+  /// @param alphaVariance The float value between 0 and 1 defining how strong the new Color's Alpha will deviate from the original Color.
+  /// @return A pseudo-randomized variant of the original Color.
   public Color nextColor(Color originalColor, float colorVariance, float alphaVariance) {
     if (originalColor == null) {
       return null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameTime.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameTime.java
@@ -3,104 +3,87 @@ package de.gurkenlabs.litiengine;
 import de.gurkenlabs.litiengine.environment.Environment;
 import de.gurkenlabs.litiengine.environment.EnvironmentLoadedListener;
 
-/**
- * The {@code GameTime} class provides temporal information that can be used to perform time based events.
- *
- * <p>
- * The time provided by this class is measured in (game loop) ticks which is essentially an iteration of the game's main
- * update loop.
- * </p>
- *
- * <p>
- * <b>Examples</b><br>
- * A common use-case is to track the passed time since a certain event occurred (e.g. some action was performed by an
- * {@code Entity}).<br>
- * Another example is an environment that has a time limit.
- * </p>
- *
- * @see GameLoop#getTickRate()
- */
+/// The `GameTime` class provides temporal information that can be used to perform time based events.
+///
+/// The time provided by this class is measured in (game loop) ticks which is essentially an iteration of the game's main
+/// update loop.
+///
+/// **Examples**
+///
+/// A common use-case is to track the passed time since a certain event occurred (e.g. some action was performed by an
+/// `Entity`).
+///
+/// Another example is an environment that has a time limit.
+///
+/// @see GameLoop#getTickRate()
 public final class GameTime implements EnvironmentLoadedListener {
 
   private long environmentLoaded;
 
   GameTime() {}
 
-  /**
-   * Gets the current game time in ticks.
-   *
-   * @return The current game time in ticks.
-   * @see GameLoop#getTicks()
-   */
+  /// Gets the current game time in ticks.
+  ///
+  /// @return The current game time in ticks.
+  /// @see GameLoop#getTicks()
   public long now() {
     return Game.loop().getTicks();
   }
 
-  /**
-   * Calculates the delta time between the current game time and the specified ticks in milliseconds.
-   *
-   * @param tick
-   *          The tick for which to calculate the delta time.
-   * @return The delta time in ms.
-   * @see #now()
-   */
+  /// Calculates the delta time between the current game time and the specified ticks in milliseconds.
+  ///
+  /// @param tick
+  /// The tick for which to calculate the delta time.
+  /// @return The delta time in ms.
+  /// @see #now()
   public long since(final long tick) {
     return toMilliseconds(now() - tick, Game.loop().getTickRate());
   }
 
-  /**
-   * Calculates the delta time between the current game time and the specified ticks in milliseconds.
-   *
-   * @param tick
-   *          The tick for which to calculate the delta time.
-   * @param updateRate
-   *          the update rate
-   * @return The delta time in ms.
-   * @see #now()
-   */
+  /// Calculates the delta time between the current game time and the specified ticks in milliseconds.
+  ///
+  /// @param tick
+  /// The tick for which to calculate the delta time.
+  /// @param updateRate
+  /// the update rate
+  /// @return The delta time in ms.
+  /// @see #now()
   public long since(final long tick, int updateRate) {
     return toMilliseconds(now() - tick, updateRate);
   }
 
-  /**
-   * Gets the time in milliseconds that has passed since the game has been started.<br>
-   * This uses the configured update rate to calculate the passed time from the specified ticks.
-   *
-   * @return The time since the game has been started.
-   */
+  /// Gets the time in milliseconds that has passed since the game has been started.
+  ///
+  /// This uses the configured update rate to calculate the passed time from the specified ticks.
+  ///
+  /// @return The time since the game has been started.
   public long sinceGameStart() {
     return this.toMilliseconds(Game.loop().getTicks());
   }
 
-  /**
-   * Get the time in milliseconds that has passed since the current environment was loaded.
-   *
-   * @return The time since the current environment was loaded.
-   */
+  /// Get the time in milliseconds that has passed since the current environment was loaded.
+  ///
+  /// @return The time since the current environment was loaded.
   public long sinceEnvironmentLoad() {
     return this.since(this.environmentLoaded);
   }
 
-  /**
-   * Converts the specified ticks to milliseconds using the game loop's update rate.
-   *
-   * @param ticks
-   *          The ticks that will be converted to milliseconds.
-   * @return The milliseconds that correspond to the specified ticks.
-   */
+  /// Converts the specified ticks to milliseconds using the game loop's update rate.
+  ///
+  /// @param ticks
+  /// The ticks that will be converted to milliseconds.
+  /// @return The milliseconds that correspond to the specified ticks.
   public long toMilliseconds(final long ticks) {
     return this.toMilliseconds(ticks, Game.loop().getTickRate());
   }
 
-  /**
-   * Converts the specified ticks to milliseconds using the specified update rate.
-   *
-   * @param ticks
-   *          The ticks that will be converted to milliseconds.
-   * @param updateRate
-   *          The updateRate that is used for the conversion.
-   * @return The milliseconds that correspond to the specified ticks.
-   */
+  /// Converts the specified ticks to milliseconds using the specified update rate.
+  ///
+  /// @param ticks
+  /// The ticks that will be converted to milliseconds.
+  /// @param updateRate
+  /// The updateRate that is used for the conversion.
+  /// @return The milliseconds that correspond to the specified ticks.
   public long toMilliseconds(final long ticks, int updateRate) {
     if (updateRate == 0) {
       throw new ArithmeticException("/ by zero");
@@ -108,26 +91,22 @@ public final class GameTime implements EnvironmentLoadedListener {
     return (long) (ticks / (updateRate / 1000.0));
   }
 
-  /**
-   * Converts the specified milliseconds to ticks using the game loop's update rate.
-   *
-   * @param milliseconds
-   *          The milliseconds that will be converted to ticks.
-   * @return The ticks that correspond to the specified milliseconds.
-   */
+  /// Converts the specified milliseconds to ticks using the game loop's update rate.
+  ///
+  /// @param milliseconds
+  /// The milliseconds that will be converted to ticks.
+  /// @return The ticks that correspond to the specified milliseconds.
   public long toTicks(final int milliseconds) {
     return this.toTicks(milliseconds, Game.loop().getTickRate());
   }
 
-  /**
-   * Converts the specified milliseconds to ticks using the specified update rate.
-   *
-   * @param milliseconds
-   *          The milliseconds that will be converted to ticks.
-   * @param updateRate
-   *          The updateRate that is used for the conversion.
-   * @return The ticks that correspond to the specified milliseconds.
-   */
+  /// Converts the specified milliseconds to ticks using the specified update rate.
+  ///
+  /// @param milliseconds
+  /// The milliseconds that will be converted to ticks.
+  /// @param updateRate
+  /// The updateRate that is used for the conversion.
+  /// @return The ticks that correspond to the specified milliseconds.
   public long toTicks(final int milliseconds, int updateRate) {
     return (long) (updateRate / 1000.0 * milliseconds);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/GameWindow.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/GameWindow.java
@@ -29,18 +29,17 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The {@code GameWindow} class is a wrapper for the game's visual window in which the {@code RenderComponent}
- * lives.<br>
- * It provides the possibility to set a title, provide an icon, configure the cursor or get information about the
- * resolution.
- *
- * @see RenderComponent
- * @see #getResolution()
- * @see #setTitle(String)
- * @see #cursor()
- * @see #setIcon(java.awt.Image)
- */
+/// The `GameWindow` class is a wrapper for the game's visual window in which the `RenderComponent`
+/// lives.
+///
+/// It provides the possibility to set a title, provide an icon, configure the cursor or get information about the
+/// resolution.
+///
+/// @see RenderComponent
+/// @see #getResolution()
+/// @see #setTitle(String)
+/// @see #cursor()
+/// @see #setIcon(java.awt.Image)
 public final class GameWindow {
   private static final Logger log = Logger.getLogger(GameWindow.class.getName());
   private static final int ICONIFIED_MAX_FPS = 1;
@@ -76,11 +75,9 @@ public final class GameWindow {
     }
   }
 
-  /**
-   * Returns true if the GameWindow is the focus owner.
-   *
-   * @return true if the GameWindow is the focus owner; false otherwise
-   */
+  /// Returns true if the GameWindow is the focus owner.
+  ///
+  /// @return true if the GameWindow is the focus owner; false otherwise
   public boolean isFocusOwner() {
     if (this.getRenderComponent() != null && this.getRenderComponent().isFocusOwner()) {
       return true;
@@ -89,131 +86,103 @@ public final class GameWindow {
     return this.hostControl.isFocusOwner();
   }
 
-  /**
-   * Adds the specified resolution changed listener to receive events when the dimensions of this game window are changed.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified resolution changed listener to receive events when the dimensions of this game window are changed.
+  ///
+  /// @param listener
+  /// The listener to add.
   public void onResolutionChanged(final ResolutionChangedListener listener) {
     this.resolutionChangedListeners.add(listener);
   }
 
-  /**
-   * Removes the specified resolution changed listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Removes the specified resolution changed listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   public void removeResolutionChangedListener(final ResolutionChangedListener listener) {
     this.resolutionChangedListeners.remove(listener);
   }
 
-  /**
-   * Sets the resolution for the GameWindow.
-   *
-   * @param res
-   *          The desired Resolution to set for the GameWindow.
-   * @see Resolution
-   */
+  /// Sets the resolution for the GameWindow.
+  ///
+  /// @param res
+  /// The desired Resolution to set for the GameWindow.
+  /// @see Resolution
   public void setResolution(Resolution res) {
     this.resolutionScale = setResolution(this.getHostControl(), res.getDimension());
   }
 
-  /**
-   * Gets the current resolution scale. The resolution scale is a float value dictating how much larger or smaller each
-   * pixel is rendered on screen.
-   *
-   * @return The GameWindow's current resolution scale.
-   */
+  /// Gets the current resolution scale. The resolution scale is a float value dictating how much larger or smaller each
+  /// pixel is rendered on screen.
+  ///
+  /// @return The GameWindow's current resolution scale.
   public float getResolutionScale() {
     return this.resolutionScale;
   }
 
-  /**
-   * Gets the current resolution scale. The resolution scale is a float value dictating how much larger or smaller each
-   * pixel is rendered on screen.
-   *
-   * @return The {@code GameWindow}'s current resolution scale.
-   */
+  /// Gets the current resolution scale. The resolution scale is a float value dictating how much larger or smaller each
+  /// pixel is rendered on screen.
+  ///
+  /// @return The `GameWindow`'s current resolution scale.
   public Point2D getCenter() {
     return new Point2D.Double(this.getWidth() / 2.0, this.getHeight() / 2.0);
   }
 
-  /**
-   * Gets the {@code GameWindow}'s JFrame, abstracted as a Container.
-   *
-   * @return The {@code GameWindow}'s {@code JFrame} as an abstract AWT {@code Container}.
-   */
+  /// Gets the `GameWindow`'s JFrame, abstracted as a Container.
+  ///
+  /// @return The `GameWindow`'s `JFrame` as an abstract AWT `Container`.
   public Container getHostControl() {
     return this.hostControl;
   }
 
-  /**
-   * Gets the window width and height wrapped in a {@code Dimension} object.
-   *
-   * @return The {@code GameWindow}'s size as a {@link Dimension}.
-   */
+  /// Gets the window width and height wrapped in a `Dimension` object.
+  ///
+  /// @return The `GameWindow`'s size as a [Dimension].
   public Dimension getSize() {
     return this.hostControl.getSize();
   }
 
-  /**
-   * Gets the window width.
-   *
-   * @return The window width.
-   */
+  /// Gets the window width.
+  ///
+  /// @return The window width.
   public int getWidth() {
     return this.hostControl.getWidth();
   }
 
-  /**
-   * Gets the window height.
-   *
-   * @return The window height.
-   */
+  /// Gets the window height.
+  ///
+  /// @return The window height.
   public int getHeight() {
     return this.hostControl.getHeight();
   }
 
-  /**
-   * Gets the AWT canvas that is used to render the game's content on.
-   *
-   * @return The AWT render component onto which the game contents are rendered.
-   */
+  /// Gets the AWT canvas that is used to render the game's content on.
+  ///
+  /// @return The AWT render component onto which the game contents are rendered.
   public RenderComponent getRenderComponent() {
     return this.renderCanvas;
   }
 
-  /**
-   * Gets the visual representation of the mouse cursor on the {@code GameWindow}.
-   *
-   * <p>
-   * This can be used to provide a custom cursor image, define its visibility or specify a rendering offset from the
-   * actual position.
-   * </p>
-   *
-   * @return The mouse cursor of the game.
-   */
+  /// Gets the visual representation of the mouse cursor on the `GameWindow`.
+  ///
+  /// This can be used to provide a custom cursor image, define its visibility or specify a rendering offset from the
+  /// actual position.
+  ///
+  /// @return The mouse cursor of the game.
   public MouseCursor cursor() {
     return this.cursor;
   }
 
-  /**
-   * Gets the window resolution wrapped in a {@code Dimension} object.
-   *
-   * @return The {@code GameWindow}'s internal resolution as a {@link Dimension}.
-   */
+  /// Gets the window resolution wrapped in a `Dimension` object.
+  ///
+  /// @return The `GameWindow`'s internal resolution as a [Dimension].
   public Dimension getResolution() {
     return this.resolution;
   }
 
-  /**
-   * Gets the screen location of the window's top left corner.
-   *
-   * @return The {@code Point} of the window's top left corner.
-   * @see Container#getLocationOnScreen
-   */
+  /// Gets the screen location of the window's top left corner.
+  ///
+  /// @return The `Point` of the window's top left corner.
+  /// @see Container#getLocationOnScreen
   public Point getLocationOnScreen() {
     if (this.screenLocation != null) {
       return this.screenLocation;
@@ -223,57 +192,48 @@ public final class GameWindow {
     return this.screenLocation;
   }
 
-  /**
-   * Sets the icon image for the window's hosting {@code JFrame}.
-   *
-   * @param image
-   *          The {@code Image} to be used as the window icon.
-   * @see JFrame#setIconImage
-   */
+  /// Sets the icon image for the window's hosting `JFrame`.
+  ///
+  /// @param image
+  /// The `Image` to be used as the window icon.
+  /// @see JFrame#setIconImage
   public void setIcon(Image image) {
     this.hostControl.setIconImage(image);
   }
 
-  /**
-   * Sets the icons for the window's hosting {@code JFrame}. Depending on the platform specifications, one or several
-   * {@code Icon}s with the correct Dimension will be chosen automatically from the list.
-   *
-   * @param images
-   *          A list of {@code Images} to be used as the window icons.
-   * @see JFrame#setIconImages
-   */
+  /// Sets the icons for the window's hosting `JFrame`. Depending on the platform specifications, one or several
+  /// `Icon`s with the correct Dimension will be chosen automatically from the list.
+  ///
+  /// @param images
+  /// A list of `Images` to be used as the window icons.
+  /// @see JFrame#setIconImages
   public void setIcons(List<? extends Image> images) {
     this.hostControl.setIconImages(images);
   }
 
-  /**
-   * Sets the title for this window to the specified string.
-   *
-   * @param title
-   *          the window title to be displayed in the frame's border. A {@code null} value is treated as an empty string,
-   *          "".
-   * @see Frame#setTitle
-   */
+  /// Sets the title for this window to the specified string.
+  ///
+  /// @param title
+  /// the window title to be displayed in the frame's border. A `null` value is treated as an empty string,
+  /// "".
+  /// @see Frame#setTitle
   public void setTitle(String title) {
     this.hostControl.setTitle(title);
   }
 
-  /**
-   * Initialize a {@code JFrame} to host the window with a given {@code DisplayMode} and resolution.
-   * <p>
-   * For example, {@code BORDERLESS} windows are not resizable and are rendered without a border.
-   * </p>
-   *
-   * @param host
-   *          The {@code JFrame} that hosts this window.
-   * @param displaymode
-   *          The {@code DisplayMode} for this window.
-   * @param resolution
-   *          The desired window resolution.
-   * @see DisplayMode
-   * @see JFrame
-   * @see #setResolution
-   */
+  /// Initialize a `JFrame` to host the window with a given `DisplayMode` and resolution.
+  ///
+  /// For example, `BORDERLESS` windows are not resizable and are rendered without a border.
+  ///
+  /// @param host
+  /// The `JFrame` that hosts this window.
+  /// @param displaymode
+  /// The `DisplayMode` for this window.
+  /// @param resolution
+  /// The desired window resolution.
+  /// @see DisplayMode
+  /// @see JFrame
+  /// @see #setResolution
   static void prepareHostControl(JFrame host, DisplayMode displaymode, Dimension resolution) {
     switch (displaymode) {
       case BORDERLESS:
@@ -310,33 +270,27 @@ public final class GameWindow {
     setResolution(host, resolution);
   }
 
-  /**
-   * Sets the display mode for this game window at runtime.
-   *
-   * <p>
-   * This allows switching between windowed, borderless, and fullscreen modes while the game is running.
-   * The change is also persisted to the graphics configuration.
-   * </p>
-   *
-   * @param displayMode
-   *          The new {@code DisplayMode} to apply.
-   * @see DisplayMode
-   */
+  /// Sets the display mode for this game window at runtime.
+  ///
+  /// This allows switching between windowed, borderless, and fullscreen modes while the game is running.
+  /// The change is also persisted to the graphics configuration.
+  ///
+  /// @param displayMode
+  /// The new `DisplayMode` to apply.
+  /// @see DisplayMode
   public void setDisplayMode(DisplayMode displayMode) {
     Game.config().graphics().setDisplayMode(displayMode);
   }
 
-  /**
-   * Initialize the {@code GameWindow}. If the Game is in "No GUI"-mode, the window resolution is set to (0,0) and the
-   * hosting JFrame is hidden. Otherwise, the {@code JFrame} is initialized with the {@code DisplayMode} and resolution
-   * defined in the Graphics Configuration. After initializing the hosting {@code JFrame}, the {@code RenderComponent} is
-   * also initialized and the window requests focus.
-   *
-   * @see Game#isInNoGUIMode
-   * @see #prepareHostControl
-   * @see GraphicConfiguration
-   * @see RenderComponent
-   */
+  /// Initialize the `GameWindow`. If the Game is in "No GUI"-mode, the window resolution is set to (0,0) and the
+  /// hosting JFrame is hidden. Otherwise, the `JFrame` is initialized with the `DisplayMode` and resolution
+  /// defined in the Graphics Configuration. After initializing the hosting `JFrame`, the `RenderComponent` is
+  /// also initialized and the window requests focus.
+  ///
+  /// @see Game#isInNoGUIMode
+  /// @see #prepareHostControl
+  /// @see GraphicConfiguration
+  /// @see RenderComponent
   void init() {
     if (Game.isInNoGUIMode()) {
       this.resolution = new Dimension(0, 0);
@@ -462,20 +416,16 @@ public final class GameWindow {
     });
   }
 
-  /**
-   * This listener interface receives resolution changed events of the game window.
-   *
-   * @see GameWindow#onResolutionChanged(ResolutionChangedListener)
-   * @see GameWindow#setResolution(Resolution)
-   */
+  /// This listener interface receives resolution changed events of the game window.
+  ///
+  /// @see GameWindow#onResolutionChanged(ResolutionChangedListener)
+  /// @see GameWindow#setResolution(Resolution)
   @FunctionalInterface
   public interface ResolutionChangedListener extends EventListener {
-    /**
-     * Invoked when the resolution of the {@code GameWindow} changed.
-     *
-     * @param resolution
-     *          The new resolution.
-     */
+    /// Invoked when the resolution of the `GameWindow` changed.
+    ///
+    /// @param resolution
+    /// The new resolution.
     void resolutionChanged(Dimension resolution);
   }
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/IGameLoop.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/IGameLoop.java
@@ -1,57 +1,44 @@
 package de.gurkenlabs.litiengine;
 
-/**
- * The {@code IGameLoop} interface provides special methods for the game's main loop
- */
+/// The `IGameLoop` interface provides special methods for the game's main loop
 public interface IGameLoop extends ILoop {
 
-  /**
-   * Performs a timed action with the specified delay in ms.
-   * 
-   * @param delay
-   *          The delay in milliseconds.
-   * @param action
-   *          The action to perform, once the delay has passed.
-   * @return The id of the {@code TimedAction} that can be used to alter the execution time of the action or remove it.
-   * 
-   * @see IGameLoop#alterExecutionTime(int, long)
-   */
+  /// Performs a timed action with the specified delay in ms.
+  ///
+  /// @param delay
+  /// The delay in milliseconds.
+  /// @param action
+  /// The action to perform, once the delay has passed.
+  /// @return The id of the `TimedAction` that can be used to alter the execution time of the action or remove it.
+  ///
+  /// @see IGameLoop#alterExecutionTime(int, long)
   int perform(int delay, Runnable action);
 
-  /**
-   * Alters the execution time of the timed action with the specified index to the defined tick. This overwrites the
-   * originally specified delay.
-   * 
-   * @param id
-   *          The id of the {@code TimedAction}.
-   * @param tick
-   *          The tick at which to perform the action instead.
-   */
+  /// Alters the execution time of the timed action with the specified index to the defined tick. This overwrites the
+  /// originally specified delay.
+  ///
+  /// @param id
+  /// The id of the `TimedAction`.
+  /// @param tick
+  /// The tick at which to perform the action instead.
   void alterExecutionTime(int id, long tick);
 
-  /**
-   * Removes the {@code TimedAction} with the specified it.
-   * 
-   * @param id
-   *          The id of the {@code TimedAction}.
-   */
+  /// Removes the `TimedAction` with the specified it.
+  ///
+  /// @param id
+  /// The id of the `TimedAction`.
   void removeAction(int id);
 
-  /**
-   * Gets the game loop's current time scale (default = 1).
-   * 
-   * @return The game loop's current time scale.
-   */
+  /// Gets the game loop's current time scale (default = 1).
+  ///
+  /// @return The game loop's current time scale.
   float getTimeScale();
 
-  /**
-   * Sets the game loop's time scale.
-   * <p>
-   * This can be used to fast-forward the gameplay or to introduce slow-motion effects.
-   * </p>
-   * 
-   * @param timeScale
-   *          The time scale to set.
-   */
+  /// Sets the game loop's time scale.
+  ///
+  /// This can be used to fast-forward the gameplay or to introduce slow-motion effects.
+  ///
+  /// @param timeScale
+  /// The time scale to set.
   void setTimeScale(float timeScale);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/ILaunchable.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/ILaunchable.java
@@ -1,17 +1,11 @@
 package de.gurkenlabs.litiengine;
 
-/**
- * A functional interface that defines methods for instances that need to be launched and terminated externally.
- */
+/// A functional interface that defines methods for instances that need to be launched and terminated externally.
 public interface ILaunchable {
 
-  /**
-   * Starts the operation of this instance.
-   */
+  /// Starts the operation of this instance.
   void start();
 
-  /**
-   * Terminates the operation of this instance.
-   */
+  /// Terminates the operation of this instance.
   void terminate();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/ILoop.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/ILoop.java
@@ -2,89 +2,69 @@ package de.gurkenlabs.litiengine;
 
 import java.util.concurrent.locks.Lock;
 
-/**
- * The {@code ILoop} interface provide method for game loops that are publicly exposed.
- * 
- * <p>
- * A loop is an implementation that performs actions (e.g. physics, rendering, input processing, ...) and updates other
- * {@code IUpdatable} instances while the game is running.
- * </p>
- * 
- * @see IUpdateable
- */
+/// The `ILoop` interface provide method for game loops that are publicly exposed.
+///
+/// A loop is an implementation that performs actions (e.g. physics, rendering, input processing, ...) and updates other
+/// `IUpdatable` instances while the game is running.
+///
+/// @see IUpdateable
 public interface ILoop extends ILaunchable {
-  /**
-   * Attaches the update method of the specified IUpdatable instance to be called every tick. The tick rate can be
-   * configured in the client configuration and is independent from rendering.
-   * 
-   * @param updatable
-   *          The instance that will be registered for the update event.
-   */
+  /// Attaches the update method of the specified IUpdatable instance to be called every tick. The tick rate can be
+  /// configured in the client configuration and is independent from rendering.
+  ///
+  /// @param updatable
+  /// The instance that will be registered for the update event.
   void attach(final IUpdateable updatable);
 
-  /**
-   * Detaches the specified instance from the game loop.
-   * 
-   * @param updatable
-   *          The instance that will be unregistered for the update event.
-   */
+  /// Detaches the specified instance from the game loop.
+  ///
+  /// @param updatable
+  /// The instance that will be unregistered for the update event.
   void detach(final IUpdateable updatable);
 
-  /**
-   * Gets the amount of attached {@code IUpdatable} instances of this loop.
-   * 
-   * @return The amount instances attached to this loop.
-   */
+  /// Gets the amount of attached `IUpdatable` instances of this loop.
+  ///
+  /// @return The amount instances attached to this loop.
   int getUpdatableCount();
 
-  /**
-   * Gets the total amount of ticks performed by this loop since it was started.
-   * 
-   * @return The total amount of elapsed ticks.
-   * 
-   * @see #start()
-   */
+  /// Gets the total amount of ticks performed by this loop since it was started.
+  ///
+  /// @return The total amount of elapsed ticks.
+  ///
+  /// @see #start()
   long getTicks();
 
-  /**
-   * Gets the rate at which this loop performs its updates.
-   * 
-   * @return The update rate in ticks per second.
-   */
+  /// Gets the rate at which this loop performs its updates.
+  ///
+  /// @return The update rate in ticks per second.
   int getTickRate();
 
-  /**
-   * Gets the total time in milliseconds that passed since the last tick. <br>
-   * i.e. process time + delay (to enforce the tick rate of this loop)
-   *
-   * @return The delta time in ms.
-   * 
-   * @see #getProcessTime()
-   */
+  /// Gets the total time in milliseconds that passed since the last tick.
+  ///
+  /// i.e. process time + delay (to enforce the tick rate of this loop)
+  ///
+  /// @return The delta time in ms.
+  ///
+  /// @see #getProcessTime()
   long getDeltaTime();
 
-  /**
-   * Gets the actual process time in milliseconds that was required during the last tick. <br>
-   * i.e. delta time - delay
-   * 
-   * @return The actual process time of the last tick in ms.
-   * 
-   * @see #getDeltaTime()
-   */
+  /// Gets the actual process time in milliseconds that was required during the last tick.
+  ///
+  /// i.e. delta time - delay
+  ///
+  /// @return The actual process time of the last tick in ms.
+  ///
+  /// @see #getDeltaTime()
   double getProcessTime();
 
-  /**
-   * Returns a lock that can be used for actions that must be performed either within or independently of the loop.
-   * 
-   * @return A {@code Lock} for this loop.
-   */
+  /// Returns a lock that can be used for actions that must be performed either within or independently of the loop.
+  ///
+  /// @return A `Lock` for this loop.
   Lock getLock();
 
-  /**
-   * Sets the tickrate at which the loop performs its updates.
-   * 
-   * @param tickRate
-   *          The tickrate of the loop.
-   */
+  /// Sets the tickrate at which the loop performs its updates.
+  ///
+  /// @param tickRate
+  /// The tickrate of the loop.
   void setTickRate(int tickRate);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/ITimeToLive.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/ITimeToLive.java
@@ -1,27 +1,19 @@
 package de.gurkenlabs.litiengine;
 
-/**
- * The {@code ITimeToLive} interface defines methods for instances the have a limited time to live.
- */
+/// The `ITimeToLive` interface defines methods for instances the have a limited time to live.
 public interface ITimeToLive {
-  /**
-   * Gets the time this instance is alive.
-   * 
-   * @return Returns how long this instance is alive.
-   */
+  /// Gets the time this instance is alive.
+  ///
+  /// @return Returns how long this instance is alive.
   long getAliveTime();
 
-  /**
-   * Gets the total time to live of this instance.
-   * 
-   * @return The total time to live.
-   */
+  /// Gets the total time to live of this instance.
+  ///
+  /// @return The total time to live.
   int getTimeToLive();
 
-  /**
-   * Determines whether this instance has exceeded its time to live.
-   * 
-   * @return True if the time to live was reached; otherwise false.
-   */
+  /// Determines whether this instance has exceeded its time to live.
+  ///
+  /// @return True if the time to live was reached; otherwise false.
   boolean timeToLiveReached();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/IUpdateable.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/IUpdateable.java
@@ -2,38 +2,30 @@ package de.gurkenlabs.litiengine;
 
 import de.gurkenlabs.litiengine.configuration.ClientConfiguration;
 
-/**
- * The functional interface {@code IUpdateable} provides the functionality to automatically update the instance from a
- * loop that it is attached to.
- * 
- * <p>
- * This should be used for code that needs to be executed on every tick/frame.
- * </p>
- * 
- * @see ILoop#attach(IUpdateable)
- * @see ILoop#detach(IUpdateable)
- * @see Game#loop()
- */
+/// The functional interface `IUpdateable` provides the functionality to automatically update the instance from a
+/// loop that it is attached to.
+///
+/// This should be used for code that needs to be executed on every tick/frame.
+///
+/// @see ILoop#attach(IUpdateable)
+/// @see ILoop#detach(IUpdateable)
+/// @see Game#loop()
 @FunctionalInterface
 public interface IUpdateable {
 
-  /** Default update priority. Lower priorities are updated first. */
+  /// Default update priority. Lower priorities are updated first.
   int DEFAULT_UPDATE_PRIORITY = 0;
 
-  /**
-   * This method is called by the game loop on all objects that are attached to the loop. It's called on every tick of the
-   * loop and the frequency can be configured using the {@code ClientConfiguration}.
-   *
-   * @see ClientConfiguration#setMaxFps(int)
-   */
+  /// This method is called by the game loop on all objects that are attached to the loop. It's called on every tick of the
+  /// loop and the frequency can be configured using the `ClientConfiguration`.
+  ///
+  /// @see ClientConfiguration#setMaxFps(int)
   void update();
 
-  /**
-   * Determines this object's stable position in an update tick. Objects with the same priority retain their
-   * registration order.
-   *
-   * @return the update priority; lower values run first
-   */
+  /// Determines this object's stable position in an update tick. Objects with the same priority retain their
+  /// registration order.
+  ///
+  /// @return the update priority; lower values run first
   default int getUpdatePriority() {
     return DEFAULT_UPDATE_PRIORITY;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/UpdateLoop.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/UpdateLoop.java
@@ -10,13 +10,11 @@ import java.util.logging.Logger;
 
 import de.gurkenlabs.litiengine.util.TimeUtilities;
 
-/**
- * The {@code UpdateLoop} is a basic loop implementation that performs operations at the specified {@code tickRate} by
- * continuously processing the registered logic and delaying the loop until the requested rate is met.
- *
- * @see #process()
- * @see #delay()
- */
+/// The `UpdateLoop` is a basic loop implementation that performs operations at the specified `tickRate` by
+/// continuously processing the registered logic and delaying the loop until the requested rate is met.
+///
+/// @see #process()
+/// @see #delay()
 public class UpdateLoop extends Thread implements AutoCloseable, ILoop {
   private static final Logger log = Logger.getLogger(UpdateLoop.class.getName());
   private final Set<IUpdateable> updatables = new LinkedHashSet<>();
@@ -36,16 +34,14 @@ public class UpdateLoop extends Thread implements AutoCloseable, ILoop {
     this.tickRate = tickRate;
   }
 
-  /**
-   * The loop implementation, executing the {@code process()} method which does the actual work. It also tracks the
-   * processing time and the total number of performed ticks while making sure that the expected tick rate is met by
-   * delaying the loop accordingly.
-   * 
-   * @see #process()
-   * @see #delay()
-   * @see #getDeltaTime()
-   * @see #getProcessTime()
-   */
+  /// The loop implementation, executing the `process()` method which does the actual work. It also tracks the
+  /// processing time and the total number of performed ticks while making sure that the expected tick rate is met by
+  /// delaying the loop accordingly.
+  ///
+  /// @see #process()
+  /// @see #delay()
+  /// @see #getDeltaTime()
+  /// @see #getProcessTime()
   @Override
   public void run() {
     while (!interrupted()) {
@@ -155,10 +151,8 @@ public class UpdateLoop extends Thread implements AutoCloseable, ILoop {
     return this.updatables;
   }
 
-  /**
-   * Performs the actual workload of a tick. This base implementation just calls the update method on all registered
-   * instances. For derived loop implementations this is more sophisticated.
-   */
+  /// Performs the actual workload of a tick. This base implementation just calls the update method on all registered
+  /// instances. For derived loop implementations this is more sophisticated.
   protected void process() {
     this.update();
   }
@@ -167,11 +161,9 @@ public class UpdateLoop extends Thread implements AutoCloseable, ILoop {
     return (long) (1000.0 / this.tickRate);
   }
 
-  /**
-   * Calls the {@code update()} procedure on all registered instances.
-   * 
-   * @see IUpdateable#update()
-   */
+  /// Calls the `update()` procedure on all registered instances.
+  ///
+  /// @see IUpdateable#update()
   protected void update() {
     // Update a snapshot so an updateable can safely attach or detach objects for the next tick.
     for (IUpdateable updatable : List.copyOf(this.getUpdatables())) {
@@ -189,14 +181,12 @@ public class UpdateLoop extends Thread implements AutoCloseable, ILoop {
     }
   }
 
-  /**
-   * This method determines how long the current tick should be delayed to match the expected delta time for the specified
-   * tick rate. It then delays the execution of this loop by pausing the thread for the necessary delay.
-   * 
-   * @return The delay for which this tick was paused after the actual processing.
-   * @throws InterruptedException
-   *           If the thread was interrupted while sleeping
-   */
+  /// This method determines how long the current tick should be delayed to match the expected delta time for the specified
+  /// tick rate. It then delays the execution of this loop by pausing the thread for the necessary delay.
+  ///
+  /// @return The delay for which this tick was paused after the actual processing.
+  /// @throws InterruptedException
+  /// If the thread was interrupted while sleeping
   protected double delay() throws InterruptedException {
     double delay = Math.max(0, this.getExpectedDelta() - this.getProcessTime());
     long sleepDelay = Math.round(delay);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/Valign.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/Valign.java
@@ -3,9 +3,7 @@ package de.gurkenlabs.litiengine;
 import jakarta.xml.bind.annotation.XmlEnum;
 import jakarta.xml.bind.annotation.XmlEnumValue;
 
-/**
- * The enum {@code Valign} defines a range of vertical alignments.
- */
+/// The enum `Valign` defines a range of vertical alignments.
 @XmlEnum
 public enum Valign {
   @XmlEnumValue("DOWN")
@@ -25,12 +23,10 @@ public enum Valign {
     this.portion = portion;
   }
 
-  /**
-   * Gets the vertical align enumeration value for the specified string.
-   *
-   * @param valignString The string representing the enum value.
-   * @return The enum value represented by the specified string or {@link Valign#DOWN} if the specified string is invalid.
-   */
+  /// Gets the vertical align enumeration value for the specified string.
+  ///
+  /// @param valignString The string representing the enum value.
+  /// @return The enum value represented by the specified string or [Valign#DOWN] if the specified string is invalid.
   public static Valign get(final String valignString) {
     if (valignString == null || valignString.isEmpty()) {
       return Valign.DOWN;
@@ -43,67 +39,58 @@ public enum Valign {
     }
   }
 
-  /**
-   * Gets the proportional value of this instance.
-   *
-   * @param height The height to calculate the relative value from.
-   * @return The proportional value for the specified height.
-   */
+  /// Gets the proportional value of this instance.
+  ///
+  /// @param height The height to calculate the relative value from.
+  /// @return The proportional value for the specified height.
   public float getValue(float height) {
     return height * this.portion;
   }
 
-  /**
-   * Gets the proportional value of this instance.
-   *
-   * @param height The height to calculate the relative value from.
-   * @return The proportional value for the specified height.
-   */
+  /// Gets the proportional value of this instance.
+  ///
+  /// @param height The height to calculate the relative value from.
+  /// @return The proportional value for the specified height.
   public double getValue(double height) {
     return height * this.portion;
   }
 
-  /**
-   * Gets the proportional value of this instance.
-   *
-   * @param height The height to calculate the relative value from.
-   * @return The proportional value for the specified height.
-   */
+  /// Gets the proportional value of this instance.
+  ///
+  /// @param height The height to calculate the relative value from.
+  /// @return The proportional value for the specified height.
   public int getValue(int height) {
     return (int) (height * this.portion);
   }
 
-  /**
-   * Gets the location for the specified object height to be vertically aligned relatively to the bounds of the specified height.<br> Suitable for
-   * <b>entity</b> alignment. The return value might be negative or exceed the bottom boundary which is
-   * <i>{@code height} - {@code objectHeight}</i>. <br>
-   * For <b>text</b> alignment {@link #getLocation(double, double, boolean)} should be used with
-   * <i>{@code preventOverflow}</i> set to {@code true}.
-   *
-   * @param height       The height, limiting the vertical alignment.
-   * @param objectHeight The height of the object for which to calculate the vertically aligned location.
-   * @return The y-coordinate for the location of the object with the specified height.
-   */
+  /// Gets the location for the specified object height to be vertically aligned relatively to the bounds of the specified height.
+  /// Suitable for
+  /// **entity** alignment. The return value might be negative or exceed the bottom boundary which is
+  /// *`height` - `objectHeight`*.
+  ///
+  /// For **text** alignment [double, boolean)][#getLocation(double,] should be used with
+  /// *`preventOverflow`* set to `true`.
+  ///
+  /// @param height       The height, limiting the vertical alignment.
+  /// @param objectHeight The height of the object for which to calculate the vertically aligned location.
+  /// @return The y-coordinate for the location of the object with the specified height.
   public double getLocation(final double height, final double objectHeight) {
     return getLocation(height, objectHeight, false);
   }
 
-  /**
-   * Gets the location for the specified object height to be vertically aligned relatively to the bounds of the specified height. An overflow behavior
-   * (whenever <i>{@code objectHeight} > {@code height}</i>) can be controlled using
-   * <b>{@code preventOverflow}</b> parameter:
-   * <ul>
-   * <li><i>false</i>: the return value might be negative or exceed the bottom boundary which is <i>{@code height} -
-   * {@code objectHeight}</i> (good for <b>entity</b> alignment).</li>
-   * <li><i>true</i>: the return value will always be clamped within the bounds (good for <b>text</b> alignment).</li>
-   * </ul>
-   *
-   * @param height          The height, limiting the vertical alignment.
-   * @param objectHeight    The height of the object for which to calculate the vertically aligned location.
-   * @param preventOverflow A flag indicating whether the return value should be clamped to keep it within the bounds (prevent values that are
-   *                        negative or beyond the bottom boundary).
-   * @return The y-coordinate for the location of the object with the specified height.
-   */
+  /// Gets the location for the specified object height to be vertically aligned relatively to the bounds of the specified height. An overflow behavior
+  /// (whenever *`objectHeight` > `height`*) can be controlled using
+  /// **`preventOverflow`** parameter:
+  ///
+  /// - *false*: the return value might be negative or exceed the bottom boundary which is *`height` -
+  /// `objectHeight`* (good for **entity** alignment).
+  /// - *true*: the return value will always be clamped within the bounds (good for **text** alignment).
+  ///
+  /// @param height          The height, limiting the vertical alignment.
+  /// @param objectHeight    The height of the object for which to calculate the vertically aligned location.
+  /// @param preventOverflow A flag indicating whether the return value should be clamped to keep it within the bounds (prevent values that are
+  /// negative or beyond the bottom boundary).
+  /// @return The y-coordinate for the location of the object with the specified height.
   public double getLocation(final double height, final double objectHeight, final boolean preventOverflow) {
     double value = this.getValue(height);
     double location = value - objectHeight / 2.0;
@@ -115,11 +102,9 @@ public enum Valign {
     return Math.max(0, Math.min(height - objectHeight, location));
   }
 
-  /**
-   * Gets the portion value of the alignment.
-   *
-   * @return The portion value of the alignment.
-   */
+  /// Gets the portion value of the alignment.
+  ///
+  /// @return The portion value of the alignment.
   public float getPortion() {
     return portion;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/Ability.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/Ability.java
@@ -22,10 +22,8 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * The {@code Ability} class represents a special skill or power that a {@code Creature} can use in a game. Each ability has a set of effects,
- * attributes, and listeners that define its behavior.
- */
+/// The `Ability` class represents a special skill or power that a `Creature` can use in a game. Each ability has a set of effects,
+/// attributes, and listeners that define its behavior.
 @AbilityInfo
 public abstract class Ability implements IRenderable {
 
@@ -43,11 +41,9 @@ public abstract class Ability implements IRenderable {
 
   private AbilityExecution currentExecution;
 
-  /**
-   * Initializes a new instance of the {@code Ability} class.
-   *
-   * @param executor The executing entity
-   */
+  /// Initializes a new instance of the `Ability` class.
+  ///
+  /// @param executor The executing entity
   protected Ability(final Creature executor) {
     this.abilityCastListeners = ConcurrentHashMap.newKeySet();
     this.effects = new CopyOnWriteArrayList<>();
@@ -63,29 +59,23 @@ public abstract class Ability implements IRenderable {
       new EntityPivot(executor, info.origin(), info.pivotOffsetX(), info.pivotOffsetY());
   }
 
-  /**
-   * Adds a listener that will be notified when the ability is cast.
-   *
-   * @param listener The listener to add
-   */
+  /// Adds a listener that will be notified when the ability is cast.
+  ///
+  /// @param listener The listener to add
   public void onCast(final AbilityCastListener listener) {
     abilityCastListeners.add(listener);
   }
 
-  /**
-   * Removes a listener that was previously added with {@link #onCast}.
-   *
-   * @param listener The listener to remove
-   */
+  /// Removes a listener that was previously added with [#onCast].
+  ///
+  /// @param listener The listener to remove
   public void removeAbilityCastListener(AbilityCastListener listener) {
     abilityCastListeners.remove(listener);
   }
 
-  /**
-   * Adds a listener that will be notified when an effect of this ability is applied.
-   *
-   * @param listener The listener to add
-   */
+  /// Adds a listener that will be notified when an effect of this ability is applied.
+  ///
+  /// @param listener The listener to add
   public void onEffectApplied(final EffectAppliedListener listener) {
     for (final Effect effect : getEffects()) {
       // registers to all effects and their follow up effects recursively
@@ -93,11 +83,9 @@ public abstract class Ability implements IRenderable {
     }
   }
 
-  /**
-   * Adds a listener that will be notified when an effect of this ability ceases.
-   *
-   * @param listener The listener to add
-   */
+  /// Adds a listener that will be notified when an effect of this ability ceases.
+  ///
+  /// @param listener The listener to add
   public void onEffectCeased(final EffectCeasedListener listener) {
     for (final Effect effect : getEffects()) {
       // registers to all effects and their follow up effects recursively
@@ -105,29 +93,23 @@ public abstract class Ability implements IRenderable {
     }
   }
 
-  /**
-   * Adds an effect to this ability.
-   *
-   * @param effect The effect to add
-   */
+  /// Adds an effect to this ability.
+  ///
+  /// @param effect The effect to add
   public void addEffect(final Effect effect) {
     getEffects().add(effect);
   }
 
-  /**
-   * Calculates the area of impact of this ability based on the executor's angle.
-   *
-   * @return The shape representing the area of impact
-   */
+  /// Calculates the area of impact of this ability based on the executor's angle.
+  ///
+  /// @return The shape representing the area of impact
   public Shape calculateImpactArea() {
     return internalCalculateImpactArea(getExecutor().getAngle());
   }
 
-  /**
-   * Calculates the potential area of impact of this ability.
-   *
-   * @return The ellipse representing the potential area of impact
-   */
+  /// Calculates the potential area of impact of this ability.
+  ///
+  /// @return The ellipse representing the potential area of impact
   public Ellipse2D calculatePotentialImpactArea() {
     final int range = getAttributes().impact().getModifiedValue();
     final double arcX = getPivot().getPoint().getX() - range * 0.5;
@@ -136,20 +118,16 @@ public abstract class Ability implements IRenderable {
     return new Ellipse2D.Double(arcX, arcY, range, range);
   }
 
-  /**
-   * Checks if this ability can be cast.
-   *
-   * @return {@code true} if the executor is not dead and the ability is not on cooldown; {@code false} otherwise
-   */
+  /// Checks if this ability can be cast.
+  ///
+  /// @return `true` if the executor is not dead and the ability is not on cooldown; `false` otherwise
   public boolean canCast() {
     return !getExecutor().isDead() && !isOnCooldown();
   }
 
-  /**
-   * Checks if this ability is on cooldown.
-   *
-   * @return {@code true} if the ability is on cooldown; {@code false} otherwise
-   */
+  /// Checks if this ability is on cooldown.
+  ///
+  /// @return `true` if the ability is on cooldown; `false` otherwise
   public boolean isOnCooldown() {
     return (getCurrentExecution() != null
       && getCurrentExecution().getExecutionTicks() > 0
@@ -157,12 +135,10 @@ public abstract class Ability implements IRenderable {
       .cooldown().getModifiedValue());
   }
 
-  /**
-   * Casts the ability by the temporal conditions of the specified game loop and the spatial circumstances of the specified environment. An ability
-   * execution will be taken out that start applying all the effects of this ability.
-   *
-   * @return An {@link AbilityExecution} object that wraps all information about this execution of the ability.
-   */
+  /// Casts the ability by the temporal conditions of the specified game loop and the spatial circumstances of the specified environment. An ability
+  /// execution will be taken out that start applying all the effects of this ability.
+  ///
+  /// @return An [AbilityExecution] object that wraps all information about this execution of the ability.
   public AbilityExecution cast() {
     if (!canCast()) {
       return null;
@@ -176,83 +152,65 @@ public abstract class Ability implements IRenderable {
     return getCurrentExecution();
   }
 
-  /**
-   * Gets the attributes of this ability.
-   *
-   * @return The attributes of this ability
-   */
+  /// Gets the attributes of this ability.
+  ///
+  /// @return The attributes of this ability
   public AbilityAttributes getAttributes() {
     return attributes;
   }
 
-  /**
-   * Gets the cast type of this ability.
-   *
-   * @return The cast type of this ability
-   */
+  /// Gets the cast type of this ability.
+  ///
+  /// @return The cast type of this ability
   public CastType getCastType() {
     return castType;
   }
 
-  /**
-   * Gets the cooldown of this ability in seconds.
-   *
-   * @return The cooldown of this ability in seconds
-   */
+  /// Gets the cooldown of this ability in seconds.
+  ///
+  /// @return The cooldown of this ability in seconds
   public float getCooldownInSeconds() {
     return (float) (getAttributes().cooldown().getModifiedValue() * 0.001);
   }
 
-  /**
-   * Gets the current execution of this ability.
-   *
-   * @return The current execution of this ability
-   */
+  /// Gets the current execution of this ability.
+  ///
+  /// @return The current execution of this ability
   public AbilityExecution getCurrentExecution() {
     return currentExecution;
   }
 
-  /**
-   * Gets the description of this ability.
-   *
-   * @return The description of this ability
-   */
+  /// Gets the description of this ability.
+  ///
+  /// @return The description of this ability
   public String getDescription() {
     return description;
   }
 
-  /**
-   * Gets the executor of this ability.
-   *
-   * @return The executor of this ability
-   */
+  /// Gets the executor of this ability.
+  ///
+  /// @return The executor of this ability
   public Creature getExecutor() {
     return executor;
   }
 
-  /**
-   * Gets the name of this ability.
-   *
-   * @return The name of this ability
-   */
+  /// Gets the name of this ability.
+  ///
+  /// @return The name of this ability
   public String getName() {
     return name;
   }
 
-  /**
-   * Gets the pivot of this ability.
-   *
-   * @return The pivot of this ability
-   */
+  /// Gets the pivot of this ability.
+  ///
+  /// @return The pivot of this ability
   public EntityPivot getPivot() {
     return entityPivot;
   }
 
-  /**
-   * Gets the remaining cooldown of this ability in seconds.
-   *
-   * @return The remaining cooldown of this ability in seconds
-   */
+  /// Gets the remaining cooldown of this ability in seconds.
+  ///
+  /// @return The remaining cooldown of this ability in seconds
   public float getRemainingCooldownInSeconds() {
     if (getCurrentExecution() == null
       || getExecutor() == null
@@ -268,31 +226,25 @@ public abstract class Ability implements IRenderable {
       : 0);
   }
 
-  /**
-   * Checks if this ability is active.
-   *
-   * @return {@code true} if the ability is active; {@code false} otherwise
-   */
+  /// Checks if this ability is active.
+  ///
+  /// @return `true` if the ability is active; `false` otherwise
   public boolean isActive() {
     return getCurrentExecution() != null
       && Game.time().since(getCurrentExecution().getExecutionTicks()) < getAttributes()
       .duration().getModifiedValue();
   }
 
-  /**
-   * Checks if this ability is multi-target.
-   *
-   * @return {@code true} if the ability is multi-target; {@code false} otherwise
-   */
+  /// Checks if this ability is multi-target.
+  ///
+  /// @return `true` if the ability is multi-target; `false` otherwise
   public boolean isMultiTarget() {
     return multiTarget;
   }
 
-  /**
-   * Renders the impact area of this ability.
-   *
-   * @param g The graphics context to render on
-   */
+  /// Renders the impact area of this ability.
+  ///
+  /// @param g The graphics context to render on
   @Override
   public void render(final Graphics2D g) {
     g.setColor(new Color(255, 255, 0, 25));
@@ -304,66 +256,52 @@ public abstract class Ability implements IRenderable {
     g.setStroke(oldStroke);
   }
 
-  /**
-   * Sets the name of this ability.
-   *
-   * @param name The new name of this ability
-   */
+  /// Sets the name of this ability.
+  ///
+  /// @param name The new name of this ability
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * Sets the description of this ability.
-   *
-   * @param description The new description of this ability
-   */
+  /// Sets the description of this ability.
+  ///
+  /// @param description The new description of this ability
   public void setDescription(String description) {
     this.description = description;
   }
 
-  /**
-   * Sets whether this ability is multi-target.
-   *
-   * @param multiTarget {@code true} if the ability is multi-target; {@code false} otherwise
-   */
+  /// Sets whether this ability is multi-target.
+  ///
+  /// @param multiTarget `true` if the ability is multi-target; `false` otherwise
   public void setMultiTarget(boolean multiTarget) {
     this.multiTarget = multiTarget;
   }
 
-  /**
-   * Sets the cast type of this ability.
-   *
-   * @param castType The new cast type of this ability
-   */
+  /// Sets the cast type of this ability.
+  ///
+  /// @param castType The new cast type of this ability
   public void setCastType(CastType castType) {
     this.castType = castType;
   }
 
-  /**
-   * Sets the current execution of this ability.
-   *
-   * @param ae The new current execution of this ability
-   */
+  /// Sets the current execution of this ability.
+  ///
+  /// @param ae The new current execution of this ability
   void setCurrentExecution(AbilityExecution ae) {
     this.currentExecution = ae;
   }
 
-  /**
-   * Gets the effects of this ability.
-   *
-   * @return The effects of this ability
-   */
+  /// Gets the effects of this ability.
+  ///
+  /// @return The effects of this ability
   public List<Effect> getEffects() {
     return effects;
   }
 
-  /**
-   * Calculates the impact area of this ability based on the given angle.
-   *
-   * @param angle The angle to calculate the impact area
-   * @return The shape representing the impact area
-   */
+  /// Calculates the impact area of this ability based on the given angle.
+  ///
+  /// @param angle The angle to calculate the impact area
+  /// @return The shape representing the impact area
   protected Shape internalCalculateImpactArea(final double angle) {
     final int impact = getAttributes().impact().getModifiedValue();
     final int impactAngle = getAttributes().impactAngle().getModifiedValue();
@@ -383,12 +321,10 @@ public abstract class Ability implements IRenderable {
       appliedRange.getX(), appliedRange.getY(), impact * 2d, impact * 2d, start, impactAngle, Arc2D.PIE);
   }
 
-  /**
-   * Adds a listener that will be notified when an effect of this ability is applied.
-   *
-   * @param effect   The effect to add the listener to
-   * @param listener The listener to add
-   */
+  /// Adds a listener that will be notified when an effect of this ability is applied.
+  ///
+  /// @param effect   The effect to add the listener to
+  /// @param listener The listener to add
   private void onEffectApplied(final Effect effect, final EffectAppliedListener listener) {
     effect.onEffectApplied(listener);
 
@@ -397,12 +333,10 @@ public abstract class Ability implements IRenderable {
     }
   }
 
-  /**
-   * Adds a listener that will be notified when an effect of this ability ceases.
-   *
-   * @param effect   The effect to add the listener to
-   * @param listener The listener to add
-   */
+  /// Adds a listener that will be notified when an effect of this ability ceases.
+  ///
+  /// @param effect   The effect to add the listener to
+  /// @param listener The listener to add
   private void onEffectCeased(final Effect effect, final EffectCeasedListener listener) {
     effect.onEffectCeased(listener);
 
@@ -411,16 +345,12 @@ public abstract class Ability implements IRenderable {
     }
   }
 
-  /**
-   * The {@code AbilityCastListener} interface defines a method for listening to ability cast events.
-   */
+  /// The `AbilityCastListener` interface defines a method for listening to ability cast events.
   @FunctionalInterface
   public interface AbilityCastListener extends EventListener {
-    /**
-     * Invoked when an ability is cast.
-     *
-     * @param execution The execution of the ability
-     */
+    /// Invoked when an ability is cast.
+    ///
+    /// @param execution The execution of the ability
     void abilityCast(AbilityExecution execution);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityAttributes.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityAttributes.java
@@ -2,10 +2,8 @@ package de.gurkenlabs.litiengine.abilities;
 
 import de.gurkenlabs.litiengine.attributes.Attribute;
 
-/**
- * The {@code AbilityAttributes} class represents the attributes of an ability in the game. Each ability has a set of attributes such as cooldown,
- * duration, impact, impact angle, range, and value.
- */
+/// The `AbilityAttributes` class represents the attributes of an ability in the game. Each ability has a set of attributes such as cooldown,
+/// duration, impact, impact angle, range, and value.
 public class AbilityAttributes {
   private final Attribute<Integer> cooldown;
   private final Attribute<Integer> duration;
@@ -14,25 +12,21 @@ public class AbilityAttributes {
   private final Attribute<Integer> range;
   private final Attribute<Integer> value;
 
-  /**
-   * Initializes a new instance of the {@code AbilityAttributes} class.
-   *
-   * @param info The information of the ability
-   */
+  /// Initializes a new instance of the `AbilityAttributes` class.
+  ///
+  /// @param info The information of the ability
   public AbilityAttributes(final AbilityInfo info) {
     this(info.cooldown(), info.duration(), info.range(), info.impact(), info.impactAngle(), info.value());
   }
 
-  /**
-   * Initializes a new instance of the {@code AbilityAttributes} class with the specified attribute values.
-   *
-   * @param cooldown    The cooldown value of the ability
-   * @param duration    The duration value of the ability
-   * @param range       The range value of the ability
-   * @param impact      The impact value of the ability
-   * @param impactAngle The impact angle value of the ability
-   * @param value       The value of the ability
-   */
+  /// Initializes a new instance of the `AbilityAttributes` class with the specified attribute values.
+  ///
+  /// @param cooldown    The cooldown value of the ability
+  /// @param duration    The duration value of the ability
+  /// @param range       The range value of the ability
+  /// @param impact      The impact value of the ability
+  /// @param impactAngle The impact angle value of the ability
+  /// @param value       The value of the ability
   public AbilityAttributes(int cooldown, int duration, int range, int impact, int impactAngle, int value) {
     this.cooldown = new Attribute<>(cooldown);
     this.duration = new Attribute<>(duration);
@@ -42,65 +36,51 @@ public class AbilityAttributes {
     this.value = new Attribute<>(value);
   }
 
-  /**
-   * Gets the cooldown attribute of this ability.
-   *
-   * @return The cooldown attribute of this ability
-   */
+  /// Gets the cooldown attribute of this ability.
+  ///
+  /// @return The cooldown attribute of this ability
   public Attribute<Integer> cooldown() {
     return this.cooldown;
   }
 
-  /**
-   * Gets the duration attribute of this ability.
-   *
-   * @return The duration attribute of this ability
-   */
+  /// Gets the duration attribute of this ability.
+  ///
+  /// @return The duration attribute of this ability
   public Attribute<Integer> duration() {
     return this.duration;
   }
 
-  /**
-   * Gets the impact attribute of this ability.
-   *
-   * @return The impact attribute of this ability
-   */
+  /// Gets the impact attribute of this ability.
+  ///
+  /// @return The impact attribute of this ability
   public Attribute<Integer> impact() {
     return this.impact;
   }
 
-  /**
-   * Gets the impact angle attribute of this ability.
-   *
-   * @return The impact angle attribute of this ability
-   */
+  /// Gets the impact angle attribute of this ability.
+  ///
+  /// @return The impact angle attribute of this ability
   public Attribute<Integer> impactAngle() {
     return this.impactAngle;
   }
 
-  /**
-   * Gets the range attribute of this ability.
-   *
-   * @return The range attribute of this ability
-   */
+  /// Gets the range attribute of this ability.
+  ///
+  /// @return The range attribute of this ability
   public Attribute<Integer> range() {
     return this.range;
   }
 
-  /**
-   * Gets the value attribute of this ability.
-   *
-   * @return The value attribute of this ability
-   */
+  /// Gets the value attribute of this ability.
+  ///
+  /// @return The value attribute of this ability
   public Attribute<Integer> value() {
     return this.value;
   }
 
-  /**
-   * Copies the values from another `AbilityAttributes` instance to this instance.
-   *
-   * @param otherAttributes the `AbilityAttributes` instance from which to copy values
-   */
+  /// Copies the values from another `AbilityAttributes` instance to this instance.
+  ///
+  /// @param otherAttributes the `AbilityAttributes` instance from which to copy values
   public void copyValues(AbilityAttributes otherAttributes) {
     cooldown().setValue(otherAttributes.cooldown().getModifiedValue());
     duration().setValue(otherAttributes.duration().getModifiedValue());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityBuilder.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityBuilder.java
@@ -7,7 +7,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-/// Fluent builder for constructing and registering [DynamicAbility] instances on a creature.
+/// Fluent builder for constructing [DynamicAbility] instances for a [Creature].
+///
+/// Use [#build()] when the caller will manage the ability itself, or [#register()] to also add it
+/// to the executor. Numeric values default to zero and the cast type defaults to [CastType#INSTANT].
+/// Negative cooldown, range, and impact values are normalized to zero.
+///
+/// @see Creature#createAbility(String)
+/// @see AbilityExecution
+/// @see Effect
 public class AbilityBuilder {
   private final Creature executor;
   private final String name;
@@ -21,51 +29,93 @@ public class AbilityBuilder {
   private Consumer<AbilityExecution> onCastConsumer;
   private final List<Effect> effects = new ArrayList<>();
 
+  /// Creates a builder for an ability executed by the specified creature.
+  ///
+  /// @param executor The creature that will execute the ability.
+  /// @param name The name used to identify the ability on the creature.
+  /// @throws NullPointerException if `executor` or `name` is `null`.
   public AbilityBuilder(Creature executor, String name) {
     this.executor = Objects.requireNonNull(executor, "Executor must not be null.");
     this.name = Objects.requireNonNull(name, "Ability name must not be null.");
   }
 
+  /// Sets the player-facing description.
+  ///
+  /// @param description The description, or `null` to use an empty description.
+  /// @return This builder.
   public AbilityBuilder description(String description) {
     this.description = description == null ? "" : description;
     return this;
   }
 
+  /// Sets the cooldown after a successful cast.
+  ///
+  /// @param cooldownMs The cooldown in milliseconds; negative values are treated as zero.
+  /// @return This builder.
   public AbilityBuilder cooldown(int cooldownMs) {
     this.cooldown = Math.max(0, cooldownMs);
     return this;
   }
 
+  /// Sets the maximum cast range.
+  ///
+  /// @param range The range in map units; negative values are treated as zero.
+  /// @return This builder.
   public AbilityBuilder range(int range) {
     this.range = Math.max(0, range);
     return this;
   }
 
+  /// Sets the base impact used by the ability's effects.
+  ///
+  /// @param impact The impact value; negative values are treated as zero.
+  /// @return This builder.
   public AbilityBuilder impact(int impact) {
     this.impact = Math.max(0, impact);
     return this;
   }
 
+  /// Sets the general-purpose value exposed through the ability attributes.
+  ///
+  /// @param value The value to expose; unlike the other numeric attributes this may be negative.
+  /// @return This builder.
   public AbilityBuilder value(int value) {
     this.value = value;
     return this;
   }
 
+  /// Sets how the ability is cast.
+  ///
+  /// @param castType The cast type.
+  /// @return This builder.
+  /// @throws NullPointerException if `castType` is `null`.
   public AbilityBuilder castType(CastType castType) {
     this.castType = Objects.requireNonNull(castType);
     return this;
   }
 
+  /// Sets whether one execution may affect multiple targets.
+  ///
+  /// @param multiTarget `true` to permit multiple targets.
+  /// @return This builder.
   public AbilityBuilder multiTarget(boolean multiTarget) {
     this.multiTarget = multiTarget;
     return this;
   }
 
+  /// Sets the callback invoked when the ability is cast.
+  ///
+  /// @param onCast The callback, or `null` to remove the current callback.
+  /// @return This builder.
   public AbilityBuilder onCast(Consumer<AbilityExecution> onCast) {
     this.onCastConsumer = onCast;
     return this;
   }
 
+  /// Sets a callback that does not need the [AbilityExecution] details.
+  ///
+  /// @param onCast The callback, or `null` to remove the current callback.
+  /// @return This builder.
   public AbilityBuilder onCast(Runnable onCast) {
     if (onCast == null) {
       this.onCastConsumer = null;
@@ -86,6 +136,11 @@ public class AbilityBuilder {
     return this;
   }
 
+  /// Constructs a new ability without adding it to the executor.
+  ///
+  /// Each invocation returns a new ability configured from the builder's current values.
+  ///
+  /// @return A new, unregistered ability.
   public DynamicAbility build() {
     DynamicAbility ability = new DynamicAbility(this.executor, this.name);
     ability.setDescription(this.description);
@@ -106,7 +161,7 @@ public class AbilityBuilder {
 
   /// Constructs the ability and registers it directly on the executing creature.
   ///
-  /// @return The registered [DynamicAbility]
+  /// @return The newly constructed and registered ability.
   public DynamicAbility register() {
     DynamicAbility ability = this.build();
     if (this.executor != null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityBuilder.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityBuilder.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-/**
- * Fluent builder for constructing and registering {@link DynamicAbility} instances on a creature.
- */
+/// Fluent builder for constructing and registering [DynamicAbility] instances on a creature.
 public class AbilityBuilder {
   private final Creature executor;
   private final String name;
@@ -77,12 +75,10 @@ public class AbilityBuilder {
     return this;
   }
 
-  /**
-   * Adds an {@link Effect} to this ability.
-   *
-   * @param effect The effect to attach.
-   * @return This builder instance for chaining.
-   */
+  /// Adds an [Effect] to this ability.
+  ///
+  /// @param effect The effect to attach.
+  /// @return This builder instance for chaining.
   public AbilityBuilder effect(Effect effect) {
     if (effect != null) {
       this.effects.add(effect);
@@ -108,11 +104,9 @@ public class AbilityBuilder {
     return ability;
   }
 
-  /**
-   * Constructs the ability and registers it directly on the executing creature.
-   *
-   * @return The registered {@link DynamicAbility}
-   */
+  /// Constructs the ability and registers it directly on the executing creature.
+  ///
+  /// @return The registered [DynamicAbility]
   public DynamicAbility register() {
     DynamicAbility ability = this.build();
     if (this.executor != null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityExecution.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityExecution.java
@@ -8,10 +8,8 @@ import java.awt.geom.Point2D;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * The {@code AbilityExecution} class represents the execution of an ability in the game. It contains information about the ability, its effects, and
- * the location and time of its execution.
- */
+/// The `AbilityExecution` class represents the execution of an ability in the game. It contains information about the ability, its effects, and
+/// the location and time of its execution.
 public class AbilityExecution implements IUpdateable {
   private final Ability ability;
   private final List<Effect> appliedEffects;
@@ -19,11 +17,9 @@ public class AbilityExecution implements IUpdateable {
   private final long executionTicks;
   private final Shape impactArea;
 
-  /**
-   * Initializes a new instance of the {@code AbilityExecution} class.
-   *
-   * @param ability The ability to be executed
-   */
+  /// Initializes a new instance of the `AbilityExecution` class.
+  ///
+  /// @param ability The ability to be executed
   AbilityExecution(final Ability ability) {
     this.appliedEffects = new CopyOnWriteArrayList<>();
     this.ability = ability;
@@ -33,55 +29,43 @@ public class AbilityExecution implements IUpdateable {
     Game.loop().attach(this);
   }
 
-  /**
-   * Gets the ability being executed.
-   *
-   * @return The ability being executed
-   */
+  /// Gets the ability being executed.
+  ///
+  /// @return The ability being executed
   public Ability getAbility() {
     return this.ability;
   }
 
-  /**
-   * Gets the effects that have been applied during this execution.
-   *
-   * @return The effects that have been applied
-   */
+  /// Gets the effects that have been applied during this execution.
+  ///
+  /// @return The effects that have been applied
   public List<Effect> getAppliedEffects() {
     return this.appliedEffects;
   }
 
-  /**
-   * Gets the location where the ability was cast.
-   *
-   * @return The location where the ability was cast
-   */
+  /// Gets the location where the ability was cast.
+  ///
+  /// @return The location where the ability was cast
   public Point2D getCastLocation() {
     return this.castLocation;
   }
 
-  /**
-   * Gets the impact area of the ability execution.
-   *
-   * @return The impact area of the ability execution
-   */
+  /// Gets the impact area of the ability execution.
+  ///
+  /// @return The impact area of the ability execution
   public Shape getExecutionImpactArea() {
     return this.impactArea;
   }
 
-  /**
-   * Gets the time (in ticks) when the ability was executed.
-   *
-   * @return The time in ticks when the ability was executed
-   */
+  /// Gets the time (in ticks) when the ability was executed.
+  ///
+  /// @return The time in ticks when the ability was executed
   public long getExecutionTicks() {
     return this.executionTicks;
   }
 
-  /**
-   * Updates the state of this ability execution. This method applies all ability effects after their delay and unregisters this instance after all
-   * effects were applied. Effects will apply their follow up effects on their own.
-   */
+  /// Updates the state of this ability execution. This method applies all ability effects after their delay and unregisters this instance after all
+  /// effects were applied. Effects will apply their follow up effects on their own.
   @Override
   public void update() {
     // if there are no effects to apply -> unregister this instance and we're done
@@ -92,9 +76,7 @@ public class AbilityExecution implements IUpdateable {
     this.applyAbilityEffects();
   }
 
-  /**
-   * Applies the effects of the ability. This method filters the effects that have not been applied yet and whose delay has passed, and applies them.
-   */
+  /// Applies the effects of the ability. This method filters the effects that have not been applied yet and whose delay has passed, and applies them.
   private void applyAbilityEffects() {
     long gameTicksSinceExecution = Game.time().since(this.getExecutionTicks());
     // ability not executed yet or delay of effect not yet reached

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/AbilityInfo.java
@@ -7,102 +7,74 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * The {@code AbilityInfo} annotation is used to define the properties of an Ability. It includes information such as cast type, cooldown,
- * description, duration, impact, impact angle, multi-target capability, name, origin, pivot offsets, range, and value.
- */
+/// The `AbilityInfo` annotation is used to define the properties of an Ability. It includes information such as cast type, cooldown,
+/// description, duration, impact, impact angle, multi-target capability, name, origin, pivot offsets, range, and value.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface AbilityInfo {
-  /**
-   * The cast type of the ability.
-   *
-   * @return The cast type of the ability
-   */
+  /// The cast type of the ability.
+  ///
+  /// @return The cast type of the ability
   CastType castType() default CastType.INSTANT;
 
-  /**
-   * The cooldown of the ability.
-   *
-   * @return The cooldown of the ability
-   */
+  /// The cooldown of the ability.
+  ///
+  /// @return The cooldown of the ability
   int cooldown() default 0;
 
-  /**
-   * The description of the ability.
-   *
-   * @return The description of the ability
-   */
+  /// The description of the ability.
+  ///
+  /// @return The description of the ability
   String description() default "";
 
-  /**
-   * The duration of the ability.
-   *
-   * @return The duration of the ability
-   */
+  /// The duration of the ability.
+  ///
+  /// @return The duration of the ability
   int duration() default 0;
 
-  /**
-   * The impact of the ability.
-   *
-   * @return The impact of the ability
-   */
+  /// The impact of the ability.
+  ///
+  /// @return The impact of the ability
   int impact() default 0;
 
-  /**
-   * The impact angle of the ability.
-   *
-   * @return The impact angle of the ability
-   */
+  /// The impact angle of the ability.
+  ///
+  /// @return The impact angle of the ability
   int impactAngle() default 360;
 
-  /**
-   * Whether the ability is multi-target.
-   *
-   * @return {@code true} if the ability is multi-target; {@code false} otherwise
-   */
+  /// Whether the ability is multi-target.
+  ///
+  /// @return `true` if the ability is multi-target; `false` otherwise
   boolean multiTarget() default false;
 
-  /**
-   * The name of the ability.
-   *
-   * @return The name of the ability
-   */
+  /// The name of the ability.
+  ///
+  /// @return The name of the ability
   String name() default "";
 
-  /**
-   * The origin of the ability.
-   *
-   * @return The origin of the ability
-   */
+  /// The origin of the ability.
+  ///
+  /// @return The origin of the ability
   EntityPivotType origin() default EntityPivotType.COLLISIONBOX_CENTER;
 
-  /**
-   * The pivot offset X of the ability.
-   *
-   * @return The pivot offset X of the ability
-   */
+  /// The pivot offset X of the ability.
+  ///
+  /// @return The pivot offset X of the ability
   double pivotOffsetX() default 0;
 
-  /**
-   * The pivot offset Y of the ability.
-   *
-   * @return The pivot offset Y of the ability
-   */
+  /// The pivot offset Y of the ability.
+  ///
+  /// @return The pivot offset Y of the ability
   double pivotOffsetY() default 0;
 
-  /**
-   * The range of the ability.
-   *
-   * @return The range of the ability
-   */
+  /// The range of the ability.
+  ///
+  /// @return The range of the ability
   int range() default 0;
 
-  /**
-   * The value of the ability.
-   *
-   * @return The value of the ability
-   */
+  /// The value of the ability.
+  ///
+  /// @return The value of the ability
   int value() default 0;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/CastType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/CastType.java
@@ -1,15 +1,9 @@
 package de.gurkenlabs.litiengine.abilities;
 
-/**
- * The {@code CastType} enum represents the types of casting an ability in the game. It can be either INSTANT or ONCONFIRM.
- */
+/// The `CastType` enum represents the types of casting an ability in the game. It can be either INSTANT or ONCONFIRM.
 public enum CastType {
-  /**
-   * Represents an ability that is cast instantly.
-   */
+  /// Represents an ability that is cast instantly.
   INSTANT,
-  /**
-   * Represents an ability that is cast upon confirmation.
-   */
+  /// Represents an ability that is cast upon confirmation.
   ONCONFIRM
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/DynamicAbility.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/DynamicAbility.java
@@ -3,9 +3,7 @@ package de.gurkenlabs.litiengine.abilities;
 import de.gurkenlabs.litiengine.entities.Creature;
 import java.util.function.Consumer;
 
-/**
- * An {@link Ability} implementation configured programmatically with attributes and executed via callbacks.
- */
+/// An [Ability] implementation configured programmatically with attributes and executed via callbacks.
 public class DynamicAbility extends Ability {
   private Consumer<AbilityExecution> castConsumer;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/AbilityEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/AbilityEffect.java
@@ -3,34 +3,28 @@ package de.gurkenlabs.litiengine.abilities.effects;
 import de.gurkenlabs.litiengine.abilities.Ability;
 import de.gurkenlabs.litiengine.abilities.targeting.TargetingStrategy;
 
-/**
- * The `AbilityEffect` class is an abstract class that represents an effect associated with a specific ability. It extends the `Effect` class and is
- * used to apply effects that are tied to a particular ability.
- * <p>
- * This class provides a way to manage and access the ability that triggers the effect, allowing for the integration of ability-specific attributes
- * such as the executor and duration.
- */
+/// The `AbilityEffect` class is an abstract class that represents an effect associated with a specific ability. It extends the `Effect` class and is
+/// used to apply effects that are tied to a particular ability.
+///
+/// This class provides a way to manage and access the ability that triggers the effect, allowing for the integration of ability-specific attributes
+/// such as the executor and duration.
 public abstract class AbilityEffect extends Effect {
   private final Ability ability;
 
-  /**
-   * Constructs a new `AbilityEffect` with the specified targeting strategy and ability.
-   * <p>
-   * The effect will inherit the executor and duration attributes from the provided ability.
-   *
-   * @param targetingStrategy The strategy used to select the targets for this effect.
-   * @param ability           The ability associated with this effect, providing information such as the executor and duration.
-   */
+  /// Constructs a new `AbilityEffect` with the specified targeting strategy and ability.
+  ///
+  /// The effect will inherit the executor and duration attributes from the provided ability.
+  ///
+  /// @param targetingStrategy The strategy used to select the targets for this effect.
+  /// @param ability           The ability associated with this effect, providing information such as the executor and duration.
   protected AbilityEffect(TargetingStrategy targetingStrategy, Ability ability) {
     super(targetingStrategy, ability.getExecutor(), ability.getAttributes().duration().getModifiedValue());
     this.ability = ability;
   }
 
-  /**
-   * Gets the ability associated with this effect.
-   *
-   * @return The ability associated with this effect.
-   */
+  /// Gets the ability associated with this effect.
+  ///
+  /// @return The ability associated with this effect.
   public Ability getAbility() {
     return ability;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/AttributeEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/AttributeEffect.java
@@ -6,91 +6,75 @@ import de.gurkenlabs.litiengine.attributes.AttributeModifier;
 import de.gurkenlabs.litiengine.attributes.Modification;
 import de.gurkenlabs.litiengine.entities.ICombatEntity;
 
-/**
- * Represents an effect that modifies an attribute of a combat entity.
- *
- * @param <T> the type of the attribute value
- */
+/// Represents an effect that modifies an attribute of a combat entity.
+///
+/// @param <T> the type of the attribute value
 public abstract class AttributeEffect<T extends Number> extends Effect {
 
   private final AttributeModifier<T> modifier;
 
-  /**
-   * Constructs an AttributeEffect with the specified targeting strategy, modification, and delta.
-   *
-   * @param targetingStrategy the strategy to determine the targets of the effect
-   * @param modification      the type of modification to apply to the attribute
-   * @param delta             the value to modify the attribute by
-   */
+  /// Constructs an AttributeEffect with the specified targeting strategy, modification, and delta.
+  ///
+  /// @param targetingStrategy the strategy to determine the targets of the effect
+  /// @param modification      the type of modification to apply to the attribute
+  /// @param delta             the value to modify the attribute by
   protected AttributeEffect(final TargetingStrategy targetingStrategy, final Modification modification, final double delta) {
     this(targetingStrategy, modification, delta, 0);
   }
 
-  /**
-   * Constructs an AttributeEffect with the specified targeting strategy, modification, and delta.
-   *
-   * @param targetingStrategy the strategy to determine the targets of the effect
-   * @param modification      the type of modification to apply to the attribute
-   * @param delta             the value to modify the attribute by
-   * @param duration          the duration of the effect in milliseconds
-   */
+  /// Constructs an AttributeEffect with the specified targeting strategy, modification, and delta.
+  ///
+  /// @param targetingStrategy the strategy to determine the targets of the effect
+  /// @param modification      the type of modification to apply to the attribute
+  /// @param delta             the value to modify the attribute by
+  /// @param duration          the duration of the effect in milliseconds
   protected AttributeEffect(final TargetingStrategy targetingStrategy, final Modification modification, final double delta,
     final int duration) {
     this(targetingStrategy, null, modification, delta, duration);
   }
 
-  /**
-   * Constructs an AttributeEffect with the specified targeting strategy, executing entity, modification, and delta.
-   *
-   * @param targetingStrategy the strategy to determine the targets of the effect
-   * @param executingEntity   the entity executing the effect
-   * @param modification      the type of modification to apply to the attribute
-   * @param delta             the value to modify the attribute by
-   */
+  /// Constructs an AttributeEffect with the specified targeting strategy, executing entity, modification, and delta.
+  ///
+  /// @param targetingStrategy the strategy to determine the targets of the effect
+  /// @param executingEntity   the entity executing the effect
+  /// @param modification      the type of modification to apply to the attribute
+  /// @param delta             the value to modify the attribute by
   protected AttributeEffect(final TargetingStrategy targetingStrategy, final ICombatEntity executingEntity, final Modification modification,
     final double delta) {
     this(targetingStrategy, executingEntity, modification, delta, 0);
   }
 
-  /**
-   * Constructs an AttributeEffect with the specified targeting strategy, executing entity, modification, and delta.
-   *
-   * @param targetingStrategy the strategy to determine the targets of the effect
-   * @param executingEntity   the entity executing the effect
-   * @param modification      the type of modification to apply to the attribute
-   * @param delta             the value to modify the attribute by
-   * @param duration          the duration of the effect in milliseconds
-   */
+  /// Constructs an AttributeEffect with the specified targeting strategy, executing entity, modification, and delta.
+  ///
+  /// @param targetingStrategy the strategy to determine the targets of the effect
+  /// @param executingEntity   the entity executing the effect
+  /// @param modification      the type of modification to apply to the attribute
+  /// @param delta             the value to modify the attribute by
+  /// @param duration          the duration of the effect in milliseconds
   protected AttributeEffect(final TargetingStrategy targetingStrategy, final ICombatEntity executingEntity, final Modification modification,
     final double delta, final int duration) {
     super(targetingStrategy, executingEntity, duration);
     this.modifier = new AttributeModifier<>(modification, delta);
   }
 
-  /**
-   * Ceases the effect on the specified entity, removing the attribute modifier.
-   *
-   * @param affectedEntity the entity affected by the effect
-   */
+  /// Ceases the effect on the specified entity, removing the attribute modifier.
+  ///
+  /// @param affectedEntity the entity affected by the effect
   @Override public void cease(final ICombatEntity affectedEntity) {
     super.cease(affectedEntity);
     this.getAttribute(affectedEntity).removeModifier(this.getModifier());
   }
 
-  /**
-   * Gets the attribute modifier associated with this effect.
-   *
-   * @return the attribute modifier
-   */
+  /// Gets the attribute modifier associated with this effect.
+  ///
+  /// @return the attribute modifier
   public AttributeModifier<T> getModifier() {
     return this.modifier;
   }
 
-  /**
-   * Applies the effect to the specified entity, adding the attribute modifier.
-   *
-   * @param affectedEntity the entity affected by the effect
-   */
+  /// Applies the effect to the specified entity, adding the attribute modifier.
+  ///
+  /// @param affectedEntity the entity affected by the effect
   @Override protected void apply(final ICombatEntity affectedEntity) {
     super.apply(affectedEntity);
     if (getAttribute(affectedEntity) == null) {
@@ -99,11 +83,9 @@ public abstract class AttributeEffect<T extends Number> extends Effect {
     getAttribute(affectedEntity).addModifier(getModifier());
   }
 
-  /**
-   * Gets the attribute to be modified for the specified entity.
-   *
-   * @param entity the entity whose attribute is to be modified
-   * @return the attribute to be modified
-   */
+  /// Gets the attribute to be modified for the specified entity.
+  ///
+  /// @param entity the entity whose attribute is to be modified
+  /// @return the attribute to be modified
   protected abstract Attribute<T> getAttribute(final ICombatEntity entity);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/Effect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/Effect.java
@@ -13,13 +13,11 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * The `Effect` class represents an abstract base class for applying effects to combat entities. Effects are applied based on a `TargetingStrategy`
- * and may affect multiple entities within a defined impact area. Effects are applied for a set duration and may have follow-up effects.
- * <p>
- * This class handles effect application, event listeners for when effects are applied or ceased, and the management of active appliances (ongoing
- * effect instances).
- */
+/// The `Effect` class represents an abstract base class for applying effects to combat entities. Effects are applied based on a `TargetingStrategy`
+/// and may affect multiple entities within a defined impact area. Effects are applied for a set duration and may have follow-up effects.
+///
+/// This class handles effect application, event listeners for when effects are applied or ceased, and the management of active appliances (ongoing
+/// effect instances).
 public abstract class Effect implements IUpdateable {
 
   private final List<EffectApplication> appliances;
@@ -32,32 +30,26 @@ public abstract class Effect implements IUpdateable {
   private int delay;
   private int duration;
 
-  /**
-   * Constructs a new `Effect` with the specified targeting strategy.
-   *
-   * @param targetingStrategy The strategy used to target entities for this effect.
-   */
+  /// Constructs a new `Effect` with the specified targeting strategy.
+  ///
+  /// @param targetingStrategy The strategy used to target entities for this effect.
   protected Effect(final TargetingStrategy targetingStrategy) {
     this(targetingStrategy, null);
   }
 
-  /**
-   * Constructs a new `Effect` with the specified targeting strategy and executor.
-   *
-   * @param targetingStrategy The strategy used to target entities for this effect.
-   * @param executor          The entity applying the effect, or null if none.
-   */
+  /// Constructs a new `Effect` with the specified targeting strategy and executor.
+  ///
+  /// @param targetingStrategy The strategy used to target entities for this effect.
+  /// @param executor          The entity applying the effect, or null if none.
   protected Effect(final TargetingStrategy targetingStrategy, final ICombatEntity executor) {
     this(targetingStrategy, executor, 0);
   }
 
-  /**
-   * Constructs a new `Effect` with the specified targeting strategy, executor, and duration.
-   *
-   * @param targetingStrategy The strategy used to target entities for this effect.
-   * @param executor          The entity applying the effect, or null if none.
-   * @param duration          The duration the effect will last.
-   */
+  /// Constructs a new `Effect` with the specified targeting strategy, executor, and duration.
+  ///
+  /// @param targetingStrategy The strategy used to target entities for this effect.
+  /// @param executor          The entity applying the effect, or null if none.
+  /// @param duration          The duration the effect will last.
   protected Effect(final TargetingStrategy targetingStrategy, final ICombatEntity executor, int duration) {
     this.appliedListeners = ConcurrentHashMap.newKeySet();
     this.ceasedListeners = ConcurrentHashMap.newKeySet();
@@ -69,47 +61,37 @@ public abstract class Effect implements IUpdateable {
     this.targetingStrategy = targetingStrategy;
   }
 
-  /**
-   * Registers a listener for when the effect is applied.
-   *
-   * @param listener The listener to register.
-   */
+  /// Registers a listener for when the effect is applied.
+  ///
+  /// @param listener The listener to register.
   public void onEffectApplied(final EffectAppliedListener listener) {
     this.appliedListeners.add(listener);
   }
 
-  /**
-   * Removes a listener that was previously registered to be notified when the effect is applied.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes a listener that was previously registered to be notified when the effect is applied.
+  ///
+  /// @param listener The listener to remove.
   public void removeEffectAppliedListener(final EffectAppliedListener listener) {
     this.appliedListeners.remove(listener);
   }
 
-  /**
-   * Registers a listener for when the effect ceases.
-   *
-   * @param listener The listener to register.
-   */
+  /// Registers a listener for when the effect ceases.
+  ///
+  /// @param listener The listener to register.
   public void onEffectCeased(final EffectCeasedListener listener) {
     this.ceasedListeners.add(listener);
   }
 
-  /**
-   * Removes a listener that was previously registered to be notified when the effect ceases.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes a listener that was previously registered to be notified when the effect ceases.
+  ///
+  /// @param listener The listener to remove.
   public void removeEffectCeasedListener(final EffectCeasedListener listener) {
     this.ceasedListeners.remove(listener);
   }
 
-  /**
-   * Applies the effect to all entities within the specified impact area.
-   *
-   * @param impactArea The area where the effect is applied.
-   */
+  /// Applies the effect to all entities within the specified impact area.
+  ///
+  /// @param impactArea The area where the effect is applied.
   public void apply(final Shape impactArea) {
     final var affected = this.targetingStrategy.findTargets(impactArea, this.getExecutingEntity());
     for (final ICombatEntity affectedEntity : affected) {
@@ -124,11 +106,9 @@ public abstract class Effect implements IUpdateable {
     }
   }
 
-  /**
-   * Ceases the effect for the specified entity.
-   *
-   * @param entity The entity for which the effect will cease.
-   */
+  /// Ceases the effect for the specified entity.
+  ///
+  /// @param entity The entity for which the effect will cease.
   public void cease(final ICombatEntity entity) {
     entity.getAppliedEffects().remove(this);
     final EffectEvent event = new EffectEvent(this, entity);
@@ -137,93 +117,73 @@ public abstract class Effect implements IUpdateable {
     }
   }
 
-  /**
-   * Returns the entity that is executing this effect.
-   *
-   * @return The executor of this effect.
-   */
+  /// Returns the entity that is executing this effect.
+  ///
+  /// @return The executor of this effect.
   public ICombatEntity getExecutingEntity() {
     return this.executor;
   }
 
-  /**
-   * Returns the list of active effect applications.
-   *
-   * @return The list of active effect applications.
-   */
+  /// Returns the list of active effect applications.
+  ///
+  /// @return The list of active effect applications.
   public List<EffectApplication> getActiveAppliances() {
     return this.appliances;
   }
 
-  /**
-   * Returns the delay before this effect is applied.
-   *
-   * @return The delay in ticks.
-   */
+  /// Returns the delay before this effect is applied.
+  ///
+  /// @return The delay in ticks.
   public int getDelay() {
     return this.delay;
   }
 
-  /**
-   * Returns the duration this effect lasts once applied.
-   *
-   * @return The effect duration in ticks.
-   */
+  /// Returns the duration this effect lasts once applied.
+  ///
+  /// @return The effect duration in ticks.
   public int getDuration() {
     return this.duration;
   }
 
-  /**
-   * Returns the targeting strategy used by this effect.
-   *
-   * @return The targeting strategy.
-   */
+  /// Returns the targeting strategy used by this effect.
+  ///
+  /// @return The targeting strategy.
   public TargetingStrategy getTargetingStrategy() {
     return this.targetingStrategy;
   }
 
-  /**
-   * Returns the list of follow-up effects that are applied after the main effect ends.
-   *
-   * @return The list of follow-up effects.
-   */
+  /// Returns the list of follow-up effects that are applied after the main effect ends.
+  ///
+  /// @return The list of follow-up effects.
   public List<Effect> getFollowUpEffects() {
     return this.followUpEffects;
   }
 
-  /**
-   * Checks if the effect is active on the specified entity.
-   *
-   * @param entity The entity to check.
-   * @return True if the effect is active on the entity, false otherwise.
-   */
+  /// Checks if the effect is active on the specified entity.
+  ///
+  /// @param entity The entity to check.
+  /// @return True if the effect is active on the entity, false otherwise.
   public boolean isActive(final ICombatEntity entity) {
     return getActiveAppliances().stream()
       .anyMatch(a -> a.getAffectedEntities().stream().anyMatch(e -> e.equals(entity)));
   }
 
-  /**
-   * Sets the delay before this effect is applied.
-   *
-   * @param delay the delay in ticks
-   */
+  /// Sets the delay before this effect is applied.
+  ///
+  /// @param delay the delay in ticks
   public void setDelay(final int delay) {
     this.delay = delay;
   }
 
-  /**
-   * Sets the duration this effect lasts once applied.
-   *
-   * @param duration the effect duration in ticks
-   */
+  /// Sets the duration this effect lasts once applied.
+  ///
+  /// @param duration the effect duration in ticks
   public void setDuration(final int duration) {
     this.duration = duration;
   }
 
-  /**
-   * Updates the effect, checking for appliances that have reached their duration and applying follow-up effects if needed. Removes appliances that
-   * have ended and detaches the effect from the game loop if no active appliances remain.
-   */
+  /// Updates the effect, checking for appliances that have reached their duration and applying follow-up effects if needed. Removes appliances that
+  /// have ended and detaches the effect from the game loop if no active appliances remain.
   @Override
   public void update() {
 
@@ -244,12 +204,10 @@ public abstract class Effect implements IUpdateable {
     }
   }
 
-  /**
-   * Applies the effect to the specified entity, adding this effect to the entity's list of applied effects and notifying all registered listeners
-   * that the effect has been applied.
-   *
-   * @param entity the entity to which the effect is applied
-   */
+  /// Applies the effect to the specified entity, adding this effect to the entity's list of applied effects and notifying all registered listeners
+  /// that the effect has been applied.
+  ///
+  /// @param entity the entity to which the effect is applied
   protected void apply(final ICombatEntity entity) {
     entity.getAppliedEffects().add(this);
     final EffectEvent event = new EffectEvent(this, entity);
@@ -258,11 +216,9 @@ public abstract class Effect implements IUpdateable {
     }
   }
 
-  /**
-   * Ceases the effect for the specified application and applies follow-up effects.
-   *
-   * @param appliance The application to cease.
-   */
+  /// Ceases the effect for the specified application and applies follow-up effects.
+  ///
+  /// @param appliance The application to cease.
   protected void cease(final EffectApplication appliance) {
     for (final ICombatEntity entity : appliance.getAffectedEntities()) {
       this.cease(entity);
@@ -271,21 +227,17 @@ public abstract class Effect implements IUpdateable {
     this.getFollowUpEffects().forEach(followUp -> followUp.apply(appliance.getImpactArea()));
   }
 
-  /**
-   * Returns the total duration of the effect, including the delay.
-   *
-   * @return The total effect duration.
-   */
+  /// Returns the total duration of the effect, including the delay.
+  ///
+  /// @return The total effect duration.
   protected long getTotalDuration() {
     return this.getDuration() + (long) this.getDelay();
   }
 
-  /**
-   * Checks if the specified effect application has ended.
-   *
-   * @param appliance The application to check.
-   * @return True if the effect duration has passed, false otherwise.
-   */
+  /// Checks if the specified effect application has ended.
+  ///
+  /// @param appliance The application to check.
+  /// @return True if the effect duration has passed, false otherwise.
   protected boolean hasEnded(final EffectApplication appliance) {
     if (this.getDuration() <= 0) {
       return false;
@@ -295,31 +247,23 @@ public abstract class Effect implements IUpdateable {
     return effectDuration > this.getDuration();
   }
 
-  /**
-   * Listener interface for receiving notifications when an effect is applied.
-   */
+  /// Listener interface for receiving notifications when an effect is applied.
   @FunctionalInterface
   public interface EffectAppliedListener extends EventListener {
 
-    /**
-     * Invoked when an effect is applied.
-     *
-     * @param event the event containing information about the applied effect
-     */
+    /// Invoked when an effect is applied.
+    ///
+    /// @param event the event containing information about the applied effect
     void applied(EffectEvent event);
   }
 
-  /**
-   * Listener interface for receiving notifications when an effect ceases.
-   */
+  /// Listener interface for receiving notifications when an effect ceases.
   @FunctionalInterface
   public interface EffectCeasedListener extends EventListener {
 
-    /**
-     * Invoked when an effect ceases.
-     *
-     * @param event the event containing information about the ceased effect
-     */
+    /// Invoked when an effect ceases.
+    ///
+    /// @param event the event containing information about the ceased effect
     void ceased(EffectEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/EffectApplication.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/EffectApplication.java
@@ -5,49 +5,39 @@ import de.gurkenlabs.litiengine.entities.ICombatEntity;
 import java.awt.Shape;
 import java.util.Collection;
 
-/**
- * Represents the application of an effect, including the entities affected and the area of impact.
- */
+/// Represents the application of an effect, including the entities affected and the area of impact.
 public class EffectApplication {
   private final Collection<ICombatEntity> affectedEntities;
   private final long applied;
   private final Shape impactArea;
 
-  /**
-   * Constructs an EffectApplication with the specified affected entities and impact area.
-   *
-   * @param affectedEntities the entities affected by the effect
-   * @param impactArea       the area where the effect is applied
-   */
+  /// Constructs an EffectApplication with the specified affected entities and impact area.
+  ///
+  /// @param affectedEntities the entities affected by the effect
+  /// @param impactArea       the area where the effect is applied
   protected EffectApplication(final Collection<ICombatEntity> affectedEntities, final Shape impactArea) {
     this.applied = Game.time().now();
     this.affectedEntities = affectedEntities;
     this.impactArea = impactArea;
   }
 
-  /**
-   * Gets the entities affected by the effect.
-   *
-   * @return the collection of affected entities
-   */
+  /// Gets the entities affected by the effect.
+  ///
+  /// @return the collection of affected entities
   public Collection<ICombatEntity> getAffectedEntities() {
     return this.affectedEntities;
   }
 
-  /**
-   * Gets the time in ticks when the effect was applied.
-   *
-   * @return the applied time in ticks
-   */
+  /// Gets the time in ticks when the effect was applied.
+  ///
+  /// @return the applied time in ticks
   public long getAppliedTicks() {
     return this.applied;
   }
 
-  /**
-   * Gets the shape of the area where the effect is applied.
-   *
-   * @return the impact area
-   */
+  /// Gets the shape of the area where the effect is applied.
+  ///
+  /// @return the impact area
   public Shape getImpactArea() {
     return this.impactArea;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/EffectEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/EffectEvent.java
@@ -4,49 +4,37 @@ import de.gurkenlabs.litiengine.entities.ICombatEntity;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * Represents an event related to an {@code Effect} being applied to a combat entity. This class provides information about the effect and the entity
- * it is applied to.
- */
+/// Represents an event related to an `Effect` being applied to a combat entity. This class provides information about the effect and the entity
+/// it is applied to.
 public class EffectEvent extends EventObject {
   @Serial private static final long serialVersionUID = -6911987630602502891L;
 
-  /**
-   * The combat entity associated with this event. This field is transient to avoid serialization issues.
-   */
+  /// The combat entity associated with this event. This field is transient to avoid serialization issues.
   private final transient ICombatEntity combatEntity;
 
-  /**
-   * The effect associated with this event. This field is transient to avoid serialization issues.
-   */
+  /// The effect associated with this event. This field is transient to avoid serialization issues.
   private final transient Effect effect;
 
-  /**
-   * Initializes a new instance of the {@code EffectEvent} class.
-   *
-   * @param effect       The effect that triggered this event.
-   * @param combatEntity The combat entity affected by the effect.
-   */
+  /// Initializes a new instance of the `EffectEvent` class.
+  ///
+  /// @param effect       The effect that triggered this event.
+  /// @param combatEntity The combat entity affected by the effect.
   EffectEvent(final Effect effect, final ICombatEntity combatEntity) {
     super(effect);
     this.effect = effect;
     this.combatEntity = combatEntity;
   }
 
-  /**
-   * Gets the combat entity associated with this event.
-   *
-   * @return The {@code ICombatEntity} affected by the effect.
-   */
+  /// Gets the combat entity associated with this event.
+  ///
+  /// @return The `ICombatEntity` affected by the effect.
   public ICombatEntity getCombatEntity() {
     return this.combatEntity;
   }
 
-  /**
-   * Gets the effect associated with this event.
-   *
-   * @return The {@code Effect} that triggered this event.
-   */
+  /// Gets the effect associated with this event.
+  ///
+  /// @return The `Effect` that triggered this event.
   public Effect getEffect() {
     return this.effect;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/ForceEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/ForceEffect.java
@@ -8,49 +8,41 @@ import de.gurkenlabs.litiengine.physics.Force;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * The `ForceEffect` represents an effect that applies a physical force to mobile entities.
- * It extends the `Effect` class and is used to manipulate the movement of entities based on the applied force,
- * such as knockbacks or pulls.
- * <p>
- * This effect can be applied to entities that implement the `IMobileEntity` interface.
- * The `ForceEffect` uses a targeting strategy to determine which entities are affected
- * and applies a force with a given strength to them.
- */
+/// The `ForceEffect` represents an effect that applies a physical force to mobile entities.
+/// It extends the `Effect` class and is used to manipulate the movement of entities based on the applied force,
+/// such as knockbacks or pulls.
+///
+/// This effect can be applied to entities that implement the `IMobileEntity` interface.
+/// The `ForceEffect` uses a targeting strategy to determine which entities are affected
+/// and applies a force with a given strength to them.
 public abstract class ForceEffect extends Effect {
 
   private final float strength;
   private final Map<IMobileEntity, Force> appliedForces;
 
-  /**
-   * Constructs a new `ForceEffect` with the specified targeting strategy and force strength.
-   *
-   * @param targetingStrategy The strategy used to select which entities will be affected by the effect.
-   * @param strength          The strength of the applied force.
-   */
+  /// Constructs a new `ForceEffect` with the specified targeting strategy and force strength.
+  ///
+  /// @param targetingStrategy The strategy used to select which entities will be affected by the effect.
+  /// @param strength          The strength of the applied force.
   protected ForceEffect(final TargetingStrategy targetingStrategy, final float strength, final int duration) {
     this(targetingStrategy, null, strength, duration);
   }
 
-  /**
-   * Constructs a new `ForceEffect` with the specified targeting strategy, executing entity, and force strength.
-   *
-   * @param targetingStrategy The strategy used to select which entities will be affected by the effect.
-   * @param executingEntity   The entity executing the effect (e.g., a player or NPC).
-   * @param strength          The strength of the applied force.
-   */
+  /// Constructs a new `ForceEffect` with the specified targeting strategy, executing entity, and force strength.
+  ///
+  /// @param targetingStrategy The strategy used to select which entities will be affected by the effect.
+  /// @param executingEntity   The entity executing the effect (e.g., a player or NPC).
+  /// @param strength          The strength of the applied force.
   protected ForceEffect(final TargetingStrategy targetingStrategy, final ICombatEntity executingEntity, final float strength, final int duration) {
     super(targetingStrategy, executingEntity, duration);
     this.strength = strength;
     this.appliedForces = new ConcurrentHashMap<>();
   }
 
-  /**
-   * Applies the effect to a specified combat entity. If the affected entity is mobile, a force is created
-   * and applied to manipulate its movement. The applied force is stored in a map for later reference.
-   *
-   * @param affectedEntity The combat entity that will be affected by the force.
-   */
+  /// Applies the effect to a specified combat entity. If the affected entity is mobile, a force is created
+  /// and applied to manipulate its movement. The applied force is stored in a map for later reference.
+  ///
+  /// @param affectedEntity The combat entity that will be affected by the force.
   @Override
   public void apply(final ICombatEntity affectedEntity) {
     super.apply(affectedEntity);
@@ -65,29 +57,23 @@ public abstract class ForceEffect extends Effect {
     }
   }
 
-  /**
-   * Gets the strength of the applied force.
-   *
-   * @return The force strength.
-   */
+  /// Gets the strength of the applied force.
+  ///
+  /// @return The force strength.
   public float getStrength() {
     return this.strength;
   }
 
-  /**
-   * Abstract method that must be implemented to define how the force is created for each entity.
-   *
-   * @param affectedEntity The mobile entity to which the force is applied.
-   * @return The created `Force` object representing the force to be applied.
-   */
+  /// Abstract method that must be implemented to define how the force is created for each entity.
+  ///
+  /// @param affectedEntity The mobile entity to which the force is applied.
+  /// @return The created `Force` object representing the force to be applied.
   protected abstract Force createForce(final IMobileEntity affectedEntity);
 
-  /**
-   * Stops the effect on a specified entity. If a force was applied to the entity, it is ended and
-   * removed from the map tracking applied forces.
-   *
-   * @param entity The entity on which the effect will cease.
-   */
+  /// Stops the effect on a specified entity. If a force was applied to the entity, it is ended and
+  /// removed from the map tracking applied forces.
+  ///
+  /// @param entity The entity on which the effect will cease.
   @Override
   public void cease(ICombatEntity entity) {
     super.cease(entity);
@@ -97,13 +83,11 @@ public abstract class ForceEffect extends Effect {
     }
   }
 
-  /**
-   * Checks whether the effect has ended. The effect is considered ended if it has naturally
-   * ended according to its duration, or if all forces applied have ended.
-   *
-   * @param appliance The current application of the effect.
-   * @return `true` if the effect has ended, `false` otherwise.
-   */
+  /// Checks whether the effect has ended. The effect is considered ended if it has naturally
+  /// ended according to its duration, or if all forces applied have ended.
+  ///
+  /// @param appliance The current application of the effect.
+  /// @return `true` if the effect has ended, `false` otherwise.
   @Override
   protected boolean hasEnded(final EffectApplication appliance) {
     return super.hasEnded(appliance) || appliedForces.isEmpty() || appliedForces.values().stream()

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/SoundEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/effects/SoundEffect.java
@@ -11,49 +11,39 @@ public class SoundEffect extends Effect {
 
   private final Sound[] sounds;
 
-  /**
-   * Initializes a new instance of the {@code SoundEffect} class.
-   *
-   * @param sounds The sounds to chose from when applying the effect.
-   */
+  /// Initializes a new instance of the `SoundEffect` class.
+  ///
+  /// @param sounds The sounds to chose from when applying the effect.
   public SoundEffect(ICombatEntity executingEntity, final Sound... sounds) {
     super(TargetingStrategy.executingEntity(), executingEntity);
     this.sounds = sounds;
   }
 
-  /**
-   * Initializes a new instance of the {@code SoundEffect} class with the specified sounds.
-   *
-   * @param sounds The sounds to choose from when applying the effect.
-   */
+  /// Initializes a new instance of the `SoundEffect` class with the specified sounds.
+  ///
+  /// @param sounds The sounds to choose from when applying the effect.
   public SoundEffect(final Sound... sounds) {
     this(null, sounds);
   }
 
-  /**
-   * Initializes a new instance of the {@code SoundEffect} class with the specified executing entity and sounds.
-   *
-   * @param executingEntity The entity executing the effect.
-   * @param sounds          The names of the sounds to choose from when applying the effect.
-   */
+  /// Initializes a new instance of the `SoundEffect` class with the specified executing entity and sounds.
+  ///
+  /// @param executingEntity The entity executing the effect.
+  /// @param sounds          The names of the sounds to choose from when applying the effect.
   public SoundEffect(ICombatEntity executingEntity, final String... sounds) {
     this(executingEntity, Arrays.stream(sounds).map(x -> Resources.sounds().get(x)).toArray(Sound[]::new));
   }
 
-  /**
-   * Initializes a new instance of the {@code SoundEffect} class with the specified sounds.
-   *
-   * @param sounds The names of the sounds to choose from when applying the effect.
-   */
+  /// Initializes a new instance of the `SoundEffect` class with the specified sounds.
+  ///
+  /// @param sounds The names of the sounds to choose from when applying the effect.
   public SoundEffect(final String... sounds) {
     this(null, sounds);
   }
 
-  /**
-   * Applies the sound effect to the specified entity, playing a random sound from the list of sounds.
-   *
-   * @param entity The entity to which the effect is applied.
-   */
+  /// Applies the sound effect to the specified entity, playing a random sound from the list of sounds.
+  ///
+  /// @param entity The entity to which the effect is applied.
   @Override
   protected void apply(final ICombatEntity entity) {
     super.apply(entity);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/package-info.java
@@ -1,0 +1,6 @@
+/// Abilities that creatures can cast and effects applied by their executions.
+///
+/// Start with [de.gurkenlabs.litiengine.entities.Creature#createAbility(String)] for dynamically
+/// configured abilities, or extend [de.gurkenlabs.litiengine.abilities.Ability] for specialized
+/// behavior.
+package de.gurkenlabs.litiengine.abilities;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/CustomTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/CustomTargetingStrategy.java
@@ -7,39 +7,33 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiPredicate;
 
-/**
- * A custom targeting strategy that allows defining a specific condition for selecting targets.
- *
- * <p>This strategy uses a {@link BiPredicate} to determine whether a combat entity
- * should be targeted based on the executor and the potential target. It supports multi-targeting and sorting by distance.
- */
+/// A custom targeting strategy that allows defining a specific condition for selecting targets.
+///
+/// This strategy uses a [BiPredicate] to determine whether a combat entity
+/// should be targeted based on the executor and the potential target. It supports multi-targeting and sorting by distance.
 public class CustomTargetingStrategy extends TargetingStrategy {
 
   private final BiPredicate<ICombatEntity, ICombatEntity> targetingCondition;
 
-  /**
-   * Creates a new {@code CustomTargetingStrategy} with the specified targeting condition.
-   *
-   * @param customPredicate The condition to determine valid targets. It takes the executor and a potential target as arguments and returns
-   *                        {@code true} if the target is valid.
-   * @param multiTarget     Whether the strategy supports targeting multiple entities.
-   * @param sortByDistance  Whether the targets should be sorted by their distance to the executor.
-   */
+  /// Creates a new `CustomTargetingStrategy` with the specified targeting condition.
+  ///
+  /// @param customPredicate The condition to determine valid targets. It takes the executor and a potential target as arguments and returns
+  /// `true` if the target is valid.
+  /// @param multiTarget     Whether the strategy supports targeting multiple entities.
+  /// @param sortByDistance  Whether the targets should be sorted by their distance to the executor.
   public CustomTargetingStrategy(BiPredicate<ICombatEntity, ICombatEntity> customPredicate, boolean multiTarget, boolean sortByDistance) {
     super(multiTarget, sortByDistance);
     this.targetingCondition = customPredicate;
   }
 
-  /**
-   * Finds the targets within the specified impact area based on the targeting condition.
-   *
-   * <p>If the targeting condition or the game environment is not available, this method
-   * returns an empty collection.
-   *
-   * @param impactArea The area in which to search for targets.
-   * @param executor   The combat entity executing the ability.
-   * @return A collection of combat entities that match the targeting condition.
-   */
+  /// Finds the targets within the specified impact area based on the targeting condition.
+  ///
+  /// If the targeting condition or the game environment is not available, this method
+  /// returns an empty collection.
+  ///
+  /// @param impactArea The area in which to search for targets.
+  /// @param executor   The combat entity executing the ability.
+  /// @return A collection of combat entities that match the targeting condition.
   @Override
   public Collection<ICombatEntity> findTargetsInternal(Shape impactArea, ICombatEntity executor) {
     if (targetingCondition == null || Game.world() == null || Game.world().environment() == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/EnemyTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/EnemyTargetingStrategy.java
@@ -1,25 +1,21 @@
 package de.gurkenlabs.litiengine.abilities.targeting;
 
-/**
- * A targeting strategy that selects enemy entities as ability targets.
- *
- * <p>This strategy extends {@link OtherEntityTargetingStrategy} and is preconfigured to exclude
- * the executing entity itself as well as any friendly entities, thereby restricting the set of valid targets to enemies only.
- *
- * @see OtherEntityTargetingStrategy
- */
+/// A targeting strategy that selects enemy entities as ability targets.
+///
+/// This strategy extends [OtherEntityTargetingStrategy] and is preconfigured to exclude
+/// the executing entity itself as well as any friendly entities, thereby restricting the set of valid targets to enemies only.
+///
+/// @see OtherEntityTargetingStrategy
 public class EnemyTargetingStrategy extends OtherEntityTargetingStrategy {
 
-  /**
-   * Creates a new {@code EnemyTargetingStrategy}.
-   *
-   * @param multiTarget     if {@code true}, the strategy may return multiple matching targets;
-   *                        otherwise only a single target is selected.
-   * @param sortByDistance  if {@code true}, the resulting targets are ordered by their distance
-   *                        to the executing entity (closest first).
-   * @param includeDead     if {@code true}, dead entities are considered valid targets;
-   *                        otherwise only living entities are selected.
-   */
+  /// Creates a new `EnemyTargetingStrategy`.
+  ///
+  /// @param multiTarget     if `true`, the strategy may return multiple matching targets;
+  /// otherwise only a single target is selected.
+  /// @param sortByDistance  if `true`, the resulting targets are ordered by their distance
+  /// to the executing entity (closest first).
+  /// @param includeDead     if `true`, dead entities are considered valid targets;
+  /// otherwise only living entities are selected.
   public EnemyTargetingStrategy(boolean multiTarget, boolean sortByDistance, boolean includeDead) {
     super(multiTarget, sortByDistance, false, false, includeDead);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/ExecutingEntityTargetTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/ExecutingEntityTargetTargetingStrategy.java
@@ -5,42 +5,36 @@ import java.awt.Shape;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * A targeting strategy that resolves to the current target of the executing entity.
- *
- * <p>This strategy ignores the impact area and instead delegates to the executor's own
- * {@link ICombatEntity#getTarget() target} reference. It is useful for abilities that should be applied to whatever entity the caster is currently
- * focused on (for example, a tab-targeted spell).
- *
- * <p>Note: if the executor has no current target, the returned collection will contain a single
- * {@code null} element. Callers should be prepared to handle this case.
- *
- * @see TargetingStrategy
- * @see ICombatEntity#getTarget()
- */
+/// A targeting strategy that resolves to the current target of the executing entity.
+///
+/// This strategy ignores the impact area and instead delegates to the executor's own
+/// [target][ICombatEntity#getTarget()] reference. It is useful for abilities that should be applied to whatever entity the caster is currently
+/// focused on (for example, a tab-targeted spell).
+///
+/// Note: if the executor has no current target, the returned collection will contain a single
+/// `null` element. Callers should be prepared to handle this case.
+///
+/// @see TargetingStrategy
+/// @see ICombatEntity#getTarget()
 public class ExecutingEntityTargetTargetingStrategy extends TargetingStrategy {
 
-  /**
-   * Creates a new {@code ExecutingEntityTargetTargetingStrategy}.
-   *
-   * <p>The strategy is configured as single-target and unsorted, since the resulting collection
-   * always contains at most one entity (the executor's current target).
-   */
+  /// Creates a new `ExecutingEntityTargetTargetingStrategy`.
+  ///
+  /// The strategy is configured as single-target and unsorted, since the resulting collection
+  /// always contains at most one entity (the executor's current target).
   public ExecutingEntityTargetTargetingStrategy() {
     super(false, false);
   }
 
-  /**
-   * Returns the executor's current target as the sole target, regardless of the given impact
-   * area.
-   *
-   * @param impactArea the shape representing the ability's area of effect; ignored by this
-   *                   strategy.
-   * @param executor   the combat entity executing the ability; its
-   *                   {@link ICombatEntity#getTarget() current target} is returned.
-   * @return an immutable collection containing exactly the executor's current target. The element
-   *         may be {@code null} if the executor has no target set.
-   */
+  /// Returns the executor's current target as the sole target, regardless of the given impact
+  /// area.
+  ///
+  /// @param impactArea the shape representing the ability's area of effect; ignored by this
+  /// strategy.
+  /// @param executor   the combat entity executing the ability; its
+  /// [current target][ICombatEntity#getTarget()] is returned.
+  /// @return an immutable collection containing exactly the executor's current target. The element
+  /// may be `null` if the executor has no target set.
   @Override
   public Collection<ICombatEntity> findTargetsInternal(Shape impactArea, ICombatEntity executor) {
     return List.of(executor.getTarget());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/ExecutingEntityTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/ExecutingEntityTargetingStrategy.java
@@ -6,35 +6,29 @@ import java.awt.Shape;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * A targeting strategy that always targets the entity executing the ability.
- *
- * <p>This strategy ignores the impact area entirely and resolves to a single-element collection
- * containing the executor itself. It is useful for self-cast abilities such as heals, buffs, or other effects that should only affect the caster.
- *
- * @see TargetingStrategy
- */
+/// A targeting strategy that always targets the entity executing the ability.
+///
+/// This strategy ignores the impact area entirely and resolves to a single-element collection
+/// containing the executor itself. It is useful for self-cast abilities such as heals, buffs, or other effects that should only affect the caster.
+///
+/// @see TargetingStrategy
 public class ExecutingEntityTargetingStrategy extends TargetingStrategy {
 
-  /**
-   * Creates a new {@code ExecutingEntityTargetingStrategy}.
-   *
-   * <p>The strategy is configured as single-target and unsorted, since the resulting collection
-   * always contains exactly one entity (the executor).
-   */
+  /// Creates a new `ExecutingEntityTargetingStrategy`.
+  ///
+  /// The strategy is configured as single-target and unsorted, since the resulting collection
+  /// always contains exactly one entity (the executor).
   public ExecutingEntityTargetingStrategy() {
     super(false, false);
   }
 
-  /**
-   * Returns the executing entity as the sole target, regardless of the given impact area.
-   *
-   * @param impactArea the shape representing the ability's area of effect; ignored by this
-   *                   strategy.
-   * @param executor   the combat entity executing the ability; this entity is returned as the
-   *                   only target.
-   * @return an immutable collection containing exactly the {@code executor}.
-   */
+  /// Returns the executing entity as the sole target, regardless of the given impact area.
+  ///
+  /// @param impactArea the shape representing the ability's area of effect; ignored by this
+  /// strategy.
+  /// @param executor   the combat entity executing the ability; this entity is returned as the
+  /// only target.
+  /// @return an immutable collection containing exactly the `executor`.
   @Override
   public Collection<ICombatEntity> findTargetsInternal(Shape impactArea, ICombatEntity executor) {
     return List.of(executor);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/FixedTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/FixedTargetingStrategy.java
@@ -5,44 +5,36 @@ import java.awt.Shape;
 import java.util.Arrays;
 import java.util.Collection;
 
-/**
- * A targeting strategy that always resolves to a predefined, fixed set of combat entities.
- *
- * <p>Unlike dynamic strategies, this implementation ignores both the impact area and the
- * executing entity, and simply returns the collection of targets supplied at construction time. It is useful for scripted scenarios, cutscenes, or
- * abilities that should always affect a known set of entities (for example, a specific boss and its minions).
- *
- * @see TargetingStrategy
- */
+/// A targeting strategy that always resolves to a predefined, fixed set of combat entities.
+///
+/// Unlike dynamic strategies, this implementation ignores both the impact area and the
+/// executing entity, and simply returns the collection of targets supplied at construction time. It is useful for scripted scenarios, cutscenes, or
+/// abilities that should always affect a known set of entities (for example, a specific boss and its minions).
+///
+/// @see TargetingStrategy
 public class FixedTargetingStrategy extends TargetingStrategy {
 
-  /**
-   * The fixed collection of targets returned by this strategy.
-   */
+  /// The fixed collection of targets returned by this strategy.
   private Collection<ICombatEntity> fixedTargets;
 
-  /**
-   * Creates a new {@code FixedTargetingStrategy} with the given fixed targets.
-   *
-   * <p>The strategy is automatically configured as multi-target when more than one entity is
-   * supplied, and as single-target otherwise. The results are never sorted by distance.
-   *
-   * @param fixedTargets the combat entities that will always be returned as the targets of this
-   *                     strategy. May be empty.
-   */
+  /// Creates a new `FixedTargetingStrategy` with the given fixed targets.
+  ///
+  /// The strategy is automatically configured as multi-target when more than one entity is
+  /// supplied, and as single-target otherwise. The results are never sorted by distance.
+  ///
+  /// @param fixedTargets the combat entities that will always be returned as the targets of this
+  /// strategy. May be empty.
   protected FixedTargetingStrategy(ICombatEntity... fixedTargets) {
     super(fixedTargets.length > 1, false);
     this.fixedTargets = Arrays.asList(fixedTargets);
   }
 
-  /**
-   * Returns the predefined fixed targets, ignoring both the impact area and the executor.
-   *
-   * @param impactArea the shape representing the ability's area of effect; ignored by this
-   *                   strategy.
-   * @param executor   the combat entity executing the ability; ignored by this strategy.
-   * @return the fixed collection of targets supplied at construction time.
-   */
+  /// Returns the predefined fixed targets, ignoring both the impact area and the executor.
+  ///
+  /// @param impactArea the shape representing the ability's area of effect; ignored by this
+  /// strategy.
+  /// @param executor   the combat entity executing the ability; ignored by this strategy.
+  /// @return the fixed collection of targets supplied at construction time.
   @Override
   protected Collection<ICombatEntity> findTargetsInternal(Shape impactArea, ICombatEntity executor) {
     return this.fixedTargets;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/FriendlyTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/FriendlyTargetingStrategy.java
@@ -1,27 +1,23 @@
 package de.gurkenlabs.litiengine.abilities.targeting;
 
-/**
- * A targeting strategy that selects friendly entities as ability targets.
- *
- * <p>This strategy extends {@link OtherEntityTargetingStrategy} and is preconfigured to include
- * only allied entities while excluding the executing entity itself. It is typically used for support abilities such as heals, buffs, or shields that
- * should affect friends but not foes or the caster.
- *
- * @see OtherEntityTargetingStrategy
- */
+/// A targeting strategy that selects friendly entities as ability targets.
+///
+/// This strategy extends [OtherEntityTargetingStrategy] and is preconfigured to include
+/// only allied entities while excluding the executing entity itself. It is typically used for support abilities such as heals, buffs, or shields that
+/// should affect friends but not foes or the caster.
+///
+/// @see OtherEntityTargetingStrategy
 public class FriendlyTargetingStrategy extends OtherEntityTargetingStrategy {
 
-  /**
-   * Creates a new {@code FriendlyTargetingStrategy}.
-   *
-   * @param multiTarget     if {@code true}, the strategy may return multiple matching targets;
-   *                        otherwise only a single target is selected.
-   * @param sortByDistance  if {@code true}, the resulting targets are ordered by their distance
-   *                        to the executing entity (closest first).
-   * @param includeDead     if {@code true}, dead entities are considered valid targets (useful
-   *                        for resurrection-like abilities); otherwise only living entities are
-   *                        selected.
-   */
+  /// Creates a new `FriendlyTargetingStrategy`.
+  ///
+  /// @param multiTarget     if `true`, the strategy may return multiple matching targets;
+  /// otherwise only a single target is selected.
+  /// @param sortByDistance  if `true`, the resulting targets are ordered by their distance
+  /// to the executing entity (closest first).
+  /// @param includeDead     if `true`, dead entities are considered valid targets (useful
+  /// for resurrection-like abilities); otherwise only living entities are
+  /// selected.
   public FriendlyTargetingStrategy(boolean multiTarget, boolean sortByDistance, boolean includeDead) {
     super(multiTarget, sortByDistance, true, false, includeDead);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/OtherEntityTargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/OtherEntityTargetingStrategy.java
@@ -5,67 +5,58 @@ import de.gurkenlabs.litiengine.entities.ICombatEntity;
 import java.awt.Shape;
 import java.util.Collection;
 
-/**
- * A targeting strategy that selects other combat entities within the ability's impact area, filtered by their relationship to the executor and their
- * alive/dead state.
- *
- * <p>This strategy queries the current environment for combat entities intersecting the given
- * impact area and filters them according to three configurable criteria:
- * <ul>
- *   <li><b>friendly</b> – whether to select allied entities or hostile ones,</li>
- *   <li><b>includeExecutor</b> – whether the executing entity itself may be returned,</li>
- *   <li><b>includeDead</b> – whether dead entities may be returned.</li>
- * </ul>
- *
- * <p>It serves as the common base for {@link FriendlyTargetingStrategy} and
- * {@link EnemyTargetingStrategy}.
- *
- * @see TargetingStrategy
- * @see FriendlyTargetingStrategy
- * @see EnemyTargetingStrategy
- */
+/// A targeting strategy that selects other combat entities within the ability's impact area, filtered by their relationship to the executor and their
+/// alive/dead state.
+///
+/// This strategy queries the current environment for combat entities intersecting the given
+/// impact area and filters them according to three configurable criteria:
+///
+/// - **friendly** – whether to select allied entities or hostile ones,
+/// - **includeExecutor** – whether the executing entity itself may be returned,
+/// - **includeDead** – whether dead entities may be returned.
+///
+/// It serves as the common base for [FriendlyTargetingStrategy] and
+/// [EnemyTargetingStrategy].
+///
+/// @see TargetingStrategy
+/// @see FriendlyTargetingStrategy
+/// @see EnemyTargetingStrategy
 public class OtherEntityTargetingStrategy extends TargetingStrategy {
 
-  /**
-   * Whether this strategy targets friendly ({@code true}) or hostile ({@code false}) entities.
-   */
+  /// Whether this strategy targets friendly (`true`) or hostile (`false`) entities.
   private final boolean friendly;
 
-  /** Whether the executing entity itself is a valid target. */
+  /// Whether the executing entity itself is a valid target.
   private final boolean includeExecutor;
 
-  /** Whether dead entities are valid targets. */
+  /// Whether dead entities are valid targets.
   private final boolean includeDead;
 
-  /**
-   * Creates a new {@code OtherEntityTargetingStrategy} that excludes both the executor and dead
-   * entities.
-   *
-   * @param multiTarget    if {@code true}, the strategy may return multiple matching targets;
-   *                       otherwise only a single target is selected.
-   * @param sortByDistance if {@code true}, the resulting targets are ordered by their distance to
-   *                       the executing entity (closest first).
-   * @param friendly       if {@code true}, only friendly entities are targeted; otherwise only
-   *                       hostile entities are targeted.
-   */
+  /// Creates a new `OtherEntityTargetingStrategy` that excludes both the executor and dead
+  /// entities.
+  ///
+  /// @param multiTarget    if `true`, the strategy may return multiple matching targets;
+  /// otherwise only a single target is selected.
+  /// @param sortByDistance if `true`, the resulting targets are ordered by their distance to
+  /// the executing entity (closest first).
+  /// @param friendly       if `true`, only friendly entities are targeted; otherwise only
+  /// hostile entities are targeted.
   public OtherEntityTargetingStrategy(boolean multiTarget, boolean sortByDistance, boolean friendly) {
     this(multiTarget, sortByDistance, friendly, false, false);
   }
 
-  /**
-   * Creates a new {@code OtherEntityTargetingStrategy} with full control over inclusion rules.
-   *
-   * @param multiTarget     if {@code true}, the strategy may return multiple matching targets;
-   *                        otherwise only a single target is selected.
-   * @param sortByDistance  if {@code true}, the resulting targets are ordered by their distance
-   *                        to the executing entity (closest first).
-   * @param friendly        if {@code true}, only friendly entities are targeted; otherwise only
-   *                        hostile entities are targeted.
-   * @param includeExecutor if {@code true}, the executing entity itself may be included in the
-   *                        result; otherwise it is filtered out.
-   * @param includeDead     if {@code true}, dead entities are considered valid targets;
-   *                        otherwise only living entities are selected.
-   */
+  /// Creates a new `OtherEntityTargetingStrategy` with full control over inclusion rules.
+  ///
+  /// @param multiTarget     if `true`, the strategy may return multiple matching targets;
+  /// otherwise only a single target is selected.
+  /// @param sortByDistance  if `true`, the resulting targets are ordered by their distance
+  /// to the executing entity (closest first).
+  /// @param friendly        if `true`, only friendly entities are targeted; otherwise only
+  /// hostile entities are targeted.
+  /// @param includeExecutor if `true`, the executing entity itself may be included in the
+  /// result; otherwise it is filtered out.
+  /// @param includeDead     if `true`, dead entities are considered valid targets;
+  /// otherwise only living entities are selected.
   public OtherEntityTargetingStrategy(boolean multiTarget, boolean sortByDistance, boolean friendly, boolean includeExecutor, boolean includeDead) {
     super(multiTarget, sortByDistance);
 
@@ -74,17 +65,15 @@ public class OtherEntityTargetingStrategy extends TargetingStrategy {
     this.includeDead = includeDead;
   }
 
-  /**
-   * Finds all combat entities in the current environment that intersect the given impact area and
-   * satisfy this strategy's friendly/executor/dead filters.
-   *
-   * @param impactArea the shape representing the ability's area of effect; only entities
-   *                   intersecting this area are considered.
-   * @param executor   the combat entity executing the ability; used as the reference for
-   *                   friend/foe classification and (optionally) excluded from the result.
-   * @return a collection of combat entities matching all configured filter criteria. May be
-   *         empty if no entity qualifies.
-   */
+  /// Finds all combat entities in the current environment that intersect the given impact area and
+  /// satisfy this strategy's friendly/executor/dead filters.
+  ///
+  /// @param impactArea the shape representing the ability's area of effect; only entities
+  /// intersecting this area are considered.
+  /// @param executor   the combat entity executing the ability; used as the reference for
+  /// friend/foe classification and (optionally) excluded from the result.
+  /// @return a collection of combat entities matching all configured filter criteria. May be
+  /// empty if no entity qualifies.
   @Override
   protected Collection<ICombatEntity> findTargetsInternal(Shape impactArea, ICombatEntity executor) {
     return Game.world().environment().findCombatEntities(impactArea, e ->

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/TargetingStrategy.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/abilities/targeting/TargetingStrategy.java
@@ -9,12 +9,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiPredicate;
 
-/**
- * The abstract class `TargetingStrategy` defines the logic for selecting targets
- * based on various strategies. It allows for different ways to filter, sort, and
- * select one or more targets in a game environment based on factors like distance
- * or custom conditions.
- */
+/// The abstract class `TargetingStrategy` defines the logic for selecting targets
+/// based on various strategies. It allows for different ways to filter, sort, and
+/// select one or more targets in a game environment based on factors like distance
+/// or custom conditions.
 public abstract class TargetingStrategy {
 
   private boolean multiTarget; // Determines if multiple targets can be selected
@@ -23,27 +21,23 @@ public abstract class TargetingStrategy {
 
   private Comparator<IEntity> customTargetPriorityComparator;
 
-  /**
-   * Constructor for the `TargetingStrategy` class.
-   *
-   * @param multiTarget Specifies if the strategy supports selecting multiple targets.
-   * @param sortByDistance Specifies if the strategy should prioritize targets by distance.
-   */
+  /// Constructor for the `TargetingStrategy` class.
+  ///
+  /// @param multiTarget Specifies if the strategy supports selecting multiple targets.
+  /// @param sortByDistance Specifies if the strategy should prioritize targets by distance.
   protected TargetingStrategy(boolean multiTarget, boolean sortByDistance) {
     this.multiTarget = multiTarget;
     this.prioritizeByDistance = sortByDistance;
   }
 
-  /**
-   * Finds and returns a collection of combat entities that match the target criteria
-   * defined by the strategy. This method applies internal logic for finding targets
-   * and then optionally filters and sorts them based on the additional condition and
-   * distance priority settings.
-   *
-   * @param impactArea The area where the effect or action is applied.
-   * @param executor The entity executing the action (e.g., the player or an NPC).
-   * @return A collection of `ICombatEntity` instances representing the selected targets.
-   */
+  /// Finds and returns a collection of combat entities that match the target criteria
+  /// defined by the strategy. This method applies internal logic for finding targets
+  /// and then optionally filters and sorts them based on the additional condition and
+  /// distance priority settings.
+  ///
+  /// @param impactArea The area where the effect or action is applied.
+  /// @param executor The entity executing the action (e.g., the player or an NPC).
+  /// @return A collection of `ICombatEntity` instances representing the selected targets.
   public Collection<ICombatEntity> findTargets(Shape impactArea, ICombatEntity executor) {
     var entities = findTargetsInternal(impactArea, executor);
 
@@ -79,14 +73,12 @@ public abstract class TargetingStrategy {
     return List.of(entities.stream().findFirst().get());
   }
 
-  /**
-   * Finds target entities in the impact area.
-   * This is implemented by the individual strategies.
-   *
-   * @param impactArea The area where the effect is applied.
-   * @param executor The entity executing the action.
-   * @return A collection of `ICombatEntity` instances that match the strategy criteria.
-   */
+  /// Finds target entities in the impact area.
+  /// This is implemented by the individual strategies.
+  ///
+  /// @param impactArea The area where the effect is applied.
+  /// @param executor The entity executing the action.
+  /// @return A collection of `ICombatEntity` instances that match the strategy criteria.
   protected abstract Collection<ICombatEntity> findTargetsInternal(Shape impactArea, ICombatEntity executor);
 
   public boolean isMultiTarget() {
@@ -109,78 +101,62 @@ public abstract class TargetingStrategy {
     this.customTargetPriorityComparator = customTargetPriorityComparator;
   }
 
-  /**
-   * Adds a custom condition to the targeting strategy.
-   *
-   * @param customCondition A condition that adds further filtering based on the executor and target.
-   * @return The current `TargetingStrategy` instance, allowing for method chaining.
-   */
+  /// Adds a custom condition to the targeting strategy.
+  ///
+  /// @param customCondition A condition that adds further filtering based on the executor and target.
+  /// @return The current `TargetingStrategy` instance, allowing for method chaining.
   public TargetingStrategy withCondition(BiPredicate<ICombatEntity, ICombatEntity> customCondition) {
     this.additionalCondition = customCondition;
     return this;
   }
 
-  /**
-   * Returns a strategy that targets enemy entities.
-   *
-   * @return An instance of `EnemyTargetingStrategy`.
-   */
+  /// Returns a strategy that targets enemy entities.
+  ///
+  /// @return An instance of `EnemyTargetingStrategy`.
   public static TargetingStrategy enemies() {
     return new EnemyTargetingStrategy(true, false, false);
   }
 
-  /**
-   * Returns a strategy that targets the entity executing the action.
-   *
-   * @return An instance of `ExecutingEntityTargetingStrategy`.
-   */
+  /// Returns a strategy that targets the entity executing the action.
+  ///
+  /// @return An instance of `ExecutingEntityTargetingStrategy`.
   public static TargetingStrategy executingEntity() {
     return new ExecutingEntityTargetingStrategy();
   }
 
-  /**
-   * Returns a strategy that targets friendly entities.
-   *
-   * @return An instance of `FriendlyTargetingStrategy`.
-   */
+  /// Returns a strategy that targets friendly entities.
+  ///
+  /// @return An instance of `FriendlyTargetingStrategy`.
   public static TargetingStrategy friendly() {
     return new FriendlyTargetingStrategy(true, false, false);
   }
 
-  /**
-   * Returns a strategy that targets dead friendly entities.
-   *
-   * @return An instance of `FriendlyTargetingStrategy`.
-   */
+  /// Returns a strategy that targets dead friendly entities.
+  ///
+  /// @return An instance of `FriendlyTargetingStrategy`.
   public static TargetingStrategy friendlyDead() {
     return new FriendlyTargetingStrategy(true, false, true);
   }
 
-  /**
-   * Returns a strategy that uses a custom condition to filter targets.
-   *
-   * @param customPredicate A condition to define custom logic for target selection.
-   * @return An instance of `CustomTargetingStrategy`.
-   */
+  /// Returns a strategy that uses a custom condition to filter targets.
+  ///
+  /// @param customPredicate A condition to define custom logic for target selection.
+  /// @return An instance of `CustomTargetingStrategy`.
   public static TargetingStrategy custom(BiPredicate<ICombatEntity, ICombatEntity> customPredicate) {
     return new CustomTargetingStrategy(customPredicate, true, false);
   }
 
-  /**
-   * Returns a strategy for a fixed list of target entities.
-   *
-   * @param fixedTargets An array of target entities to always include as the targets.
-   * @return An instance of `StaticTargetingStrategy` initialized with the given entities.
-   */
+  /// Returns a strategy for a fixed list of target entities.
+  ///
+  /// @param fixedTargets An array of target entities to always include as the targets.
+  /// @return An instance of `StaticTargetingStrategy` initialized with the given entities.
   public static TargetingStrategy fixed(ICombatEntity... fixedTargets) {
     return new FixedTargetingStrategy(fixedTargets);
   }
 
-  /**
-   * Returns a strategy that targets no entities.
-   *
-   * @return A `TargetingStrategy` that selects no entities.
-   */
+  /// Returns a strategy that targets no entities.
+  ///
+  /// @return A `TargetingStrategy` that selects no entities.
   public static TargetingStrategy none() {
     return custom((e, f) -> false);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/Attribute.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/Attribute.java
@@ -12,31 +12,23 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Represents an attribute with a base value and a list of modifiers. The attribute value can be modified by adding or removing modifiers.
- * <p>
- * This class is XML-serializable via JAXB. The base {@link #value} is written as an XML attribute
- * named {@code value}; runtime-only data (such as registered modifiers and property change support)
- * is marked transient and is not part of the serialized form.
- * </p>
- *
- * @param <T> the type of the attribute value, which must be a Number
- */
+/// Represents an attribute with a base value and a list of modifiers. The attribute value can be modified by adding or removing modifiers.
+///
+/// This class is XML-serializable via JAXB. The base [#value] is written as an XML attribute
+/// named `value`; runtime-only data (such as registered modifiers and property change support)
+/// is marked transient and is not part of the serialized form.
+///
+/// @param <T> the type of the attribute value, which must be a Number
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Attribute<T extends Number> implements IAttribute<T>, Serializable {
-  /**
-   * The support object used to manage and notify property change listeners. It allows other components to listen for changes to the properties of
-   * this object.
-   */
+  /// The support object used to manage and notify property change listeners. It allows other components to listen for changes to the properties of
+  /// this object.
   protected final transient PropertyChangeSupport support;
-  /**
-   * The base value of the attribute. This value represents the unmodified state of the attribute
-   * before any modifiers are applied. It is serialized as the {@code value} XML attribute.
-   * <p>
-   * Subclasses such as {@link RangeAttribute} that do not want to persist a base value can suppress
-   * serialization at runtime via JAXB {@code beforeMarshal} / {@code afterMarshal} callbacks.
-   * </p>
-   */
+  /// The base value of the attribute. This value represents the unmodified state of the attribute
+  /// before any modifiers are applied. It is serialized as the `value` XML attribute.
+  ///
+  /// Subclasses such as [RangeAttribute] that do not want to persist a base value can suppress
+  /// serialization at runtime via JAXB `beforeMarshal` / `afterMarshal` callbacks.
   @XmlAttribute(name = "value")
   @XmlJavaTypeAdapter(NumberAdapter.class)
   protected T value;
@@ -45,39 +37,31 @@ public class Attribute<T extends Number> implements IAttribute<T>, Serializable 
   private final transient List<AttributeModifier<T>> modifiers = new ArrayList<>();
 
 
-  /**
-   * Default no-argument constructor.
-   */
+  /// Default no-argument constructor.
   public Attribute() {
     this(null);
   }
 
-  /**
-   * Constructs a new Attribute with the specified initial value.
-   *
-   * @param initialValue the initial value of the attribute
-   */
+  /// Constructs a new Attribute with the specified initial value.
+  ///
+  /// @param initialValue the initial value of the attribute
   public Attribute(T initialValue) {
     this.value = initialValue;
     this.support = new PropertyChangeSupport(this);
     this.modifierListener = evt -> support.firePropertyChange(VALUE_PROPERTY, evt.getOldValue(), evt.getNewValue());
   }
 
-  /**
-   * Gets the base value of the attribute.
-   *
-   * @return the base value of the attribute
-   */
+  /// Gets the base value of the attribute.
+  ///
+  /// @return the base value of the attribute
   public T getValue() {
     return this.value;
   }
 
 
-  /**
-   * Gets the current value of the attribute, computed by applying all active modifications to the base value.
-   *
-   * @return the current value
-   */
+  /// Gets the current value of the attribute, computed by applying all active modifications to the base value.
+  ///
+  /// @return the current value
   @Override
   public T getModifiedValue() {
     T modifiedValue = value;
@@ -89,11 +73,9 @@ public class Attribute<T extends Number> implements IAttribute<T>, Serializable 
     return modifiedValue;
   }
 
-  /**
-   * Sets the base value of the attribute and fires a property change event.
-   *
-   * @param newValue the new base value of the attribute
-   */
+  /// Sets the base value of the attribute and fires a property change event.
+  ///
+  /// @param newValue the new base value of the attribute
   @Override
   public void setValue(T newValue) {
     T oldValue = getModifiedValue();
@@ -103,31 +85,25 @@ public class Attribute<T extends Number> implements IAttribute<T>, Serializable 
     support.firePropertyChange("baseValue", oldValue, newModifiedValue);
   }
 
-  /**
-   * Adds a property change listener to the attribute.
-   *
-   * @param listener the property change listener to be added
-   */
+  /// Adds a property change listener to the attribute.
+  ///
+  /// @param listener the property change listener to be added
   @Override
   public void addListener(PropertyChangeListener listener) {
     support.addPropertyChangeListener(listener);
   }
 
-  /**
-   * Removes a property change listener from the attribute.
-   *
-   * @param listener the property change listener to be removed
-   */
+  /// Removes a property change listener from the attribute.
+  ///
+  /// @param listener the property change listener to be removed
   @Override
   public void removeListener(PropertyChangeListener listener) {
     support.removePropertyChangeListener(listener);
   }
 
-  /**
-   * Adds a modifier to the attribute and fires a property change event. If the modifier is already present, it will not be added again.
-   *
-   * @param modifier the property modifier to be added
-   */
+  /// Adds a modifier to the attribute and fires a property change event. If the modifier is already present, it will not be added again.
+  ///
+  /// @param modifier the property modifier to be added
   @Override
   public void addModifier(AttributeModifier<T> modifier) {
     if (modifiers.contains(modifier)) {
@@ -141,11 +117,9 @@ public class Attribute<T extends Number> implements IAttribute<T>, Serializable 
     support.firePropertyChange(VALUE_PROPERTY, oldValue, newValue);
   }
 
-  /**
-   * Removes a modifier from the attribute and fires a property change event. If the modifier is not present, no action is taken.
-   *
-   * @param modifier the property modifier to be removed
-   */
+  /// Removes a modifier from the attribute and fires a property change event. If the modifier is not present, no action is taken.
+  ///
+  /// @param modifier the property modifier to be removed
   @Override
   public void removeModifier(AttributeModifier<T> modifier) {
     if (!modifiers.contains(modifier)) {
@@ -159,41 +133,33 @@ public class Attribute<T extends Number> implements IAttribute<T>, Serializable 
     support.firePropertyChange(VALUE_PROPERTY, oldValue, newValue);
   }
 
-  /**
-   * Gets the list of all property modifiers applied to the attribute.
-   *
-   * @return the list of property modifiers
-   */
+  /// Gets the list of all property modifiers applied to the attribute.
+  ///
+  /// @return the list of property modifiers
   public List<AttributeModifier<T>> getModifiers() {
     return modifiers;
   }
 
-  /**
-   * Modifies the current value of the attribute using the specified property modifier.
-   *
-   * @param modifier the property modifier to apply
-   */
+  /// Modifies the current value of the attribute using the specified property modifier.
+  ///
+  /// @param modifier the property modifier to apply
   @Override
   public void modify(AttributeModifier<T> modifier) {
     this.setValue(modifier.modify(this.getModifiedValue()));
   }
 
-  /**
-   * Modifies the current value of the attribute using a new property modifier created with the specified modification and value.
-   *
-   * @param modification the type of modification to apply
-   * @param value        the value to use for the modification
-   */
+  /// Modifies the current value of the attribute using a new property modifier created with the specified modification and value.
+  ///
+  /// @param modification the type of modification to apply
+  /// @param value        the value to use for the modification
   @Override
   public void modify(Modification modification, double value) {
     this.modify(new AttributeModifier<>(modification, value));
   }
 
-  /**
-   * Returns a string representation of the current value of the attribute.
-   *
-   * @return the string representation of the current value
-   */
+  /// Returns a string representation of the current value of the attribute.
+  ///
+  /// @return the string representation of the current value
   @Override
   public String toString() {
     return getModifiedValue().toString();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/AttributeModifier.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/AttributeModifier.java
@@ -3,25 +3,21 @@ package de.gurkenlabs.litiengine.attributes;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
-/**
- * The PropertyModifier class represents a modifier that can be applied to a property. It supports various types of modifications such as addition,
- * subtraction, multiplication, division, and setting a value. The class implements the Comparable interface to allow comparison based on the
- * modification's apply order.
- *
- * @param <T> the type of the number that this modifier can modify
- */
+/// The PropertyModifier class represents a modifier that can be applied to a property. It supports various types of modifications such as addition,
+/// subtraction, multiplication, division, and setting a value. The class implements the Comparable interface to allow comparison based on the
+/// modification's apply order.
+///
+/// @param <T> the type of the number that this modifier can modify
 public class AttributeModifier<T extends Number> implements Comparable<AttributeModifier<T>> {
   private final PropertyChangeSupport support;
   private final Modification modification;
   private double modifyValue;
   private boolean active;
 
-  /**
-   * Constructs a new PropertyModifier with the specified modification type and value.
-   *
-   * @param mod         the type of modification to be applied
-   * @param modifyValue the value to be used for the modification
-   */
+  /// Constructs a new PropertyModifier with the specified modification type and value.
+  ///
+  /// @param mod         the type of modification to be applied
+  /// @param modifyValue the value to be used for the modification
   public AttributeModifier(final Modification mod, final double modifyValue) {
     this.modification = mod;
     this.modifyValue = modifyValue;
@@ -29,26 +25,22 @@ public class AttributeModifier<T extends Number> implements Comparable<Attribute
     this.support = new PropertyChangeSupport(this);
   }
 
-  /**
-   * Compares this PropertyModifier with the specified PropertyModifier for order. Returns a negative integer, zero, or a positive integer as this
-   * PropertyModifier's apply order is less than, equal to, or greater than the specified PropertyModifier's apply order.
-   *
-   * @param otherModifier the PropertyModifier to be compared
-   * @return a negative integer, zero, or a positive integer as this PropertyModifier is less than, equal to, or greater than the specified
-   * PropertyModifier
-   */
+  /// Compares this PropertyModifier with the specified PropertyModifier for order. Returns a negative integer, zero, or a positive integer as this
+  /// PropertyModifier's apply order is less than, equal to, or greater than the specified PropertyModifier's apply order.
+  ///
+  /// @param otherModifier the PropertyModifier to be compared
+  /// @return a negative integer, zero, or a positive integer as this PropertyModifier is less than, equal to, or greater than the specified
+  /// PropertyModifier
   @Override
   public int compareTo(final AttributeModifier<T> otherModifier) {
     return Integer.compare(getModification().getApplyOrder(), otherModifier.getModification().getApplyOrder());
   }
 
-  /**
-   * Checks if this PropertyModifier is equal to the specified object. Two PropertyModifiers are considered equal if they have the same active state,
-   * modification type, and modification value.
-   *
-   * @param obj the object to compare with
-   * @return true if the specified object is equal to this PropertyModifier, false otherwise
-   */
+  /// Checks if this PropertyModifier is equal to the specified object. Two PropertyModifiers are considered equal if they have the same active state,
+  /// modification type, and modification value.
+  ///
+  /// @param obj the object to compare with
+  /// @return true if the specified object is equal to this PropertyModifier, false otherwise
   @Override
   public boolean equals(Object obj) {
     if (obj instanceof AttributeModifier<?> am) {
@@ -59,47 +51,37 @@ public class AttributeModifier<T extends Number> implements Comparable<Attribute
     return super.equals(obj);
   }
 
-  /**
-   * Adds a PropertyChangeListener to the listener list.
-   *
-   * @param listener the PropertyChangeListener to be added
-   */
+  /// Adds a PropertyChangeListener to the listener list.
+  ///
+  /// @param listener the PropertyChangeListener to be added
   public void addListener(PropertyChangeListener listener) {
     support.addPropertyChangeListener(listener);
   }
 
-  /**
-   * Removes a PropertyChangeListener from the listener list.
-   *
-   * @param listener the PropertyChangeListener to be removed
-   */
+  /// Removes a PropertyChangeListener from the listener list.
+  ///
+  /// @param listener the PropertyChangeListener to be removed
   public void removeListener(PropertyChangeListener listener) {
     support.removePropertyChangeListener(listener);
   }
 
-  /**
-   * Gets the type of modification to be applied.
-   *
-   * @return the modification type
-   */
+  /// Gets the type of modification to be applied.
+  ///
+  /// @return the modification type
   public Modification getModification() {
     return this.modification;
   }
 
-  /**
-   * Gets the value to be used for the modification.
-   *
-   * @return the modification value
-   */
+  /// Gets the value to be used for the modification.
+  ///
+  /// @return the modification value
   public double getModifyValue() {
     return modifyValue;
   }
 
-  /**
-   * Sets the modification value for this PropertyModifier and fires a property change event if the value changes.
-   *
-   * @param value the new modification value
-   */
+  /// Sets the modification value for this PropertyModifier and fires a property change event if the value changes.
+  ///
+  /// @param value the new modification value
   public void setModifyValue(double value) {
     double oldValue = this.modifyValue;
     this.modifyValue = value;
@@ -109,20 +91,16 @@ public class AttributeModifier<T extends Number> implements Comparable<Attribute
     }
   }
 
-  /**
-   * Checks if this PropertyModifier is currently active.
-   *
-   * @return true if this PropertyModifier is active, false otherwise
-   */
+  /// Checks if this PropertyModifier is currently active.
+  ///
+  /// @return true if this PropertyModifier is active, false otherwise
   public boolean isActive() {
     return active;
   }
 
-  /**
-   * Sets the active state of this PropertyModifier and fires a property change event if the state changes.
-   *
-   * @param active the new active state
-   */
+  /// Sets the active state of this PropertyModifier and fires a property change event if the state changes.
+  ///
+  /// @param active the new active state
   public void setActive(boolean active) {
     boolean oldActive = this.active;
     this.active = active;
@@ -132,13 +110,11 @@ public class AttributeModifier<T extends Number> implements Comparable<Attribute
     }
   }
 
-  /**
-   * Modifies the given value based on the modification type and value of this PropertyModifier. If the PropertyModifier is not active, the original
-   * value is returned.
-   *
-   * @param modValue the value to be modified
-   * @return the modified value
-   */
+  /// Modifies the given value based on the modification type and value of this PropertyModifier. If the PropertyModifier is not active, the original
+  /// value is returned.
+  ///
+  /// @param modValue the value to be modified
+  /// @return the modified value
   public T modify(final T modValue) {
     if (!this.isActive()) {
       return modValue;
@@ -154,13 +130,11 @@ public class AttributeModifier<T extends Number> implements Comparable<Attribute
     };
   }
 
-  /**
-   * Ensures that the modified value is of the same type as the original value.
-   *
-   * @param modValue      the modified value as a Double
-   * @param originalValue the original value to determine the type
-   * @return the modified value cast to the type of the original value, or null if the type is not supported
-   */
+  /// Ensures that the modified value is of the same type as the original value.
+  ///
+  /// @param modValue      the modified value as a Double
+  /// @param originalValue the original value to determine the type
+  /// @return the modified value cast to the type of the original value, or null if the type is not supported
   @SuppressWarnings("unchecked")
   private T ensureType(final Double modValue, final T originalValue) {
     if (originalValue instanceof Double) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/IAttribute.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/IAttribute.java
@@ -2,74 +2,54 @@ package de.gurkenlabs.litiengine.attributes;
 
 import java.beans.PropertyChangeListener;
 
-/**
- * Interface representing an observable property that holds a numeric value. It provides methods to get and set the value, add and remove listeners,
- * and add and remove modifiers.
- *
- * @param <T> the type of the numeric value
- */
+/// Interface representing an observable property that holds a numeric value. It provides methods to get and set the value, add and remove listeners,
+/// and add and remove modifiers.
+///
+/// @param <T> the type of the numeric value
 public interface IAttribute<T extends Number> {
-  /**
-   * Gets the base value of the attribute.
-   *
-   * @return the base value of the attribute
-   */
+  /// Gets the base value of the attribute.
+  ///
+  /// @return the base value of the attribute
   T getValue();
 
-  /**
-   * Gets the current value of the attribute, including any modifications.
-   *
-   * @return the current value
-   */
+  /// Gets the current value of the attribute, including any modifications.
+  ///
+  /// @return the current value
   T getModifiedValue();
 
-  /**
-   * Sets a new value for this property.
-   *
-   * @param newValue the new value to set
-   */
+  /// Sets a new value for this property.
+  ///
+  /// @param newValue the new value to set
   void setValue(T newValue);
 
-  /**
-   * Adds a PropertyChangeListener to the listener list.
-   *
-   * @param listener the PropertyChangeListener to be added
-   */
+  /// Adds a PropertyChangeListener to the listener list.
+  ///
+  /// @param listener the PropertyChangeListener to be added
   void addListener(PropertyChangeListener listener);
 
-  /**
-   * Removes a PropertyChangeListener from the listener list.
-   *
-   * @param listener the PropertyChangeListener to be removed
-   */
+  /// Removes a PropertyChangeListener from the listener list.
+  ///
+  /// @param listener the PropertyChangeListener to be removed
   void removeListener(PropertyChangeListener listener);
 
-  /**
-   * Adds a PropertyModifier to this property.
-   *
-   * @param modifier the PropertyModifier to be added
-   */
+  /// Adds a PropertyModifier to this property.
+  ///
+  /// @param modifier the PropertyModifier to be added
   void addModifier(AttributeModifier<T> modifier);
 
-  /**
-   * Removes a PropertyModifier from this property.
-   *
-   * @param modifier the PropertyModifier to be removed
-   */
+  /// Removes a PropertyModifier from this property.
+  ///
+  /// @param modifier the PropertyModifier to be removed
   void removeModifier(AttributeModifier<T> modifier);
 
-  /**
-   * Modifies the value of this property using the specified PropertyModifier.
-   *
-   * @param modifier the PropertyModifier to apply
-   */
+  /// Modifies the value of this property using the specified PropertyModifier.
+  ///
+  /// @param modifier the PropertyModifier to apply
   void modify(AttributeModifier<T> modifier);
 
-  /**
-   * Modifies the value of this property using the specified modification type and value.
-   *
-   * @param modification the type of modification to apply
-   * @param value        the value to use for the modification
-   */
+  /// Modifies the value of this property using the specified modification type and value.
+  ///
+  /// @param modification the type of modification to apply
+  /// @param value        the value to use for the modification
   void modify(Modification modification, double value);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/Modification.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/Modification.java
@@ -1,8 +1,6 @@
 package de.gurkenlabs.litiengine.attributes;
 
-/**
- * Represents the types of modifications that can be applied. Each modification type has an associated apply order.
- */
+/// Represents the types of modifications that can be applied. Each modification type has an associated apply order.
 public enum Modification {
   ADD(1),
   DIVIDE(4),
@@ -17,11 +15,9 @@ public enum Modification {
     this.applyOrder = order;
   }
 
-  /**
-   * Gets the apply order of this modification type.
-   *
-   * @return the apply order
-   */
+  /// Gets the apply order of this modification type.
+  ///
+  /// @return the apply order
   public int getApplyOrder() {
     return this.applyOrder;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/RangeAttribute.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/attributes/RangeAttribute.java
@@ -13,17 +13,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Represents an attribute with a defined range, extending the base Attribute class. The attribute value is constrained between a minimum and maximum
- * value.
- * <p>
- * This class is XML-serializable via JAXB. The base value, {@link #getMin() min} and
- * {@link #getMax() max} are persisted as XML attributes; modifiers and property change support
- * are runtime-only state and are not serialized.
- * </p>
- *
- * @param <T> the type of the attribute value, which must be a Number and Comparable
- */
+/// Represents an attribute with a defined range, extending the base Attribute class. The attribute value is constrained between a minimum and maximum
+/// value.
+///
+/// This class is XML-serializable via JAXB. The base value, [min][#getMin()] and
+/// [max][#getMax()] are persisted as XML attributes; modifiers and property change support
+/// are runtime-only state and are not serialized.
+///
+/// @param <T> the type of the attribute value, which must be a Number and Comparable
 @XmlAccessorType(XmlAccessType.FIELD)
 public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<T> implements Serializable {
   private static final String MIN_PROPERTY = "min";
@@ -50,15 +47,13 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     this.maxModifierListener = evt -> maxSupport.firePropertyChange(MAX_PROPERTY, evt.getOldValue(), evt.getNewValue());
   }
 
-  /**
-   * Constructs a new RangeAttribute with the specified initial value, minimum value, and maximum value. Ensures that the minimum value is not greater
-   * than the maximum value.
-   *
-   * @param initialValue the initial value of the attribute
-   * @param min          the minimum value of the attribute
-   * @param max          the maximum value of the attribute
-   * @throws IllegalArgumentException if the minimum value is greater than the maximum value
-   */
+  /// Constructs a new RangeAttribute with the specified initial value, minimum value, and maximum value. Ensures that the minimum value is not greater
+  /// than the maximum value.
+  ///
+  /// @param initialValue the initial value of the attribute
+  /// @param min          the minimum value of the attribute
+  /// @param max          the maximum value of the attribute
+  /// @throws IllegalArgumentException if the minimum value is greater than the maximum value
   public RangeAttribute(T initialValue, T min, T max) {
     super(initialValue);
     if (min.compareTo(max) > 0) {
@@ -72,65 +67,54 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     this.maxModifierListener = evt -> maxSupport.firePropertyChange(MAX_PROPERTY, evt.getOldValue(), evt.getNewValue());
   }
 
-  /**
-   * Constructs a new {@code RangeAttribute} with the specified minimum and maximum values, using
-   * {@code min} as the initial base value.
-   *
-   * @param min the minimum value of the attribute
-   * @param max the maximum value of the attribute
-   * @throws IllegalArgumentException if the minimum value is greater than the maximum value
-   */
+  /// Constructs a new `RangeAttribute` with the specified minimum and maximum values, using
+  /// `min` as the initial base value.
+  ///
+  /// @param min the minimum value of the attribute
+  /// @param max the maximum value of the attribute
+  /// @throws IllegalArgumentException if the minimum value is greater than the maximum value
   public RangeAttribute(T min, T max) {
     this(min, min, max);
   }
 
-  /**
-   * Gets the current value of the attribute, ensuring it is within the defined range.
-   *
-   * @return the current value of the attribute
-   */
+  /// Gets the current value of the attribute, ensuring it is within the defined range.
+  ///
+  /// @return the current value of the attribute
   @Override public T getModifiedValue() {
     return enforceRangeForValue(super.getModifiedValue());
   }
 
-  /**
-   * {@inheritDoc}
-   * <p>
-   * The base value is intentionally <em>not</em> serialized for a {@code RangeAttribute}. Range
-   * attributes describe a value range via {@link #getMin() min} and {@link #getMax() max} (for
-   * example particle emitter parameters); persisting a single base value alongside the range is
-   * not meaningful, since consumers such as the particle system always draw a fresh random sample
-   * between {@code min} and {@code max} (see {@link #getRandomNumber()}). Suppression of the
-   * inherited {@code value} XML attribute is implemented via the JAXB
-   * {@code beforeMarshal} / {@code afterMarshal} callbacks below.
-   * </p>
-   */
+  /// {@inheritDoc}
+  ///
+  /// The base value is intentionally *not* serialized for a `RangeAttribute`. Range
+  /// attributes describe a value range via [min][#getMin()] and [max][#getMax()] (for
+  /// example particle emitter parameters); persisting a single base value alongside the range is
+  /// not meaningful, since consumers such as the particle system always draw a fresh random sample
+  /// between `min` and `max` (see [#getRandomNumber()]). Suppression of the
+  /// inherited `value` XML attribute is implemented via the JAXB
+  /// `beforeMarshal` / `afterMarshal` callbacks below.
   @Override public T getValue() {
     return super.getValue();
   }
 
-  /**
-   * JAXB callback invoked immediately before this instance is marshalled. Clears the inherited
-   * {@link #value} so that it is not written to XML, and stashes it so it can be restored in
-   * {@link #afterMarshal(jakarta.xml.bind.Marshaller)}. This keeps runtime behavior of
-   * {@link #getValue()} unchanged while ensuring the serialized form only contains
-   * {@link #getMin() min} and {@link #getMax() max}.
-   *
-   * @param marshaller the JAXB marshaller invoking this callback (unused)
-   */
+  /// JAXB callback invoked immediately before this instance is marshalled. Clears the inherited
+  /// [#value] so that it is not written to XML, and stashes it so it can be restored in
+  /// [#afterMarshal(jakarta.xml.bind.Marshaller)]. This keeps runtime behavior of
+  /// [#getValue()] unchanged while ensuring the serialized form only contains
+  /// [min][#getMin()] and [max][#getMax()].
+  ///
+  /// @param marshaller the JAXB marshaller invoking this callback (unused)
   @SuppressWarnings("unused")
   private void beforeMarshal(jakarta.xml.bind.Marshaller marshaller) {
     this.suppressedValue = this.value;
     this.value = null;
   }
 
-  /**
-   * JAXB callback invoked immediately after this instance is marshalled. Restores the base
-   * {@link #value} that was temporarily cleared by
-   * {@link #beforeMarshal(jakarta.xml.bind.Marshaller)}.
-   *
-   * @param marshaller the JAXB marshaller invoking this callback (unused)
-   */
+  /// JAXB callback invoked immediately after this instance is marshalled. Restores the base
+  /// [#value] that was temporarily cleared by
+  /// [#beforeMarshal(jakarta.xml.bind.Marshaller)].
+  ///
+  /// @param marshaller the JAXB marshaller invoking this callback (unused)
   @SuppressWarnings("unused")
   private void afterMarshal(jakarta.xml.bind.Marshaller marshaller) {
     this.value = this.suppressedValue;
@@ -139,20 +123,16 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
 
   private transient T suppressedValue;
 
-  /**
-   * Gets the base minimum value of the attribute.
-   *
-   * @return the minimum value of the attribute
-   */
+  /// Gets the base minimum value of the attribute.
+  ///
+  /// @return the minimum value of the attribute
   public T getMin() {
     return min;
   }
 
-  /**
-   * Computes the modified minimum value by applying all active modifiers to the base minimum value.
-   *
-   * @return the computed modified minimum value
-   */
+  /// Computes the modified minimum value by applying all active modifiers to the base minimum value.
+  ///
+  /// @return the computed modified minimum value
   public T getModifiedMin() {
     T modifiedMin = min;
     for (AttributeModifier<T> modifier : getMinModifiers()) {
@@ -163,11 +143,9 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     return modifiedMin;
   }
 
-  /**
-   * Sets the minimum value of the attribute and notifies listeners of the change.
-   *
-   * @param min the new minimum value
-   */
+  /// Sets the minimum value of the attribute and notifies listeners of the change.
+  ///
+  /// @param min the new minimum value
   public void setMin(T min) {
     T oldMin = this.min;
     this.min = min;
@@ -175,20 +153,16 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     minSupport.firePropertyChange("min", oldMin, min);
   }
 
-  /**
-   * Gets the base maximum value of the attribute.
-   *
-   * @return the maximum value of the attribute
-   */
+  /// Gets the base maximum value of the attribute.
+  ///
+  /// @return the maximum value of the attribute
   public T getMax() {
     return max;
   }
 
-  /**
-   * Computes the modified maximum value by applying all active modifiers to the base maximum value.
-   *
-   * @return the computed modified maximum value
-   */
+  /// Computes the modified maximum value by applying all active modifiers to the base maximum value.
+  ///
+  /// @return the computed modified maximum value
   public T getModifiedMax() {
     T modifiedMax = max;
     for (AttributeModifier<T> modifier : getMaxModifiers()) {
@@ -199,11 +173,9 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     return modifiedMax;
   }
 
-  /**
-   * Sets the maximum value of the attribute and notifies listeners of the change.
-   *
-   * @param max the new maximum value
-   */
+  /// Sets the maximum value of the attribute and notifies listeners of the change.
+  ///
+  /// @param max the new maximum value
   public void setMax(T max) {
     T oldMax = this.max;
     this.max = max;
@@ -211,65 +183,51 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     maxSupport.firePropertyChange("max", oldMax, max);
   }
 
-  /**
-   * Adds a PropertyChangeListener for the minimum value.
-   *
-   * @param listener the listener to be added
-   */
+  /// Adds a PropertyChangeListener for the minimum value.
+  ///
+  /// @param listener the listener to be added
   public void addMinListener(PropertyChangeListener listener) {
     minSupport.addPropertyChangeListener(listener);
   }
 
-  /**
-   * Removes a PropertyChangeListener for the minimum value.
-   *
-   * @param listener the listener to be removed
-   */
+  /// Removes a PropertyChangeListener for the minimum value.
+  ///
+  /// @param listener the listener to be removed
   public void removeMinListener(PropertyChangeListener listener) {
     minSupport.removePropertyChangeListener(listener);
   }
 
-  /**
-   * Adds a PropertyChangeListener for the maximum value.
-   *
-   * @param listener the listener to be added
-   */
+  /// Adds a PropertyChangeListener for the maximum value.
+  ///
+  /// @param listener the listener to be added
   public void addMaxListener(PropertyChangeListener listener) {
     maxSupport.addPropertyChangeListener(listener);
   }
 
-  /**
-   * Removes a PropertyChangeListener for the maximum value.
-   *
-   * @param listener the listener to be removed
-   */
+  /// Removes a PropertyChangeListener for the maximum value.
+  ///
+  /// @param listener the listener to be removed
   public void removeMaxListener(PropertyChangeListener listener) {
     maxSupport.removePropertyChangeListener(listener);
   }
 
-  /**
-   * Gets the list of minimum value modifiers.
-   *
-   * @return the list of minimum value modifiers
-   */
+  /// Gets the list of minimum value modifiers.
+  ///
+  /// @return the list of minimum value modifiers
   public List<AttributeModifier<T>> getMinModifiers() {
     return minModifiers;
   }
 
-  /**
-   * Gets the list of maximum value modifiers.
-   *
-   * @return the list of maximum value modifiers
-   */
+  /// Gets the list of maximum value modifiers.
+  ///
+  /// @return the list of maximum value modifiers
   public List<AttributeModifier<T>> getMaxModifiers() {
     return maxModifiers;
   }
 
-  /**
-   * Adds a modifier to the list of minimum value modifiers and notifies listeners of the change.
-   *
-   * @param modifier the modifier to add
-   */
+  /// Adds a modifier to the list of minimum value modifiers and notifies listeners of the change.
+  ///
+  /// @param modifier the modifier to add
   public void addMinModifier(AttributeModifier<T> modifier) {
     if (getMinModifiers().contains(modifier)) {
       return;
@@ -282,11 +240,9 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     minSupport.firePropertyChange(MIN_PROPERTY, oldMin, newMin);
   }
 
-  /**
-   * Removes a modifier from the list of minimum value modifiers and notifies listeners of the change.
-   *
-   * @param modifier the modifier to remove
-   */
+  /// Removes a modifier from the list of minimum value modifiers and notifies listeners of the change.
+  ///
+  /// @param modifier the modifier to remove
   public void removeMinModifier(AttributeModifier<T> modifier) {
     if (!getMinModifiers().contains(modifier)) {
       return;
@@ -299,11 +255,9 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     minSupport.firePropertyChange(MIN_PROPERTY, oldMin, newMin);
   }
 
-  /**
-   * Adds a modifier to the list of maximum value modifiers and notifies listeners of the change.
-   *
-   * @param modifier the modifier to add
-   */
+  /// Adds a modifier to the list of maximum value modifiers and notifies listeners of the change.
+  ///
+  /// @param modifier the modifier to add
   public void addMaxModifier(AttributeModifier<T> modifier) {
     if (getMaxModifiers().contains(modifier)) {
       return;
@@ -316,11 +270,9 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     maxSupport.firePropertyChange(MAX_PROPERTY, oldMax, newMax);
   }
 
-  /**
-   * Removes a modifier from the list of maximum value modifiers and notifies listeners of the change.
-   *
-   * @param modifier the modifier to remove
-   */
+  /// Removes a modifier from the list of maximum value modifiers and notifies listeners of the change.
+  ///
+  /// @param modifier the modifier to remove
   public void removeMaxModifier(AttributeModifier<T> modifier) {
     if (!getMaxModifiers().contains(modifier)) {
       return;
@@ -333,27 +285,22 @@ public class RangeAttribute<T extends Number & Comparable<T>> extends Attribute<
     maxSupport.firePropertyChange(MAX_PROPERTY, oldMax, newMax);
   }
 
-  /**
-   * Gets the ratio of the current value to the maximum value as a float. This is calculated as the current value divided by the maximum value.
-   *
-   * @return The ratio of the current value to the maximum value.
-   */
+  /// Gets the ratio of the current value to the maximum value as a float. This is calculated as the current value divided by the maximum value.
+  ///
+  /// @return The ratio of the current value to the maximum value.
   public float getRatio() {
     return getModifiedValue().floatValue() / getModifiedMax().floatValue();
   }
 
-  /**
-   * Returns a uniformly distributed pseudo-random number between this attribute's modified minimum
-   * and modified maximum values.
-   * <p>
-   * This is intended for use-cases that need to draw a random sample from a configured range (e.g.
-   * particle parameters used by an emitter). If {@code modifiedMin >= modifiedMax}, the modified
-   * minimum is returned.
-   * </p>
-   *
-   * @return a {@link Number} between {@link #getModifiedMin()} (inclusive) and
-   * {@link #getModifiedMax()} (exclusive), or {@link #getModifiedMin()} if the range is empty
-   */
+  /// Returns a uniformly distributed pseudo-random number between this attribute's modified minimum
+  /// and modified maximum values.
+  ///
+  /// This is intended for use-cases that need to draw a random sample from a configured range (e.g.
+  /// particle parameters used by an emitter). If `modifiedMin >= modifiedMax`, the modified
+  /// minimum is returned.
+  ///
+  /// @return a [Number] between [#getModifiedMin()] (inclusive) and
+  /// [#getModifiedMax()] (exclusive), or [#getModifiedMin()] if the range is empty
   public Number getRandomNumber() {
     final T modMin = getModifiedMin();
     final T modMax = getModifiedMax();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/CleanProperties.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/CleanProperties.java
@@ -9,56 +9,44 @@ import java.util.Enumeration;
 import java.util.Properties;
 import java.util.TreeSet;
 
-/**
- * A custom implementation of the Properties class that sorts the keys and strips the first line of comments when storing.
- */
+/// A custom implementation of the Properties class that sorts the keys and strips the first line of comments when storing.
 class CleanProperties extends Properties {
   @Serial private static final long serialVersionUID = 7567765340218227372L;
 
-  /**
-   * Returns an enumeration of the keys in this property list, sorted in ascending order.
-   *
-   * @return an enumeration of the keys in this property list.
-   */
+  /// Returns an enumeration of the keys in this property list, sorted in ascending order.
+  ///
+  /// @return an enumeration of the keys in this property list.
   @Override
   public synchronized Enumeration<Object> keys() {
     return Collections.enumeration(new TreeSet<>(super.keySet()));
   }
 
-  /**
-   * Writes this property list (key and element pairs) in this Properties table to the output stream in a format suitable for loading into a
-   * Properties table using the load method. This implementation strips the first line of comments.
-   *
-   * @param out      an output stream.
-   * @param comments a description of the property list.
-   * @throws IOException if an I/O error occurs.
-   */
+  /// Writes this property list (key and element pairs) in this Properties table to the output stream in a format suitable for loading into a
+  /// Properties table using the load method. This implementation strips the first line of comments.
+  ///
+  /// @param out      an output stream.
+  /// @param comments a description of the property list.
+  /// @throws IOException if an I/O error occurs.
   @Override
   public void store(final OutputStream out, final String comments) throws IOException {
     super.store(new StripFirstLineStream(out), null);
   }
 
-  /**
-   * A custom FilterOutputStream that strips the first line of output.
-   */
+  /// A custom FilterOutputStream that strips the first line of output.
   private static class StripFirstLineStream extends FilterOutputStream {
     private boolean firstlineseen = false;
 
-    /**
-     * Constructs a new StripFirstLineStream.
-     *
-     * @param out the underlying output stream.
-     */
+    /// Constructs a new StripFirstLineStream.
+    ///
+    /// @param out the underlying output stream.
     public StripFirstLineStream(final OutputStream out) {
       super(out);
     }
 
-    /**
-     * Writes the specified byte to this output stream. This implementation skips the first line.
-     *
-     * @param b the byte to be written.
-     * @throws IOException if an I/O error occurs.
-     */
+    /// Writes the specified byte to this output stream. This implementation skips the first line.
+    ///
+    /// @param b the byte to be written.
+    /// @throws IOException if an I/O error occurs.
     @Override
     public void write(final int b) throws IOException {
       if (firstlineseen) {
@@ -68,14 +56,12 @@ class CleanProperties extends Properties {
       }
     }
 
-    /**
-     * Writes len bytes from the specified byte array starting at offset off to this output stream. This implementation skips the first line.
-     *
-     * @param b   the data.
-     * @param off the start offset in the data.
-     * @param len the number of bytes to write.
-     * @throws IOException if an I/O error occurs.
-     */
+    /// Writes len bytes from the specified byte array starting at offset off to this output stream. This implementation skips the first line.
+    ///
+    /// @param b   the data.
+    /// @param off the start offset in the data.
+    /// @param len the number of bytes to write.
+    /// @throws IOException if an I/O error occurs.
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
       while (!firstlineseen) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/ClientConfiguration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/ClientConfiguration.java
@@ -2,9 +2,7 @@ package de.gurkenlabs.litiengine.configuration;
 
 import java.util.Locale;
 
-/**
- * The client configuration contains client specific configuration elements.
- */
+/// The client configuration contains client specific configuration elements.
 @ConfigurationGroupInfo(prefix = "cl_")
 public class ClientConfiguration extends ConfigurationGroup {
 
@@ -18,9 +16,7 @@ public class ClientConfiguration extends ConfigurationGroup {
 
   private boolean exitOnError;
 
-  /**
-   * Constructs a new ClientConfiguration with default settings.
-   */
+  /// Constructs a new ClientConfiguration with default settings.
   ClientConfiguration() {
     super();
     this.setMaxFps(60);
@@ -31,29 +27,23 @@ public class ClientConfiguration extends ConfigurationGroup {
     this.setCountry(Locale.getDefault().getCountry());
   }
 
-  /**
-   * Gets the country code.
-   *
-   * @return the country code.
-   */
+  /// Gets the country code.
+  ///
+  /// @return the country code.
   public String getCountry() {
     return this.country;
   }
 
-  /**
-   * Gets the language code.
-   *
-   * @return the language code.
-   */
+  /// Gets the language code.
+  ///
+  /// @return the language code.
   public String getLanguage() {
     return this.language;
   }
 
-  /**
-   * Gets the locale based on the language and country codes.
-   *
-   * @return the locale.
-   */
+  /// Gets the locale based on the language and country codes.
+  ///
+  /// @return the locale.
   public Locale getLocale() {
     if (this.getCountry() == null || this.getCountry().isEmpty()) {
       return Locale.of(this.getLanguage());
@@ -61,74 +51,58 @@ public class ClientConfiguration extends ConfigurationGroup {
     return Locale.of(this.getLanguage(), this.getCountry());
   }
 
-  /**
-   * Gets the maximum frames per second.
-   *
-   * @return the maximum frames per second.
-   */
+  /// Gets the maximum frames per second.
+  ///
+  /// @return the maximum frames per second.
   public int getMaxFps() {
     return this.maxFps;
   }
 
-  /**
-   * Sets the country code.
-   *
-   * @param country the country code to set.
-   */
+  /// Sets the country code.
+  ///
+  /// @param country the country code to set.
   public void setCountry(final String country) {
     this.set("country", country);
   }
 
-  /**
-   * Sets the language code.
-   *
-   * @param language the language code to set.
-   */
+  /// Sets the language code.
+  ///
+  /// @param language the language code to set.
   public void setLanguage(final String language) {
     this.set("language", language);
   }
 
-  /**
-   * Sets the maximum frames per second.
-   *
-   * @param maxFps the maximum frames per second to set.
-   */
+  /// Sets the maximum frames per second.
+  ///
+  /// @param maxFps the maximum frames per second to set.
   public void setMaxFps(final int maxFps) {
     this.set("maxFps", Math.max(1, maxFps));
   }
 
-  /**
-   * Sets whether to show game metrics.
-   *
-   * @param showGameMetrics true to show game metrics, false to hide.
-   */
+  /// Sets whether to show game metrics.
+  ///
+  /// @param showGameMetrics true to show game metrics, false to hide.
   public void setShowGameMetrics(final boolean showGameMetrics) {
     this.set("showGameMetrics", showGameMetrics);
   }
 
-  /**
-   * Sets whether to exit on error.
-   *
-   * @param exit true to exit on error, false to continue.
-   */
+  /// Sets whether to exit on error.
+  ///
+  /// @param exit true to exit on error, false to continue.
   public void setExitOnError(boolean exit) {
     this.set("exitOnError", exit);
   }
 
-  /**
-   * Checks if game metrics are shown.
-   *
-   * @return true if game metrics are shown, false otherwise.
-   */
+  /// Checks if game metrics are shown.
+  ///
+  /// @return true if game metrics are shown, false otherwise.
   public boolean showGameMetrics() {
     return this.showGameMetrics;
   }
 
-  /**
-   * Checks if the application exits on error.
-   *
-   * @return true if the application exits on error, false otherwise.
-   */
+  /// Checks if the application exits on error.
+  ///
+  /// @return true if the application exits on error, false otherwise.
   public boolean exitOnError() {
     return this.exitOnError;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Configuration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Configuration.java
@@ -16,9 +16,7 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Configuration class that manages multiple configuration groups and handles loading and saving settings.
- */
+/// Configuration class that manages multiple configuration groups and handles loading and saving settings.
 public class Configuration {
   private static final Logger log = Logger.getLogger(Configuration.class.getName());
   private static final String DEFAULT_CONFIGURATION_FILE_NAME = "config.properties";
@@ -26,32 +24,26 @@ public class Configuration {
   private final List<ConfigurationGroup> configurationGroups;
   private final Path path;
 
-  /**
-   * Initializes a new instance of the {@code Configuration} class.
-   *
-   * @param configurationGroups The configuration groups managed by this instance.
-   */
+  /// Initializes a new instance of the `Configuration` class.
+  ///
+  /// @param configurationGroups The configuration groups managed by this instance.
   public Configuration(final ConfigurationGroup... configurationGroups) {
     this(DEFAULT_CONFIGURATION_FILE_NAME, configurationGroups);
   }
 
-  /**
-   * Constructs a new instance of the {@code Configuration} class using the specified file name. This constructor converts the provided file name
-   * string into a {@code Path} object and delegates the initialization to another constructor.
-   *
-   * @param path                The path of the file from which to load the settings.
-   * @param configurationGroups The configuration groups managed by this instance.
-   */
+  /// Constructs a new instance of the `Configuration` class using the specified file name. This constructor converts the provided file name
+  /// string into a `Path` object and delegates the initialization to another constructor.
+  ///
+  /// @param path                The path of the file from which to load the settings.
+  /// @param configurationGroups The configuration groups managed by this instance.
   public Configuration(final String path, final ConfigurationGroup... configurationGroups) {
     this(Path.of(path), configurationGroups);
   }
 
-  /**
-   * Initializes a new instance of the {@code Configuration} class.
-   *
-   * @param path                The path of the file from which to load the settings.
-   * @param configurationGroups The configuration groups managed by this instance.
-   */
+  /// Initializes a new instance of the `Configuration` class.
+  ///
+  /// @param path                The path of the file from which to load the settings.
+  /// @param configurationGroups The configuration groups managed by this instance.
   public Configuration(final Path path, final ConfigurationGroup... configurationGroups) {
     this.path = path;
     this.configurationGroups = new ArrayList<>();
@@ -60,13 +52,11 @@ public class Configuration {
     }
   }
 
-  /**
-   * Gets the strongly typed configuration group if it was previously added to the configuration.
-   *
-   * @param <T>        The type of the config group.
-   * @param groupClass The class that provides the generic type for this method.
-   * @return The configuration group of the specified type or null if none can be found.
-   */
+  /// Gets the strongly typed configuration group if it was previously added to the configuration.
+  ///
+  /// @param <T>        The type of the config group.
+  /// @param groupClass The class that provides the generic type for this method.
+  /// @return The configuration group of the specified type or null if none can be found.
   public <T extends ConfigurationGroup> T getConfigurationGroup(final Class<T> groupClass) {
     for (final ConfigurationGroup group : getConfigurationGroups()) {
       if (group.getClass().equals(groupClass)) {
@@ -77,12 +67,10 @@ public class Configuration {
     return null;
   }
 
-  /**
-   * Gets the configuration group with the specified prefix.
-   *
-   * @param prefix The prefix of the configuration group to retrieve.
-   * @return The configuration group with the specified prefix, or null if none can be found.
-   */
+  /// Gets the configuration group with the specified prefix.
+  ///
+  /// @param prefix The prefix of the configuration group to retrieve.
+  /// @return The configuration group with the specified prefix, or null if none can be found.
   public ConfigurationGroup getConfigurationGroup(final String prefix) {
     for (final ConfigurationGroup group : getConfigurationGroups()) {
 
@@ -99,38 +87,30 @@ public class Configuration {
     return null;
   }
 
-  /**
-   * Gets all {@code ConfigurationGroups} from the configuration.
-   *
-   * @return All config groups.
-   */
+  /// Gets all `ConfigurationGroups` from the configuration.
+  ///
+  /// @return All config groups.
   public List<ConfigurationGroup> getConfigurationGroups() {
     return this.configurationGroups;
   }
 
-  /**
-   * Adds the specified configuration group to the configuration.
-   *
-   * @param group The group to add.
-   */
+  /// Adds the specified configuration group to the configuration.
+  ///
+  /// @param group The group to add.
   public void add(ConfigurationGroup group) {
     getConfigurationGroups().add(group);
   }
 
-  /**
-   * Gets the path of the file to which this configuration is saved.
-   *
-   * @return The path of the configuration file.
-   * @see #save()
-   */
+  /// Gets the path of the file to which this configuration is saved.
+  ///
+  /// @return The path of the configuration file.
+  /// @see #save()
   public Path getPath() {
     return this.path;
   }
 
-  /**
-   * Tries to load the configuration from file in the application folder. If none exists, it tries to load the file from any resource folder. If none
-   * exists, it creates a new configuration file in the application folder.
-   */
+  /// Tries to load the configuration from file in the application folder. If none exists, it tries to load the file from any resource folder. If none
+  /// exists, it creates a new configuration file in the application folder.
   public void load() {
     try (InputStream settingsStream = Resources.get(getPath().toString())) {
       if (!Files.exists(getPath()) || !Files.isRegularFile(getPath()) || settingsStream == null) {
@@ -158,12 +138,10 @@ public class Configuration {
     }
   }
 
-  /**
-   * Saves this configuration to a file with the specified name of this instance (config.properties is the engines default config file).
-   *
-   * @see #getPath()
-   * @see Configuration#DEFAULT_CONFIGURATION_FILE_NAME
-   */
+  /// Saves this configuration to a file with the specified name of this instance (config.properties is the engines default config file).
+  ///
+  /// @see #getPath()
+  /// @see Configuration#DEFAULT_CONFIGURATION_FILE_NAME
   public void save() {
     try {
       Files.deleteIfExists(getPath());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/ConfigurationGroup.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/ConfigurationGroup.java
@@ -12,10 +12,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * This class contains some basic functionality for all setting groups. It gets the SettingsGroupInfo annotation and reads out the prefix that is used
- * when reading/ writing the settings into a property file.
- */
+/// This class contains some basic functionality for all setting groups. It gets the SettingsGroupInfo annotation and reads out the prefix that is used
+/// when reading/ writing the settings into a property file.
 @ConfigurationGroupInfo
 public abstract class ConfigurationGroup {
   private static final Logger log = Logger.getLogger(ConfigurationGroup.class.getName());
@@ -25,86 +23,66 @@ public abstract class ConfigurationGroup {
   private final String prefix;
   private boolean debug;
 
-  /**
-   * Initializes a new instance of the {@code ConfigurationGroup} class.
-   */
+  /// Initializes a new instance of the `ConfigurationGroup` class.
   protected ConfigurationGroup() {
     final ConfigurationGroupInfo info = this.getClass().getAnnotation(ConfigurationGroupInfo.class);
     this.prefix = info.prefix();
     this.debug = info.debug();
   }
 
-  /**
-   * Adds the specified configuration changed listener to receive events about any configuration property that changed.
-   *
-   * <p>
-   * The event is supported for any property that uses the {@link #set(String, Object)} method to set the field value.
-   * </p>
-   *
-   * <p>
-   * The event will provide you with the fieldName of the called setter (e.g. "debug" for the "setDebug" call).
-   * </p>
-   *
-   * @param listener The listener to add.
-   * @see ConfigurationGroup#set(String, Object)
-   */
+  /// Adds the specified configuration changed listener to receive events about any configuration property that changed.
+  ///
+  /// The event is supported for any property that uses the [Object)][#set(String,] method to set the field value.
+  ///
+  /// The event will provide you with the fieldName of the called setter (e.g. "debug" for the "setDebug" call).
+  ///
+  /// @param listener The listener to add.
+  /// @see ConfigurationGroup#set(String, Object)
   public void onChanged(ConfigurationChangedListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes the specified configuration changed listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified configuration changed listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeListener(ConfigurationChangedListener listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Gets the prefix for the configuration group.
-   *
-   * @return The prefix for the configuration group, or an empty string if the prefix is null.
-   */
+  /// Gets the prefix for the configuration group.
+  ///
+  /// @return The prefix for the configuration group, or an empty string if the prefix is null.
   public String getPrefix() {
     return this.prefix != null ? this.prefix : "";
   }
 
-  /**
-   * Checks if debug mode is enabled.
-   *
-   * @return true if debug mode is enabled, false otherwise.
-   */
+  /// Checks if debug mode is enabled.
+  ///
+  /// @return true if debug mode is enabled, false otherwise.
   public boolean isDebug() {
     return debug;
   }
 
-  /**
-   * Sets the debug mode.
-   *
-   * @param debug true to enable debug mode, false to disable.
-   */
+  /// Sets the debug mode.
+  ///
+  /// @param debug true to enable debug mode, false to disable.
   public void setDebug(boolean debug) {
     this.set("debug", debug);
   }
 
-  /**
-   * Initializes a property by its key and value.
-   *
-   * @param key   The key of the property.
-   * @param value The value of the property.
-   */
+  /// Initializes a property by its key and value.
+  ///
+  /// @param key   The key of the property.
+  /// @param value The value of the property.
   protected void initializeByProperty(final String key, final String value) {
     final String propertyName = key.substring(this.getPrefix().length());
     ReflectionUtilities.setFieldValue(this.getClass(), this, propertyName, value);
   }
 
-  /**
-   * Store properties. By default, it is supported to store the following types: boolean, int, double, float, String and enum values. If you need to
-   * store any other object, you should overwrite this method as well as the initializeProperty method and implement a custom approach.
-   *
-   * @param properties the properties
-   */
+  /// Store properties. By default, it is supported to store the following types: boolean, int, double, float, String and enum values. If you need to
+  /// store any other object, you should overwrite this method as well as the initializeProperty method and implement a custom approach.
+  ///
+  /// @param properties the properties
   protected void storeProperties(final Properties properties) {
     try {
       for (Field field : this.getClass().getDeclaredFields()) {
@@ -134,13 +112,11 @@ public abstract class ConfigurationGroup {
     }
   }
 
-  /**
-   * Use this method to set configuration properties if you want to support {@code configurationChanged} for your property.
-   *
-   * @param <T>       The type of the value to set.
-   * @param fieldName The name of the field to set.
-   * @param value     The value to set.
-   */
+  /// Use this method to set configuration properties if you want to support `configurationChanged` for your property.
+  ///
+  /// @param <T>       The type of the value to set.
+  /// @param fieldName The name of the field to set.
+  /// @param value     The value to set.
   protected <T> void set(String fieldName, T value) {
     Field field = ReflectionUtilities.getField(this.getClass(), fieldName, true);
     if (field != null) {
@@ -163,19 +139,15 @@ public abstract class ConfigurationGroup {
     }
   }
 
-  /**
-   * This listener interface receives events when any property of the configuration changed.
-   *
-   * @see ConfigurationGroup#onChanged(ConfigurationChangedListener)
-   */
+  /// This listener interface receives events when any property of the configuration changed.
+  ///
+  /// @see ConfigurationGroup#onChanged(ConfigurationChangedListener)
   @FunctionalInterface
   public interface ConfigurationChangedListener extends EventListener {
-    /**
-     * Invoked when a property of the configuration has been changed using the {@link ConfigurationGroup#set(String, Object)} method to support this
-     * event.
-     *
-     * @param event The property changed event.
-     */
+    /// Invoked when a property of the configuration has been changed using the [Object)][ConfigurationGroup#set(String,] method to support this
+    /// event.
+    ///
+    /// @param event The property changed event.
     void configurationChanged(PropertyChangeEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/ConfigurationGroupInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/ConfigurationGroupInfo.java
@@ -6,25 +6,19 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Annotation to provide metadata for configuration groups. This annotation can be used to specify a prefix and debug mode for configuration groups.
- */
+/// Annotation to provide metadata for configuration groups. This annotation can be used to specify a prefix and debug mode for configuration groups.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface ConfigurationGroupInfo {
 
-  /**
-   * Specifies the prefix for the configuration group.
-   *
-   * @return the prefix for the configuration group.
-   */
+  /// Specifies the prefix for the configuration group.
+  ///
+  /// @return the prefix for the configuration group.
   String prefix() default "";
 
-  /**
-   * Specifies whether debug mode is enabled for the configuration group.
-   *
-   * @return true if debug mode is enabled, false otherwise.
-   */
+  /// Specifies whether debug mode is enabled for the configuration group.
+  ///
+  /// @return true if debug mode is enabled, false otherwise.
   boolean debug() default false;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/DebugConfiguration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/DebugConfiguration.java
@@ -2,9 +2,7 @@ package de.gurkenlabs.litiengine.configuration;
 
 import de.gurkenlabs.litiengine.Game;
 
-/**
- * Configuration class for debug settings.
- */
+/// Configuration class for debug settings.
 @ConfigurationGroupInfo(prefix = "dbg_", debug = true)
 public class DebugConfiguration extends ConfigurationGroup {
   private boolean debugEnabled = false;
@@ -18,189 +16,147 @@ public class DebugConfiguration extends ConfigurationGroup {
   private boolean showTilesMetric = false;
   private boolean trackRenderTimes = false;
 
-  /**
-   * Constructs a new DebugConfiguration with default settings.
-   */
+  /// Constructs a new DebugConfiguration with default settings.
   DebugConfiguration() {
     super();
   }
 
-  /**
-   * Checks if debug mode is enabled.
-   *
-   * @return true if debug mode is enabled, false otherwise.
-   */
+  /// Checks if debug mode is enabled.
+  ///
+  /// @return true if debug mode is enabled, false otherwise.
   public boolean isDebugEnabled() {
     return Game.isDebug() && this.debugEnabled;
   }
 
-  /**
-   * Checks if debug mouse rendering is enabled.
-   *
-   * @return true if debug mouse rendering is enabled, false otherwise.
-   */
+  /// Checks if debug mouse rendering is enabled.
+  ///
+  /// @return true if debug mouse rendering is enabled, false otherwise.
   public boolean isRenderDebugMouse() {
     return this.isDebugEnabled() && this.renderDebugMouse;
   }
 
-  /**
-   * Checks if bounding boxes rendering is enabled.
-   *
-   * @return true if bounding boxes rendering is enabled, false otherwise.
-   */
+  /// Checks if bounding boxes rendering is enabled.
+  ///
+  /// @return true if bounding boxes rendering is enabled, false otherwise.
   public boolean renderBoundingBoxes() {
     return this.isDebugEnabled() && this.renderBoundingBoxes;
   }
 
-  /**
-   * Checks if collision boxes rendering is enabled.
-   *
-   * @return true if collision boxes rendering is enabled, false otherwise.
-   */
+  /// Checks if collision boxes rendering is enabled.
+  ///
+  /// @return true if collision boxes rendering is enabled, false otherwise.
   public boolean renderCollisionBoxes() {
     return this.isDebugEnabled() && this.renderCollisionBoxes;
   }
 
-  /**
-   * Checks if entity names rendering is enabled.
-   *
-   * @return true if entity names rendering is enabled, false otherwise.
-   */
+  /// Checks if entity names rendering is enabled.
+  ///
+  /// @return true if entity names rendering is enabled, false otherwise.
   public boolean renderEntityNames() {
     return this.isDebugEnabled() && this.renderEntityNames;
   }
 
-  /**
-   * Checks if hit boxes rendering is enabled.
-   *
-   * @return true if hit boxes rendering is enabled, false otherwise.
-   */
+  /// Checks if hit boxes rendering is enabled.
+  ///
+  /// @return true if hit boxes rendering is enabled, false otherwise.
   public boolean renderHitBoxes() {
     return this.isDebugEnabled() && this.renderHitBoxes;
   }
 
-  /**
-   * Checks if GUI component bounding boxes rendering is enabled.
-   *
-   * @return true if GUI component bounding boxes rendering is enabled, false otherwise.
-   */
+  /// Checks if GUI component bounding boxes rendering is enabled.
+  ///
+  /// @return true if GUI component bounding boxes rendering is enabled, false otherwise.
   public boolean renderGuiComponentBoundingBoxes() {
     return this.isDebugEnabled() && this.renderGuiComponentBoundingBoxes;
   }
 
-  /**
-   * Checks if mouse target metric is shown.
-   *
-   * @return true if mouse target metric is shown, false otherwise.
-   */
+  /// Checks if mouse target metric is shown.
+  ///
+  /// @return true if mouse target metric is shown, false otherwise.
   public boolean showMouseTargetMetric() {
     return this.isDebugEnabled() && this.showMouseTargetMetric;
   }
 
-  /**
-   * Checks if tiles metric is shown.
-   *
-   * @return true if tiles metric is shown, false otherwise.
-   */
+  /// Checks if tiles metric is shown.
+  ///
+  /// @return true if tiles metric is shown, false otherwise.
   public boolean showTilesMetric() {
     return this.isDebugEnabled() && this.showTilesMetric;
   }
 
-  /**
-   * Checks if render times tracking is enabled.
-   *
-   * @return true if render times tracking is enabled, false otherwise.
-   */
+  /// Checks if render times tracking is enabled.
+  ///
+  /// @return true if render times tracking is enabled, false otherwise.
   public boolean trackRenderTimes() {
     return this.isDebugEnabled() && this.trackRenderTimes;
   }
 
-  /**
-   * Sets whether debug mode is enabled.
-   *
-   * @param debugEnabled true to enable debug mode, false to disable.
-   */
+  /// Sets whether debug mode is enabled.
+  ///
+  /// @param debugEnabled true to enable debug mode, false to disable.
   public void setDebugEnabled(final boolean debugEnabled) {
     this.set("debugEnabled", debugEnabled);
   }
 
-  /**
-   * Sets whether bounding boxes rendering is enabled.
-   *
-   * @param renderBoundingBoxes true to enable bounding boxes rendering, false to disable.
-   */
+  /// Sets whether bounding boxes rendering is enabled.
+  ///
+  /// @param renderBoundingBoxes true to enable bounding boxes rendering, false to disable.
   public void setRenderBoundingBoxes(final boolean renderBoundingBoxes) {
     this.set("renderBoundingBoxes", renderBoundingBoxes);
   }
 
-  /**
-   * Sets whether collision boxes rendering is enabled.
-   *
-   * @param renderCollisionBoxes true to enable collision boxes rendering, false to disable.
-   */
+  /// Sets whether collision boxes rendering is enabled.
+  ///
+  /// @param renderCollisionBoxes true to enable collision boxes rendering, false to disable.
   public void setRenderCollisionBoxes(final boolean renderCollisionBoxes) {
     this.set("renderCollisionBoxes", renderCollisionBoxes);
   }
 
-  /**
-   * Sets whether debug mouse rendering is enabled.
-   *
-   * @param renderDebugMouse true to enable debug mouse rendering, false to disable.
-   */
+  /// Sets whether debug mouse rendering is enabled.
+  ///
+  /// @param renderDebugMouse true to enable debug mouse rendering, false to disable.
   public void setRenderDebugMouse(final boolean renderDebugMouse) {
     this.set("renderDebugMouse", renderDebugMouse);
   }
 
-  /**
-   * Sets whether entity names rendering is enabled.
-   *
-   * @param renderEntityNames true to enable entity names rendering, false to disable.
-   */
+  /// Sets whether entity names rendering is enabled.
+  ///
+  /// @param renderEntityNames true to enable entity names rendering, false to disable.
   public void setRenderEntityNames(final boolean renderEntityNames) {
     this.set("renderEntityNames", renderEntityNames);
   }
 
-  /**
-   * Sets whether hit boxes rendering is enabled.
-   *
-   * @param renderHitBoxes true to enable hit boxes rendering, false to disable.
-   */
+  /// Sets whether hit boxes rendering is enabled.
+  ///
+  /// @param renderHitBoxes true to enable hit boxes rendering, false to disable.
   public void setRenderHitBoxes(final boolean renderHitBoxes) {
     this.set("renderHitBoxes", renderHitBoxes);
   }
 
-  /**
-   * Sets whether mouse target metric is shown.
-   *
-   * @param showMouseTargetMetric true to show mouse target metric, false to hide.
-   */
+  /// Sets whether mouse target metric is shown.
+  ///
+  /// @param showMouseTargetMetric true to show mouse target metric, false to hide.
   public void setShowMouseTargetMetric(final boolean showMouseTargetMetric) {
     this.set("showMouseTargetMetric", showMouseTargetMetric);
   }
 
-  /**
-   * Sets whether tiles metric is shown.
-   *
-   * @param showTilesMetric true to show tiles metric, false to hide.
-   */
+  /// Sets whether tiles metric is shown.
+  ///
+  /// @param showTilesMetric true to show tiles metric, false to hide.
   public void setShowTilesMetric(final boolean showTilesMetric) {
     this.set("showTilesMetric", showTilesMetric);
   }
 
-  /**
-   * Sets whether GUI component bounding boxes rendering is enabled.
-   *
-   * @param renderGuiComponentBoundingBoxes true to enable GUI component bounding boxes rendering, false to disable.
-   */
+  /// Sets whether GUI component bounding boxes rendering is enabled.
+  ///
+  /// @param renderGuiComponentBoundingBoxes true to enable GUI component bounding boxes rendering, false to disable.
   public void setRenderGuiComponentBoundingBoxes(boolean renderGuiComponentBoundingBoxes) {
     this.set("renderGuiComponentBoundingBoxes", renderGuiComponentBoundingBoxes);
   }
 
-  /**
-   * Sets whether render times tracking is enabled.
-   *
-   * @param trackRenderTimes true to enable render times tracking, false to disable.
-   */
+  /// Sets whether render times tracking is enabled.
+  ///
+  /// @param trackRenderTimes true to enable render times tracking, false to disable.
   public void setTrackRenderTimes(boolean trackRenderTimes) {
     this.set("trackRenderTimes", trackRenderTimes);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/DisplayMode.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/DisplayMode.java
@@ -1,21 +1,13 @@
 package de.gurkenlabs.litiengine.configuration;
 
-/**
- * Enum representing the different display modes available.
- */
+/// Enum representing the different display modes available.
 public enum DisplayMode {
-  /**
-   * Fullscreen display mode.
-   */
+  /// Fullscreen display mode.
   FULLSCREEN,
 
-  /**
-   * Windowed display mode.
-   */
+  /// Windowed display mode.
   WINDOWED,
 
-  /**
-   * Borderless window display mode.
-   */
+  /// Borderless window display mode.
   BORDERLESS,
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/GameConfiguration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/GameConfiguration.java
@@ -1,13 +1,11 @@
 package de.gurkenlabs.litiengine.configuration;
 
-/**
- * This class contains all default {@code ConfigurationGroups} that are provided by the LITIENGINE. Additionally, it can
- * be used to register and manage custom settings that are specific to your game.
- *
- * @see ConfigurationGroup
- * @see Configuration#add(ConfigurationGroup)
- * @see Configuration#getConfigurationGroup(Class)
- */
+/// This class contains all default `ConfigurationGroups` that are provided by the LITIENGINE. Additionally, it can
+/// be used to register and manage custom settings that are specific to your game.
+///
+/// @see ConfigurationGroup
+/// @see Configuration#add(ConfigurationGroup)
+/// @see Configuration#getConfigurationGroup(Class)
 public final class GameConfiguration extends Configuration {
   private final ClientConfiguration client;
   private final DebugConfiguration debug;
@@ -29,48 +27,38 @@ public final class GameConfiguration extends Configuration {
     this.getConfigurationGroups().add(this.debug);
   }
 
-  /**
-   * Gets the basic game client configuration like update-rate or localization.
-   * 
-   * @return The game client configuration.
-   */
+  /// Gets the basic game client configuration like update-rate or localization.
+  ///
+  /// @return The game client configuration.
   public ClientConfiguration client() {
     return this.client;
   }
 
-  /**
-   * Gets the configuration group with all default debugging settings.
-   * 
-   * @return The debugging configuration.
-   */
+  /// Gets the configuration group with all default debugging settings.
+  ///
+  /// @return The debugging configuration.
   public DebugConfiguration debug() {
     return this.debug;
   }
 
-  /**
-   * Gets the configuration group with all default graphics settings. Elements in this group will allow you to adjust the
-   * game's rendering behavior.
-   * 
-   * @return The graphics configuration.
-   */
+  /// Gets the configuration group with all default graphics settings. Elements in this group will allow you to adjust the
+  /// game's rendering behavior.
+  ///
+  /// @return The graphics configuration.
   public GraphicConfiguration graphics() {
     return this.graphics;
   }
 
-  /**
-   * Gets the configuration group with all default input settings.
-   * 
-   * @return The input configuration.
-   */
+  /// Gets the configuration group with all default input settings.
+  ///
+  /// @return The input configuration.
   public InputConfiguration input() {
     return this.input;
   }
 
-  /**
-   * Gets the configuration group with all default sound settings.
-   * 
-   * @return The sound configuration.
-   */
+  /// Gets the configuration group with all default sound settings.
+  ///
+  /// @return The sound configuration.
   public SoundConfiguration sound() {
     return this.sound;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/GraphicConfiguration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/GraphicConfiguration.java
@@ -5,9 +5,7 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Toolkit;
 
-/**
- * Represents the graphic configuration settings. This class extends the ConfigurationGroup to provide specific settings for graphics.
- */
+/// Represents the graphic configuration settings. This class extends the ConfigurationGroup to provide specific settings for graphics.
 @ConfigurationGroupInfo(prefix = "gfx_")
 public class GraphicConfiguration extends ConfigurationGroup {
 
@@ -31,9 +29,7 @@ public class GraphicConfiguration extends ConfigurationGroup {
 
   private Java2DPipeline java2DPipeline;
 
-  /**
-   * Constructs a new GraphicConfiguration with default settings.
-   */
+  /// Constructs a new GraphicConfiguration with default settings.
   GraphicConfiguration() {
     this.graphicQuality = Quality.LOW;
     this.displayMode = DisplayMode.WINDOWED;
@@ -65,175 +61,137 @@ public class GraphicConfiguration extends ConfigurationGroup {
     return new Dimension(this.resolutionWidth, this.resolutionHeight);
   }
 
-  /**
-   * Gets the current resolution height.
-   *
-   * @return the resolution height.
-   */
+  /// Gets the current resolution height.
+  ///
+  /// @return the resolution height.
   public int getResolutionHeight() {
     return resolutionHeight;
   }
 
-  /**
-   * Gets the current resolution width.
-   *
-   * @return the resolution width.
-   */
+  /// Gets the current resolution width.
+  ///
+  /// @return the resolution width.
   public int getResolutionWidth() {
     return resolutionWidth;
   }
 
-  /**
-   * Checks if dynamic shadows rendering is enabled.
-   *
-   * @return true if dynamic shadows rendering is enabled, false otherwise.
-   */
+  /// Checks if dynamic shadows rendering is enabled.
+  ///
+  /// @return true if dynamic shadows rendering is enabled, false otherwise.
   public boolean renderDynamicShadows() {
     return renderDynamicShadows;
   }
 
-  /**
-   * Checks if anti-aliasing is enabled.
-   *
-   * @return true if anti-aliasing is enabled, false otherwise.
-   */
+  /// Checks if anti-aliasing is enabled.
+  ///
+  /// @return true if anti-aliasing is enabled, false otherwise.
   public boolean antiAliasing() {
     return antiAliasing;
   }
 
-  /**
-   * Checks if color interpolation is enabled.
-   *
-   * @return true if color interpolation is enabled, false otherwise.
-   */
+  /// Checks if color interpolation is enabled.
+  ///
+  /// @return true if color interpolation is enabled, false otherwise.
   public boolean colorInterpolation() {
     return colorInterpolation;
   }
 
-  /**
-   * Gets the current display mode.
-   *
-   * @return the display mode.
-   */
+  /// Gets the current display mode.
+  ///
+  /// @return the display mode.
   public DisplayMode getDisplayMode() {
     return displayMode;
   }
 
-  /**
-   * Sets the display mode.
-   *
-   * @param displayMode the new display mode.
-   */
+  /// Sets the display mode.
+  ///
+  /// @param displayMode the new display mode.
   public void setDisplayMode(DisplayMode displayMode) {
     this.set("displayMode", displayMode);
   }
 
-  /**
-   * Sets the graphic quality.
-   *
-   * @param graphicQuality the new graphic quality.
-   */
+  /// Sets the graphic quality.
+  ///
+  /// @param graphicQuality the new graphic quality.
   public void setGraphicQuality(final Quality graphicQuality) {
     this.set("graphicQuality", graphicQuality);
   }
 
-  /**
-   * Sets whether to render dynamic shadows.
-   *
-   * @param renderDynamicShadows true to enable dynamic shadows rendering, false to disable.
-   */
+  /// Sets whether to render dynamic shadows.
+  ///
+  /// @param renderDynamicShadows true to enable dynamic shadows rendering, false to disable.
   public void setRenderDynamicShadows(final boolean renderDynamicShadows) {
     this.set("renderDynamicShadows", renderDynamicShadows);
   }
 
-  /**
-   * Sets the resolution height.
-   *
-   * @param resolutionHeight the new resolution height.
-   */
+  /// Sets the resolution height.
+  ///
+  /// @param resolutionHeight the new resolution height.
   public void setResolutionHeight(final int resolutionHeight) {
     this.set("resolutionHeight", resolutionHeight);
   }
 
-  /**
-   * Sets the resolution width.
-   *
-   * @param resolutionWidth the new resolution width.
-   */
+  /// Sets the resolution width.
+  ///
+  /// @param resolutionWidth the new resolution width.
   public void setResolutionWidth(final int resolutionWidth) {
     this.set("resolutionWidth", resolutionWidth);
   }
 
-  /**
-   * Checks if resolution scaling is enabled.
-   *
-   * @return true if resolution scaling is enabled, false otherwise.
-   */
+  /// Checks if resolution scaling is enabled.
+  ///
+  /// @return true if resolution scaling is enabled, false otherwise.
   public boolean enableResolutionScaling() {
     return enableResolutionScale;
   }
 
-  /**
-   * Sets whether to enable resolution scaling.
-   *
-   * @param enableResolutionScale true to enable resolution scaling, false to disable.
-   */
+  /// Sets whether to enable resolution scaling.
+  ///
+  /// @param enableResolutionScale true to enable resolution scaling, false to disable.
   public void setEnableResolutionScale(boolean enableResolutionScale) {
     this.set("enableResolutionScale", enableResolutionScale);
   }
 
-  /**
-   * Checks if frames should be reduced when not focused.
-   *
-   * @return true if frames should be reduced when not focused, false otherwise.
-   */
+  /// Checks if frames should be reduced when not focused.
+  ///
+  /// @return true if frames should be reduced when not focused, false otherwise.
   public boolean reduceFramesWhenNotFocused() {
     return reduceFramesWhenNotFocused;
   }
 
-  /**
-   * Sets whether to reduce frames when not focused.
-   *
-   * @param reduceFramesWhenNotFocused true to reduce frames when not focused, false to not reduce.
-   */
+  /// Sets whether to reduce frames when not focused.
+  ///
+  /// @param reduceFramesWhenNotFocused true to reduce frames when not focused, false to not reduce.
   public void setReduceFramesWhenNotFocused(boolean reduceFramesWhenNotFocused) {
     this.set("reduceFramesWhenNotFocused", reduceFramesWhenNotFocused);
   }
 
-  /**
-   * Sets whether to enable anti-aliasing.
-   *
-   * @param antiAliasing true to enable anti-aliasing, false to disable.
-   */
+  /// Sets whether to enable anti-aliasing.
+  ///
+  /// @param antiAliasing true to enable anti-aliasing, false to disable.
   public void setAntiAliasing(boolean antiAliasing) {
     this.set("antiAliasing", antiAliasing);
   }
 
-  /**
-   * Sets whether to enable color interpolation.
-   *
-   * @param colorInterpolation true to enable color interpolation, false to disable.
-   */
+  /// Sets whether to enable color interpolation.
+  ///
+  /// @param colorInterpolation true to enable color interpolation, false to disable.
   public void setColorInterpolation(boolean colorInterpolation) {
     this.set("colorInterpolation", colorInterpolation);
   }
 
-  /**
-   * Gets the Java2D rendering pipeline. The pipeline is locked in once the
-   * first {@code Graphics2D} context is created, so changing this after
-   * {@code Game.init()} has no effect.
-   *
-   * @return the configured Java2D pipeline.
-   */
+  /// Gets the Java2D rendering pipeline. The pipeline is locked in once the
+  /// first `Graphics2D` context is created, so changing this after
+  /// `Game.init()` has no effect.
+  ///
+  /// @return the configured Java2D pipeline.
   public Java2DPipeline getJava2DPipeline() {
     return java2DPipeline;
   }
 
-  /**
-   * Sets the Java2D rendering pipeline.
-   *
-   * @param pipeline the desired Java2D pipeline.
-   */
+  /// Sets the Java2D rendering pipeline.
+  ///
+  /// @param pipeline the desired Java2D pipeline.
   public void setJava2DPipeline(Java2DPipeline pipeline) {
     this.set("java2DPipeline", pipeline);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/InputConfiguration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/InputConfiguration.java
@@ -8,9 +8,7 @@ public class InputConfiguration extends ConfigurationGroup {
   private float gamepadTriggerDeadzone;
   private float gamepadStickDeadzone;
 
-  /**
-   * Constructs a new InputConfiguration with default settings.
-   */
+  /// Constructs a new InputConfiguration with default settings.
   InputConfiguration() {
     this.setMouseSensitivity(1.0F);
     this.setGamepadSupport(false);
@@ -19,92 +17,72 @@ public class InputConfiguration extends ConfigurationGroup {
     this.setGamepadStickDeadzone(0.15f);
   }
 
-  /**
-   * Gets the current mouse sensitivity.
-   *
-   * @return the mouse sensitivity.
-   */
+  /// Gets the current mouse sensitivity.
+  ///
+  /// @return the mouse sensitivity.
   public float getMouseSensitivity() {
     return mouseSensitivity;
   }
 
-  /**
-   * Gets the current gamepad axis deadzone.
-   *
-   * @return the gamepad axis deadzone.
-   */
+  /// Gets the current gamepad axis deadzone.
+  ///
+  /// @return the gamepad axis deadzone.
   public float getGamepadAxisDeadzone() {
     return gamepadAxisDeadzone;
   }
 
-  /**
-   * Gets the current gamepad trigger deadzone.
-   *
-   * @return the gamepad trigger deadzone.
-   */
+  /// Gets the current gamepad trigger deadzone.
+  ///
+  /// @return the gamepad trigger deadzone.
   public float getGamepadTriggerDeadzone() {
     return gamepadTriggerDeadzone;
   }
 
-  /**
-   * Gets the current gamepad stick deadzone.
-   *
-   * @return the gamepad stick deadzone.
-   */
+  /// Gets the current gamepad stick deadzone.
+  ///
+  /// @return the gamepad stick deadzone.
   public float getGamepadStickDeadzone() {
     return gamepadStickDeadzone;
   }
 
-  /**
-   * Checks if gamepad support is enabled.
-   *
-   * @return true if gamepad support is enabled, false otherwise.
-   */
+  /// Checks if gamepad support is enabled.
+  ///
+  /// @return true if gamepad support is enabled, false otherwise.
   public boolean isGamepadSupport() {
     return gamepadSupport;
   }
 
-  /**
-   * Sets the mouse sensitivity.
-   *
-   * @param mouseSensitivity the new mouse sensitivity.
-   */
+  /// Sets the mouse sensitivity.
+  ///
+  /// @param mouseSensitivity the new mouse sensitivity.
   public void setMouseSensitivity(final float mouseSensitivity) {
     this.set("mouseSensitivity", mouseSensitivity);
   }
 
-  /**
-   * Sets the gamepad support.
-   *
-   * @param gamepadSupport the new gamepad support status.
-   */
+  /// Sets the gamepad support.
+  ///
+  /// @param gamepadSupport the new gamepad support status.
   public void setGamepadSupport(boolean gamepadSupport) {
     this.set("gamepadSupport", gamepadSupport);
   }
 
-  /**
-   * Sets the gamepad axis deadzone.
-   *
-   * @param gamepadAxisDeadzone the new gamepad axis deadzone.
-   */
+  /// Sets the gamepad axis deadzone.
+  ///
+  /// @param gamepadAxisDeadzone the new gamepad axis deadzone.
   public void setGamepadAxisDeadzone(float gamepadAxisDeadzone) {
     this.set("gamepadAxisDeadzone", gamepadAxisDeadzone);
   }
 
-  /**
-   * Sets the gamepad trigger deadzone.
-   *
-   * @param gamepadTriggerDeadzone the new gamepad trigger deadzone.
-   */
+  /// Sets the gamepad trigger deadzone.
+  ///
+  /// @param gamepadTriggerDeadzone the new gamepad trigger deadzone.
   public void setGamepadTriggerDeadzone(float gamepadTriggerDeadzone) {
     this.set("gamepadTriggerDeadzone", gamepadTriggerDeadzone);
   }
 
-  /**
-   * Sets the gamepad stick deadzone.
-   *
-   * @param gamepadStickDeadzone the new gamepad stick deadzone.
-   */
+  /// Sets the gamepad stick deadzone.
+  ///
+  /// @param gamepadStickDeadzone the new gamepad stick deadzone.
   public void setGamepadStickDeadzone(float gamepadStickDeadzone) {
     this.set("gamepadStickDeadzone", gamepadStickDeadzone);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Java2DPipeline.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Java2DPipeline.java
@@ -1,37 +1,27 @@
 package de.gurkenlabs.litiengine.configuration;
 
-/**
- * Represents the Java2D rendering pipeline to use.
- * The pipeline is applied automatically during {@code Game.init()} via
- * {@link de.gurkenlabs.litiengine.graphics.RenderComponent#configurePipeline()},
- * which must run before any {@code Graphics2D} context is created.
- *
- * @see GraphicConfiguration#setJava2DPipeline(Java2DPipeline)
- */
+/// Represents the Java2D rendering pipeline to use.
+/// The pipeline is applied automatically during `Game.init()` via
+/// [de.gurkenlabs.litiengine.graphics.RenderComponent#configurePipeline()],
+/// which must run before any `Graphics2D` context is created.
+///
+/// @see GraphicConfiguration#setJava2DPipeline(Java2DPipeline)
 public enum Java2DPipeline {
-  /**
-   * Use the platform-default Java2D pipeline. On most systems this is a
-   * software rasterizer, but on some platforms it may select a hardware
-   * accelerated pipeline automatically.
-   */
+  /// Use the platform-default Java2D pipeline. On most systems this is a
+  /// software rasterizer, but on some platforms it may select a hardware
+  /// accelerated pipeline automatically.
   DEFAULT,
 
-  /**
-   * Force the OpenGL rendering pipeline ({@code sun.java2d.opengl=true}).
-   * This typically gives a large performance boost on desktop systems with
-   * capable GPU drivers. Falls back to software if OpenGL is unavailable.
-   */
+  /// Force the OpenGL rendering pipeline (`sun.java2d.opengl=true`).
+  /// This typically gives a large performance boost on desktop systems with
+  /// capable GPU drivers. Falls back to software if OpenGL is unavailable.
   OPENGL,
 
-  /**
-   * Force the Direct3D rendering pipeline ({@code sun.java2d.d3d=true}).
-   * Only effective on Windows. Falls back to software on other platforms.
-   */
+  /// Force the Direct3D rendering pipeline (`sun.java2d.d3d=true`).
+  /// Only effective on Windows. Falls back to software on other platforms.
   DIRECT3D,
 
-  /**
-   * Force software rendering by disabling the OpenGL and Direct3D pipelines.
-   * Use this if hardware acceleration causes rendering glitches.
-   */
+  /// Force software rendering by disabling the OpenGL and Direct3D pipelines.
+  /// Use this if hardware acceleration causes rendering glitches.
   SOFTWARE
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Quality.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/Quality.java
@@ -1,8 +1,6 @@
 package de.gurkenlabs.litiengine.configuration;
 
-/**
- * Enum representing different quality levels.
- */
+/// Enum representing different quality levels.
 public enum Quality {
   VERYLOW(0),
   LOW(1),
@@ -12,20 +10,16 @@ public enum Quality {
 
   private final int value;
 
-  /**
-   * Constructs a Quality enum with the specified value.
-   *
-   * @param value The integer value representing the quality level.
-   */
+  /// Constructs a Quality enum with the specified value.
+  ///
+  /// @param value The integer value representing the quality level.
   private Quality(int value) {
     this.value = value;
   }
 
-  /**
-   * Gets the integer value of the quality level.
-   *
-   * @return The integer value of the quality level.
-   */
+  /// Gets the integer value of the quality level.
+  ///
+  /// @return The integer value of the quality level.
   public int getValue() {
     return value;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/SoundConfiguration.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/configuration/SoundConfiguration.java
@@ -7,46 +7,36 @@ public class SoundConfiguration extends ConfigurationGroup {
 
   private float soundVolume;
 
-  /**
-   * Constructs a new SoundConfiguration with default volume settings.
-   */
+  /// Constructs a new SoundConfiguration with default volume settings.
   SoundConfiguration() {
     this.setSoundVolume(0.5f);
     this.setMusicVolume(0.5f);
   }
 
-  /**
-   * Gets the current music volume.
-   *
-   * @return the music volume.
-   */
+  /// Gets the current music volume.
+  ///
+  /// @return the music volume.
   public float getMusicVolume() {
     return this.musicVolume;
   }
 
-  /**
-   * Gets the current sound volume.
-   *
-   * @return the sound volume.
-   */
+  /// Gets the current sound volume.
+  ///
+  /// @return the sound volume.
   public float getSoundVolume() {
     return this.soundVolume;
   }
 
-  /**
-   * Sets the music volume.
-   *
-   * @param musicVolume the new music volume.
-   */
+  /// Sets the music volume.
+  ///
+  /// @param musicVolume the new music volume.
   public void setMusicVolume(final float musicVolume) {
     this.set("musicVolume", musicVolume);
   }
 
-  /**
-   * Sets the sound volume.
-   *
-   * @param soundVolume the new sound volume.
-   */
+  /// Sets the sound volume.
+  ///
+  /// @param soundVolume the new sound volume.
   public void setSoundVolume(final float soundVolume) {
     this.set("soundVolume", soundVolume);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Action.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Action.java
@@ -6,27 +6,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation is used by the LITIENGINE to identify methods that should be registered as {@code EntityAction} by the entity framework.
- */
+/// This annotation is used by the LITIENGINE to identify methods that should be registered as `EntityAction` by the entity framework.
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Action {
-  /**
-   * The name of the {@code EntityAction}.
-   *
-   * <p>
-   * <i> If null or empty, the framework will use the name of the methods that this annotation was declared on. </i>
-   *
-   * @return The name of the EntityAction.
-   */
+  /// The name of the `EntityAction`.
+  ///
+  /// *If null or empty, the framework will use the name of the methods that this annotation was declared on.*
+  ///
+  /// @return The name of the EntityAction.
   String name() default "";
 
-  /**
-   * A brief description of the {@code EntityAction}.
-   *
-   * @return The description of the EntityAction.
-   */
+  /// A brief description of the `EntityAction`.
+  ///
+  /// @return The description of the EntityAction.
   String description() default "";
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/AnimationInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/AnimationInfo.java
@@ -6,26 +6,20 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * The AnimationInfo annotation provides metadata for animation properties of an entity.
- * It can be applied to types (classes or interfaces) and is inherited by subclasses.
- */
+/// The AnimationInfo annotation provides metadata for animation properties of an entity.
+/// It can be applied to types (classes or interfaces) and is inherited by subclasses.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface AnimationInfo {
-  /**
-   * Specifies the prefixes for the sprite animations.
-   *
-   * @return an array of sprite prefixes
-   */
+  /// Specifies the prefixes for the sprite animations.
+  ///
+  /// @return an array of sprite prefixes
   String[] spritePrefix();
 
-  /**
-   * Specifies the animations to be used when the entity dies.
-   * Defaults to an empty array.
-   *
-   * @return an array of death animation names
-   */
+  /// Specifies the animations to be used when the entity dies.
+  /// Defaults to an empty array.
+  ///
+  /// @return an array of death animation names
   String[] deathAnimations() default {};
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionBox.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionBox.java
@@ -8,44 +8,34 @@ import de.gurkenlabs.litiengine.graphics.RenderType;
 import de.gurkenlabs.litiengine.physics.Collision;
 import java.awt.geom.Rectangle2D;
 
-/**
- * The {@code CollisionBox} class represents a collision entity in the game. It extends the {@code CollisionEntity} class and provides additional
- * properties and methods specific to collision boxes.
- *
- * <p>This class is annotated with various annotations to define its behavior
- * and properties in the game environment, such as rendering type, collision information, and map object type.</p>
- */
+/// The `CollisionBox` class represents a collision entity in the game. It extends the `CollisionEntity` class and provides additional
+/// properties and methods specific to collision boxes.
+///
+/// This class is annotated with various annotations to define its behavior
+/// and properties in the game environment, such as rendering type, collision information, and map object type.
 @EntityInfo(renderType = RenderType.OVERLAY)
 @CollisionInfo(collision = true, collisionType = Collision.STATIC)
 @TmxType(MapObjectType.COLLISIONBOX)
 public class CollisionBox extends CollisionEntity {
-  /**
-   * A flag indicating whether this instance should obstruct lights.
-   */
+  /// A flag indicating whether this instance should obstruct lights.
   @TmxProperty(name = MapObjectProperty.COLLISIONBOX_OBSTRUCTINGLIGHTS)
   private boolean obstructingLight;
 
-  /**
-   * Instantiates a new {@code CollisionBox} entity.
-   */
+  /// Instantiates a new `CollisionBox` entity.
   public CollisionBox() {
   }
 
-  /**
-   * Instantiates a new {@code CollisionBox} entity.
-   *
-   * @param obstructingLight A flag indicating whether this instance should obstruct lights.
-   */
+  /// Instantiates a new `CollisionBox` entity.
+  ///
+  /// @param obstructingLight A flag indicating whether this instance should obstruct lights.
   public CollisionBox(final boolean obstructingLight) {
     this.obstructingLight = obstructingLight;
   }
 
-  /**
-   * Instantiates a new {@code CollisionBox} entity.
-   *
-   * @param width  The width of this instance.
-   * @param height The height of this instance.
-   */
+  /// Instantiates a new `CollisionBox` entity.
+  ///
+  /// @param width  The width of this instance.
+  /// @param height The height of this instance.
   public CollisionBox(double width, double height) {
     this.setWidth(width);
     this.setHeight(height);
@@ -53,34 +43,28 @@ public class CollisionBox extends CollisionEntity {
     this.setCollisionBoxHeight(this.getHeight());
   }
 
-  /**
-   * Instantiates a new {@code CollisionBox} entity.
-   *
-   * @param x      The x-coordinate of this instance.
-   * @param y      The y-coordinate of this instance.
-   * @param width  The width of this instance.
-   * @param height The height of this instance.
-   */
+  /// Instantiates a new `CollisionBox` entity.
+  ///
+  /// @param x      The x-coordinate of this instance.
+  /// @param y      The y-coordinate of this instance.
+  /// @param width  The width of this instance.
+  /// @param height The height of this instance.
   public CollisionBox(double x, double y, double width, double height) {
     this(width, height);
     this.setX(x);
     this.setY(y);
   }
 
-  /**
-   * Instantiates a new {@code CollisionBox} entity.
-   *
-   * @param box The rectangle defining the location and dimension of this instnace.
-   */
+  /// Instantiates a new `CollisionBox` entity.
+  ///
+  /// @param box The rectangle defining the location and dimension of this instnace.
   public CollisionBox(Rectangle2D box) {
     this(box.getX(), box.getY(), box.getWidth(), box.getHeight());
   }
 
-  /**
-   * Checks if this instance is obstructing light.
-   *
-   * @return {@code true} if this instance is obstructing light; {@code false} otherwise.
-   */
+  /// Checks if this instance is obstructing light.
+  ///
+  /// @return `true` if this instance is obstructing light; `false` otherwise.
   public boolean isObstructingLight() {
     return this.obstructingLight;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionEntity.java
@@ -16,10 +16,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Represents an abstract collision entity. This class provides the base implementation for entities that can collide with other entities. It extends
- * the Entity class and implements the ICollisionEntity interface.
- */
+/// Represents an abstract collision entity. This class provides the base implementation for entities that can collide with other entities. It extends
+/// the Entity class and implements the ICollisionEntity interface.
 @CollisionInfo(collision = true) public abstract class CollisionEntity extends Entity implements ICollisionEntity {
   private static final Logger log = Logger.getLogger(CollisionEntity.class.getName());
 
@@ -43,10 +41,8 @@ import java.util.logging.Logger;
 
   private Rectangle2D collisionBox;
 
-  /**
-   * Constructs a new CollisionEntity. Initializes the collision box dimensions, alignment, and type based on the CollisionInfo annotation. Refreshes
-   * the collision box to reflect the initial state.
-   */
+  /// Constructs a new CollisionEntity. Initializes the collision box dimensions, alignment, and type based on the CollisionInfo annotation. Refreshes
+  /// the collision box to reflect the initial state.
   protected CollisionEntity() {
     super();
     final CollisionInfo info = getClass().getAnnotation(CollisionInfo.class);
@@ -59,18 +55,16 @@ import java.util.logging.Logger;
     this.refreshCollisionBox();
   }
 
-  /**
-   * Calculates the collision box for an entity based on its location, dimensions, and alignment.
-   *
-   * @param location           the location of the entity
-   * @param entityWidth        the width of the entity
-   * @param entityHeight       the height of the entity
-   * @param collisionBoxWidth  the width of the collision box
-   * @param collisionBoxHeight the height of the collision box
-   * @param align              the horizontal alignment of the collision box
-   * @param valign             the vertical alignment of the collision box
-   * @return the calculated collision box as a Rectangle2D object
-   */
+  /// Calculates the collision box for an entity based on its location, dimensions, and alignment.
+  ///
+  /// @param location           the location of the entity
+  /// @param entityWidth        the width of the entity
+  /// @param entityHeight       the height of the entity
+  /// @param collisionBoxWidth  the width of the collision box
+  /// @param collisionBoxHeight the height of the collision box
+  /// @param align              the horizontal alignment of the collision box
+  /// @param valign             the vertical alignment of the collision box
+  /// @return the calculated collision box as a Rectangle2D object
   public static Rectangle2D getCollisionBox(final Point2D location, final double entityWidth, final double entityHeight,
     final double collisionBoxWidth, final double collisionBoxHeight, final Align align, final Valign valign) {
     double x = location.getX() + align.getLocation(entityWidth, collisionBoxWidth);
@@ -86,21 +80,17 @@ import java.util.logging.Logger;
     return this.align;
   }
 
-  /**
-   * Gets the collision box.
-   *
-   * @return the collision box
-   */
+  /// Gets the collision box.
+  ///
+  /// @return the collision box
   @Override public Rectangle2D getCollisionBox() {
     return this.collisionBox;
   }
 
-  /**
-   * Gets the collision box.
-   *
-   * @param location the location
-   * @return the collision box
-   */
+  /// Gets the collision box.
+  ///
+  /// @param location the location
+  /// @return the collision box
   @Override public Rectangle2D getCollisionBox(final Point2D location) {
     final double newCollisionBoxWidth = getCollisionBoxWidth() != -1 ? getCollisionBoxWidth() : Math.round(getWidth() * WIDTH_FACTOR);
     final double newCollisionBoxHeight = getCollisionBoxHeight() != -1 ? getCollisionBoxHeight() : Math.round(getHeight() * HEIGHT_FACTOR);
@@ -159,20 +149,16 @@ import java.util.logging.Logger;
     }
   }
 
-  /**
-   * Checks for collision.
-   *
-   * @return true, if successful
-   */
+  /// Checks for collision.
+  ///
+  /// @return true, if successful
   @Override public boolean hasCollision() {
     return this.collision && getCollisionBoxWidth() > 0 && getCollisionBoxHeight() > 0;
   }
 
-  /**
-   * Sets the collision.
-   *
-   * @param collision the new collision
-   */
+  /// Sets the collision.
+  ///
+  /// @param collision the new collision
   @Override public void setCollision(final boolean collision) {
     this.collision = collision;
   }
@@ -248,10 +234,8 @@ import java.util.logging.Logger;
     }
   }
 
-  /**
-   * Refreshes the collision box to reflect the current state of the entity. This method recalculates the collision box based on the entity's
-   * location, dimensions, and alignment.
-   */
+  /// Refreshes the collision box to reflect the current state of the entity. This method recalculates the collision box based on the entity's
+  /// location, dimensions, and alignment.
   protected void refreshCollisionBox() {
     this.collisionBox = getCollisionBox(getLocation());
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionInfo.java
@@ -9,58 +9,44 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * The CollisionInfo annotation provides metadata for collision properties of an entity.
- * It can be applied to types (classes or interfaces) and is inherited by subclasses.
- */
+/// The CollisionInfo annotation provides metadata for collision properties of an entity.
+/// It can be applied to types (classes or interfaces) and is inherited by subclasses.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface CollisionInfo {
-  /**
-   * Specifies the horizontal alignment of the entity's collision box.
-   * Defaults to {@link Align#CENTER}.
-   *
-   * @return the horizontal alignment of the collision box
-   */
+  /// Specifies the horizontal alignment of the entity's collision box.
+  /// Defaults to [Align#CENTER].
+  ///
+  /// @return the horizontal alignment of the collision box
   Align align() default Align.CENTER;
 
-  /**
-   * Specifies whether the entity has collision enabled.
-   *
-   * @return true if collision is enabled, false otherwise
-   */
+  /// Specifies whether the entity has collision enabled.
+  ///
+  /// @return true if collision is enabled, false otherwise
   boolean collision();
 
-  /**
-   * Specifies the height of the entity's collision box.
-   * Defaults to 0.
-   *
-   * @return the height of the collision box
-   */
+  /// Specifies the height of the entity's collision box.
+  /// Defaults to 0.
+  ///
+  /// @return the height of the collision box
   float collisionBoxHeight() default -1;
 
-  /**
-   * Specifies the width of the entity's collision box.
-   * Defaults to 0.
-   *
-   * @return the width of the collision box
-   */
+  /// Specifies the width of the entity's collision box.
+  /// Defaults to 0.
+  ///
+  /// @return the width of the collision box
   float collisionBoxWidth() default -1;
 
-  /**
-   * Specifies the vertical alignment of the entity's collision box.
-   * Defaults to {@link Valign#DOWN}.
-   *
-   * @return the vertical alignment of the collision box
-   */
+  /// Specifies the vertical alignment of the entity's collision box.
+  /// Defaults to [Valign#DOWN].
+  ///
+  /// @return the vertical alignment of the collision box
   Valign valign() default Valign.DOWN;
 
-  /**
-   * Specifies the type of collision for the entity.
-   * Defaults to {@link Collision#DYNAMIC}.
-   *
-   * @return the type of collision
-   */
+  /// Specifies the type of collision for the entity.
+  /// Defaults to [Collision#DYNAMIC].
+  ///
+  /// @return the type of collision
   Collision collisionType() default Collision.DYNAMIC;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CollisionListener.java
@@ -4,27 +4,22 @@ import de.gurkenlabs.litiengine.physics.CollisionEvent;
 import de.gurkenlabs.litiengine.physics.PhysicsEngine;
 import java.util.EventListener;
 
-/** This listener provides callbacks for collision events on {@code ICollisionEntity}. */
+/// This listener provides callbacks for collision events on `ICollisionEntity`.
 @FunctionalInterface
 public interface CollisionListener extends EventListener {
 
-  /**
-   * This method gets called after a collision has been resolved with the related {@code
-   * ICollisionEntity}.
-   *
-   * <p>
-   * If the entity is considered to be the "active collider" of the collision (i.e. it was moved with the
-   * {@code PhysicsEngine}), the event provides all other entities for which a collision had to be resolved during the
-   * movement.
-   *
-   * <p>
-   * If an entity was just in a collision resolving process (i.e. was "touched" by an actively moved collider), the event
-   * contains a reference to the collider instance.
-   *
-   * @param event
-   *          The collision event.
-   * @see PhysicsEngine#move(IMobileEntity, double, double)
-   * @see CollisionEvent#getInvolvedEntities()
-   */
+  /// This method gets called after a collision has been resolved with the related `ICollisionEntity`.
+  ///
+  /// If the entity is considered to be the "active collider" of the collision (i.e. it was moved with the
+  /// `PhysicsEngine`), the event provides all other entities for which a collision had to be resolved during the
+  /// movement.
+  ///
+  /// If an entity was just in a collision resolving process (i.e. was "touched" by an actively moved collider), the event
+  /// contains a reference to the collider instance.
+  ///
+  /// @param event
+  /// The collision event.
+  /// @see PhysicsEngine#move(IMobileEntity, double, double)
+  /// @see CollisionEvent#getInvolvedEntities()
   void collisionResolved(CollisionEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntity.java
@@ -17,9 +17,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * Represents a combat entity in the game. This class extends {@link CollisionEntity} and implements {@link ICombatEntity}.
- */
+/// Represents a combat entity in the game. This class extends [CollisionEntity] and implements [ICombatEntity].
 @CombatInfo
 @CollisionInfo(collision = true)
 public class CombatEntity extends CollisionEntity implements ICombatEntity {
@@ -45,9 +43,7 @@ public class CombatEntity extends CollisionEntity implements ICombatEntity {
   private ICombatEntity target;
   private long lastHit;
 
-  /**
-   * Represents a combat entity in the game. This class extends {@link CollisionEntity} and implements {@link ICombatEntity}.
-   */
+  /// Represents a combat entity in the game. This class extends [CollisionEntity] and implements [ICombatEntity].
   public CombatEntity() {
     super();
     this.listeners = ConcurrentHashMap.newKeySet();
@@ -123,21 +119,17 @@ public class CombatEntity extends CollisionEntity implements ICombatEntity {
     return this.appliedEffects;
   }
 
-  /**
-   * Gets the attributes.
-   *
-   * @return the attributes
-   */
+  /// Gets the attributes.
+  ///
+  /// @return the attributes
   @Override
   public RangeAttribute<Integer> getHitPoints() {
     return this.hitPoints;
   }
 
-  /**
-   * Gets the hit box.
-   *
-   * @return the hit box
-   */
+  /// Gets the hit box.
+  ///
+  /// @return the hit box
   @Override
   public Shape getHitBox() {
     return new Ellipse2D.Double(this.getX(), this.getY(), this.getWidth(), this.getHeight());
@@ -202,11 +194,9 @@ public class CombatEntity extends CollisionEntity implements ICombatEntity {
     this.lastHit = Game.time().now();
   }
 
-  /**
-   * Fires a death event for the combat entity.
-   *
-   * @param entityHitEvent the event that triggered the death
-   */
+  /// Fires a death event for the combat entity.
+  ///
+  /// @param entityHitEvent the event that triggered the death
   protected void fireDeathEvent(EntityHitEvent entityHitEvent) {
     this.setCollision(false);
 
@@ -219,32 +209,26 @@ public class CombatEntity extends CollisionEntity implements ICombatEntity {
     }
   }
 
-  /**
-   * Checks if is dead.
-   *
-   * @return true, if is dead
-   */
+  /// Checks if is dead.
+  ///
+  /// @return true, if is dead
   @Override
   public boolean isDead() {
     return !this.isIndestructible() && this.getHitPoints().getModifiedValue() <= 0;
   }
 
-  /**
-   * Checks if is friendly.
-   *
-   * @param entity the entity
-   * @return true, if is friendly
-   */
+  /// Checks if is friendly.
+  ///
+  /// @param entity the entity
+  /// @return true, if is friendly
   @Override
   public boolean isFriendly(final ICombatEntity entity) {
     return entity != null && this.getTeam() == entity.getTeam();
   }
 
-  /**
-   * Checks if is indestructible.
-   *
-   * @return true, if is indestructible
-   */
+  /// Checks if is indestructible.
+  ///
+  /// @return true, if is indestructible
   @Override
   public boolean isIndestructible() {
     return this.isIndestructible;
@@ -255,9 +239,7 @@ public class CombatEntity extends CollisionEntity implements ICombatEntity {
     return this.getTeam() == 0;
   }
 
-  /**
-   * Resurrect.
-   */
+  /// Resurrect.
   @Override
   public void resurrect() {
     if (!this.isDead()) {
@@ -296,11 +278,9 @@ public class CombatEntity extends CollisionEntity implements ICombatEntity {
     }
   }
 
-  /**
-   * Sets the team.
-   *
-   * @param team the new team
-   */
+  /// Sets the team.
+  ///
+  /// @param team the new team
   @Override
   public void setTeam(final int team) {
     this.team = team;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityDeathListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityDeathListener.java
@@ -2,21 +2,17 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/**
- * This listener provides callbacks for when an {@code ICombatEntity} died.
- *
- * @see ICombatEntity#die()
- */
+/// This listener provides callbacks for when an `ICombatEntity` died.
+///
+/// @see ICombatEntity#die()
 @FunctionalInterface
 public interface CombatEntityDeathListener extends EventListener {
 
-  /**
-   * This method is called whenever a {@code ICombatEntity} dies.
-   *
-   * @param entity
-   *          The combat entity that died.
-   * @param hitEvent
-   *          The hit event that caused the death or null.
-   */
+  /// This method is called whenever a `ICombatEntity` dies.
+  ///
+  /// @param entity
+  /// The combat entity that died.
+  /// @param hitEvent
+  /// The hit event that caused the death or null.
   void death(ICombatEntity entity, EntityHitEvent hitEvent);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityHitListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityHitListener.java
@@ -2,21 +2,17 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/**
- * This listener provides callbacks for when an {@code ICombatEntity} was hit.
- *
- * @see ICombatEntity#hit(int)
- * @see ICombatEntity#hit(int, de.gurkenlabs.litiengine.abilities.Ability)
- */
+/// This listener provides callbacks for when an `ICombatEntity` was hit.
+///
+/// @see ICombatEntity#hit(int)
+/// @see ICombatEntity#hit(int, de.gurkenlabs.litiengine.abilities.Ability)
 @FunctionalInterface
 public interface CombatEntityHitListener extends EventListener {
 
-  /**
-   * This method is called whenever a {@code ICombatEntity} was hit.
-   *
-   * @param event
-   *          The event data that contains information about the entity, for how much it was hit and the ability that
-   *          caused the hit.
-   */
+  /// This method is called whenever a `ICombatEntity` was hit.
+  ///
+  /// @param event
+  /// The event data that contains information about the entity, for how much it was hit and the ability that
+  /// caused the hit.
   void hit(EntityHitEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityListener.java
@@ -2,13 +2,11 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/**
- * This listener provides callbacks for when an {@code ICombatEntity} dies, was resurrected or is being hit.
- *
- * @see ICombatEntity#die()
- * @see ICombatEntity#resurrect()
- * @see ICombatEntity#hit(int)
- */
+/// This listener provides callbacks for when an `ICombatEntity` dies, was resurrected or is being hit.
+///
+/// @see ICombatEntity#die()
+/// @see ICombatEntity#resurrect()
+/// @see ICombatEntity#hit(int)
 public interface CombatEntityListener
     extends CombatEntityHitListener,
     CombatEntityDeathListener,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityResurrectListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatEntityResurrectListener.java
@@ -2,18 +2,14 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/**
- * This listener provides callbacks for when an {@code ICombatEntity} was resurrected.
- *
- * @see ICombatEntity#resurrect()
- */
+/// This listener provides callbacks for when an `ICombatEntity` was resurrected.
+///
+/// @see ICombatEntity#resurrect()
 @FunctionalInterface
 public interface CombatEntityResurrectListener extends EventListener {
-  /**
-   * This method is called whenever a {@code ICombatEntity} was resurrected.
-   *
-   * @param entity
-   *          The combat entity that was resurrected.
-   */
+  /// This method is called whenever a `ICombatEntity` was resurrected.
+  ///
+  /// @param entity
+  /// The combat entity that was resurrected.
   void resurrect(ICombatEntity entity);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/CombatInfo.java
@@ -6,42 +6,33 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation provides initial values for combat entity attributes. It can be applied to types (classes, interfaces, etc.) and is inherited by
- * subclasses.
- *
- * <p>Attributes:</p>
- * <ul>
- *   <li>hitpoints: The initial hitpoints of the combat entity. Default is {@link CombatEntity#DEFAULT_HITPOINTS}.</li>
- *   <li>team: The team number of the combat entity. Default is 0.</li>
- *   <li>isIndestructible: Indicates whether the combat entity is indestructible. Default is false.</li>
- * </ul>
- */
+/// This annotation provides initial values for combat entity attributes. It can be applied to types (classes, interfaces, etc.) and is inherited by
+/// subclasses.
+///
+/// Attributes:
+///
+/// - hitpoints: The initial hitpoints of the combat entity. Default is [CombatEntity#DEFAULT_HITPOINTS].
+/// - team: The team number of the combat entity. Default is 0.
+/// - isIndestructible: Indicates whether the combat entity is indestructible. Default is false.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface CombatInfo {
-  /**
-   * The initial hitpoints of the combat entity.
-   *  Defaults to {@link CombatEntity#DEFAULT_HITPOINTS}.
-   *
-   * @return the initial hitpoints
-   */
+  /// The initial hitpoints of the combat entity.
+  /// Defaults to [CombatEntity#DEFAULT_HITPOINTS].
+  ///
+  /// @return the initial hitpoints
   int hitpoints() default CombatEntity.DEFAULT_HITPOINTS;
 
-  /**
-   * The team number of the combat entity.
-   * Defaults to 0.
-   *
-   * @return the team number
-   */
+  /// The team number of the combat entity.
+  /// Defaults to 0.
+  ///
+  /// @return the team number
   int team() default 0;
 
-  /**
-   * Indicates whether the combat entity is indestructible.
-   * Defaults to false.
-   *
-   * @return true if the entity is indestructible, false otherwise
-   */
+  /// Indicates whether the combat entity is indestructible.
+  /// Defaults to false.
+  ///
+  /// @return true if the entity is indestructible, false otherwise
   boolean isIndestructible() default false;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Creature.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Creature.java
@@ -25,10 +25,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * The {@code Creature} class extends the {@code CombatEntity} class and implements the {@code IMobileEntity} interface. It represents a creature
- * entity in the game with movement and combat capabilities.
- */
+/// The `Creature` class extends the `CombatEntity` class and implements the `IMobileEntity` interface. It represents a creature
+/// entity in the game with movement and combat capabilities.
 @MovementInfo
 @TmxType(MapObjectType.CREATURE)
 public class Creature extends CombatEntity implements IMobileEntity {
@@ -56,19 +54,15 @@ public class Creature extends CombatEntity implements IMobileEntity {
 
   private long lastMoved;
 
-  /**
-   * Instantiates a new {@code Creature} entity with default settings.
-   */
+  /// Instantiates a new `Creature` entity with default settings.
   public Creature() {
     this(null);
   }
 
-  /**
-   * Instantiates a new {@code Creature} entity.
-   *
-   * @param spritesheetName The spritesheet name that identifies the sprites bound to this instance.
-   * @see CreatureAnimationController#getSpriteName(Creature, de.gurkenlabs.litiengine.graphics.CreatureAnimationState)
-   */
+  /// Instantiates a new `Creature` entity.
+  ///
+  /// @param spritesheetName The spritesheet name that identifies the sprites bound to this instance.
+  /// @see CreatureAnimationController#getSpriteName(Creature, de.gurkenlabs.litiengine.graphics.CreatureAnimationState)
   public Creature(String spritesheetName) {
     super();
     final MovementInfo movementInfo = getClass().getAnnotation(MovementInfo.class);
@@ -124,11 +118,9 @@ public class Creature extends CombatEntity implements IMobileEntity {
     return this.deceleration;
   }
 
-  /**
-   * Gets the facing direction of the creature based on its current angle.
-   *
-   * @return The direction the creature is facing.
-   */
+  /// Gets the facing direction of the creature based on its current angle.
+  ///
+  /// @return The direction the creature is facing.
   public Direction getFacingDirection() {
     return Direction.fromAngle(getAngle());
   }
@@ -138,14 +130,12 @@ public class Creature extends CombatEntity implements IMobileEntity {
     return getController(IMovementController.class);
   }
 
-  /**
-   * Gets the current spritesheet name of this instance. Overwriting this allows for a more sophisticated logic that determines the sprite to be used;
-   * e.g. This method could append certain properties of the creature (state, weapon, ...) to the default string. <br>
-   * <br>
-   * The value of this method will be used e.g. by the {@link CreatureAnimationController} to determine the animation that it should play.
-   *
-   * @return The current spritesheet name of this instance.
-   */
+  /// Gets the current spritesheet name of this instance. Overwriting this allows for a more sophisticated logic that determines the sprite to be used;
+  /// e.g. This method could append certain properties of the creature (state, weapon, ...) to the default string.
+  ///
+  /// The value of this method will be used e.g. by the [CreatureAnimationController] to determine the animation that it should play.
+  ///
+  /// @return The current spritesheet name of this instance.
   public String getSpritesheetName() {
     return this.spritesheetName;
   }
@@ -165,20 +155,16 @@ public class Creature extends CombatEntity implements IMobileEntity {
     return this.velocity;
   }
 
-  /**
-   * Checks if the creature's sprite is being scaled with the entity dimensions.
-   *
-   * @return true if the sprite is being scaled, false otherwise.
-   */
+  /// Checks if the creature's sprite is being scaled with the entity dimensions.
+  ///
+  /// @return true if the sprite is being scaled, false otherwise.
   public boolean isScaling() {
     return this.scaling;
   }
 
-  /**
-   * Checks if the creature is idle.
-   *
-   * @return true if the creature has not moved for a duration longer than the idle delay, false otherwise.
-   */
+  /// Checks if the creature is idle.
+  ///
+  /// @return true if the creature has not moved for a duration longer than the idle delay, false otherwise.
   public boolean isIdle() {
     return Game.time().since(this.lastMoved) > IDLE_DELAY;
   }
@@ -193,11 +179,9 @@ public class Creature extends CombatEntity implements IMobileEntity {
     this.deceleration = deceleration;
   }
 
-  /**
-   * Sets the facing direction of the creature.
-   *
-   * @param facingDirection The direction to set the creature's facing angle to.
-   */
+  /// Sets the facing direction of the creature.
+  ///
+  /// @param facingDirection The direction to set the creature's facing angle to.
   public void setFacingDirection(final Direction facingDirection) {
     this.setAngle(facingDirection.toAngle());
   }
@@ -224,11 +208,9 @@ public class Creature extends CombatEntity implements IMobileEntity {
     this.turnOnMove = turn;
   }
 
-  /**
-   * Sets the spritesheet name for this creature.
-   *
-   * @param spritesheetName The name of the spritesheet to set.
-   */
+  /// Sets the spritesheet name for this creature.
+  ///
+  /// @param spritesheetName The name of the spritesheet to set.
   public void setSpritesheetName(String spritesheetName) {
     if (this.spritesheetName != null && this.spritesheetName.equals(spritesheetName)) {
       return;
@@ -238,11 +220,9 @@ public class Creature extends CombatEntity implements IMobileEntity {
     this.updateAnimationController();
   }
 
-  /**
-   * Sets whether the creature's sprite should be scaled with the entity dimensions.
-   *
-   * @param scaling true to scale the sprite, false otherwise.
-   */
+  /// Sets whether the creature's sprite should be scaled with the entity dimensions.
+  ///
+  /// @param scaling true to scale the sprite, false otherwise.
   public void setScaling(boolean scaling) {
     this.scaling = scaling;
   }
@@ -271,10 +251,8 @@ public class Creature extends CombatEntity implements IMobileEntity {
     return sb.toString();
   }
 
-  /**
-   * Updates the animation controller for the creature. This method creates a new animation controller and adds it to the creature's controllers. If
-   * the game world environment is loaded, the new controller is attached to the game loop.
-   */
+  /// Updates the animation controller for the creature. This method creates a new animation controller and adds it to the creature's controllers. If
+  /// the game world environment is loaded, the new controller is attached to the game loop.
   protected void updateAnimationController() {
     IEntityAnimationController<? extends Creature> controller = this.createAnimationController();
     getControllers().addController(controller);
@@ -283,39 +261,31 @@ public class Creature extends CombatEntity implements IMobileEntity {
     }
   }
 
-  /**
-   * Creates a new animation controller for the creature.
-   *
-   * @return A new instance of {@link IEntityAnimationController} for the creature.
-   */
+  /// Creates a new animation controller for the creature.
+  ///
+  /// @return A new instance of [IEntityAnimationController] for the creature.
   protected IEntityAnimationController<? extends Creature> createAnimationController() {
     return new CreatureAnimationController<>(this, true);
   }
 
-  /**
-   * Creates a new movement controller for the creature.
-   *
-   * @return A new instance of {@link IMovementController} for the creature.
-   */
+  /// Creates a new movement controller for the creature.
+  ///
+  /// @return A new instance of [IMovementController] for the creature.
   protected IMovementController createMovementController() {
     return new MovementController<>(this);
   }
 
-  /**
-   * Gets all abilities currently registered on this creature.
-   *
-   * @return A collection of registered abilities.
-   */
+  /// Gets all abilities currently registered on this creature.
+  ///
+  /// @return A collection of registered abilities.
   public Collection<Ability> getAbilities() {
     return List.copyOf(this.abilities.values());
   }
 
-  /**
-   * Gets an ability registered on this creature by its name.
-   *
-   * @param name The name of the ability to retrieve.
-   * @return An {@link Optional} containing the ability if found, or empty otherwise.
-   */
+  /// Gets an ability registered on this creature by its name.
+  ///
+  /// @param name The name of the ability to retrieve.
+  /// @return An [Optional] containing the ability if found, or empty otherwise.
   public Optional<Ability> getAbility(String name) {
     if (name == null || name.isBlank()) {
       return Optional.empty();
@@ -323,13 +293,11 @@ public class Creature extends CombatEntity implements IMobileEntity {
     return Optional.ofNullable(this.abilities.get(name));
   }
 
-  /**
-   * Gets the first ability of the specified class registered on this creature.
-   *
-   * @param <T> The ability type.
-   * @param abilityClass The class of the ability.
-   * @return An {@link Optional} containing the ability if found, or empty otherwise.
-   */
+  /// Gets the first ability of the specified class registered on this creature.
+  ///
+  /// @param <T> The ability type.
+  /// @param abilityClass The class of the ability.
+  /// @return An [Optional] containing the ability if found, or empty otherwise.
   @SuppressWarnings("unchecked")
   public <T extends Ability> Optional<T> getAbility(Class<T> abilityClass) {
     if (abilityClass == null) {
@@ -343,31 +311,25 @@ public class Creature extends CombatEntity implements IMobileEntity {
     return Optional.empty();
   }
 
-  /**
-   * Checks whether this creature has an ability with the specified name.
-   *
-   * @param name The ability name.
-   * @return true if the ability exists, false otherwise.
-   */
+  /// Checks whether this creature has an ability with the specified name.
+  ///
+  /// @param name The ability name.
+  /// @return true if the ability exists, false otherwise.
   public boolean hasAbility(String name) {
     return name != null && this.abilities.containsKey(name);
   }
 
-  /**
-   * Checks whether this creature has an ability of the specified class.
-   *
-   * @param abilityClass The class of the ability.
-   * @return true if an ability of the class is registered, false otherwise.
-   */
+  /// Checks whether this creature has an ability of the specified class.
+  ///
+  /// @param abilityClass The class of the ability.
+  /// @return true if an ability of the class is registered, false otherwise.
   public boolean hasAbility(Class<? extends Ability> abilityClass) {
     return this.getAbility(abilityClass).isPresent();
   }
 
-  /**
-   * Adds an ability to this creature.
-   *
-   * @param ability The ability to register.
-   */
+  /// Adds an ability to this creature.
+  ///
+  /// @param ability The ability to register.
   public void addAbility(Ability ability) {
     if (ability == null) {
       return;
@@ -378,11 +340,9 @@ public class Creature extends CombatEntity implements IMobileEntity {
     this.abilities.put(key, ability);
   }
 
-  /**
-   * Removes an ability from this creature.
-   *
-   * @param ability The ability to remove.
-   */
+  /// Removes an ability from this creature.
+  ///
+  /// @param ability The ability to remove.
   public void removeAbility(Ability ability) {
     if (ability == null) {
       return;
@@ -390,11 +350,9 @@ public class Creature extends CombatEntity implements IMobileEntity {
     this.abilities.values().remove(ability);
   }
 
-  /**
-   * Removes an ability with the specified name from this creature.
-   *
-   * @param name The name of the ability to remove.
-   */
+  /// Removes an ability with the specified name from this creature.
+  ///
+  /// @param name The name of the ability to remove.
   public void removeAbility(String name) {
     if (name == null) {
       return;
@@ -402,73 +360,59 @@ public class Creature extends CombatEntity implements IMobileEntity {
     this.abilities.remove(name);
   }
 
-  /**
-   * Casts a registered ability by name.
-   *
-   * @param name The name of the ability to cast.
-   * @return The {@link AbilityExecution} if cast successfully, or null otherwise.
-   */
+  /// Casts a registered ability by name.
+  ///
+  /// @param name The name of the ability to cast.
+  /// @return The [AbilityExecution] if cast successfully, or null otherwise.
   public AbilityExecution cast(String name) {
     return this.getAbility(name).map(Ability::cast).orElse(null);
   }
 
-  /**
-   * Casts a registered ability of the specified class.
-   *
-   * @param <T> The ability type.
-   * @param abilityClass The class of the ability to cast.
-   * @return The {@link AbilityExecution} if cast successfully, or null otherwise.
-   */
+  /// Casts a registered ability of the specified class.
+  ///
+  /// @param <T> The ability type.
+  /// @param abilityClass The class of the ability to cast.
+  /// @return The [AbilityExecution] if cast successfully, or null otherwise.
   public <T extends Ability> AbilityExecution cast(Class<T> abilityClass) {
     return this.getAbility(abilityClass).map(Ability::cast).orElse(null);
   }
 
-  /**
-   * Checks whether a registered ability with the specified name can currently be cast.
-   *
-   * @param name The name of the ability.
-   * @return true if the ability exists and can be cast, false otherwise.
-   */
+  /// Checks whether a registered ability with the specified name can currently be cast.
+  ///
+  /// @param name The name of the ability.
+  /// @return true if the ability exists and can be cast, false otherwise.
   public boolean canCast(String name) {
     return this.getAbility(name).map(Ability::canCast).orElse(false);
   }
 
-  /**
-   * Checks whether a registered ability of the specified class can currently be cast.
-   *
-   * @param abilityClass The class of the ability.
-   * @return true if the ability exists and can be cast, false otherwise.
-   */
+  /// Checks whether a registered ability of the specified class can currently be cast.
+  ///
+  /// @param abilityClass The class of the ability.
+  /// @return true if the ability exists and can be cast, false otherwise.
   public boolean canCast(Class<? extends Ability> abilityClass) {
     return this.getAbility(abilityClass).map(Ability::canCast).orElse(false);
   }
 
-  /**
-   * Checks whether a registered ability with the specified name is currently on cooldown.
-   *
-   * @param name The name of the ability.
-   * @return true if the ability exists and is on cooldown, false otherwise.
-   */
+  /// Checks whether a registered ability with the specified name is currently on cooldown.
+  ///
+  /// @param name The name of the ability.
+  /// @return true if the ability exists and is on cooldown, false otherwise.
   public boolean isOnCooldown(String name) {
     return this.getAbility(name).map(Ability::isOnCooldown).orElse(false);
   }
 
-  /**
-   * Checks whether a registered ability of the specified class is currently on cooldown.
-   *
-   * @param abilityClass The class of the ability.
-   * @return true if the ability exists and is on cooldown, false otherwise.
-   */
+  /// Checks whether a registered ability of the specified class is currently on cooldown.
+  ///
+  /// @param abilityClass The class of the ability.
+  /// @return true if the ability exists and is on cooldown, false otherwise.
   public boolean isOnCooldown(Class<? extends Ability> abilityClass) {
     return this.getAbility(abilityClass).map(Ability::isOnCooldown).orElse(false);
   }
 
-  /**
-   * Begins fluently building a new {@link DynamicAbility} for this creature.
-   *
-   * @param name The name of the ability.
-   * @return An {@link AbilityBuilder} configured for this creature.
-   */
+  /// Begins fluently building a new [de.gurkenlabs.litiengine.abilities.DynamicAbility] for this creature.
+  ///
+  /// @param name The name of the ability.
+  /// @return An [AbilityBuilder] configured for this creature.
   public AbilityBuilder createAbility(String name) {
     return new AbilityBuilder(this, name);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EmitterInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EmitterInfo.java
@@ -11,95 +11,69 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation contains default values for the initialization of an emitter.
- */
+/// This annotation contains default values for the initialization of an emitter.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface EmitterInfo {
 
-  /**
-   * Indicates whether the emitter should be activated on initialization.
-   *
-   * @return true if the emitter should be activated on initialization, false otherwise.
-   */
+  /// Indicates whether the emitter should be activated on initialization.
+  ///
+  /// @return true if the emitter should be activated on initialization, false otherwise.
   boolean activateOnInit() default true;
 
-  /**
-   * Specifies the duration of the emitter.
-   *
-   * @return the duration of the emitter in milliseconds.
-   */
+  /// Specifies the duration of the emitter.
+  ///
+  /// @return the duration of the emitter in milliseconds.
   int duration() default EmitterAttributes.DEFAULT_DURATION;
 
-  /**
-   * Specifies the maximum number of particles the emitter can have.
-   *
-   * @return the maximum number of particles.
-   */
+  /// Specifies the maximum number of particles the emitter can have.
+  ///
+  /// @return the maximum number of particles.
   int maxParticles() default EmitterAttributes.DEFAULT_MAXPARTICLES;
 
-  /**
-   * Specifies the maximum time-to-live (TTL) of particles.
-   *
-   * @return the maximum TTL of particles in milliseconds.
-   */
+  /// Specifies the maximum time-to-live (TTL) of particles.
+  ///
+  /// @return the maximum TTL of particles in milliseconds.
   int particleMaxTTL() default EmitterAttributes.DEFAULT_MAX_PARTICLE_TTL;
 
-  /**
-   * Specifies the minimum time-to-live (TTL) of particles.
-   *
-   * @return the minimum TTL of particles in milliseconds.
-   */
+  /// Specifies the minimum time-to-live (TTL) of particles.
+  ///
+  /// @return the minimum TTL of particles in milliseconds.
   int particleMinTTL() default EmitterAttributes.DEFAULT_MIN_PARTICLE_TTL;
 
-  /**
-   * Specifies the update rate of particles.
-   *
-   * @return the update rate of particles in milliseconds.
-   */
+  /// Specifies the update rate of particles.
+  ///
+  /// @return the update rate of particles in milliseconds.
   int particleUpdateRate() default EmitterAttributes.DEFAULT_UPDATERATE;
 
-  /**
-   * Specifies the amount of particles to spawn.
-   *
-   * @return the amount of particles to spawn.
-   */
+  /// Specifies the amount of particles to spawn.
+  ///
+  /// @return the amount of particles to spawn.
   int spawnAmount() default EmitterAttributes.DEFAULT_SPAWNAMOUNT;
 
-  /**
-   * Specifies the rate at which particles are spawned.
-   *
-   * @return the spawn rate of particles in milliseconds.
-   */
+  /// Specifies the rate at which particles are spawned.
+  ///
+  /// @return the spawn rate of particles in milliseconds.
   int spawnRate() default EmitterAttributes.DEFAULT_SPAWNRATE;
 
-  /**
-   * Specifies the horizontal alignment of the emitter's origin.
-   *
-   * @return the horizontal alignment of the emitter's origin.
-   */
+  /// Specifies the horizontal alignment of the emitter's origin.
+  ///
+  /// @return the horizontal alignment of the emitter's origin.
   Align originAlign() default Align.CENTER;
 
-  /**
-   * Specifies the vertical alignment of the emitter's origin.
-   *
-   * @return the vertical alignment of the emitter's origin.
-   */
+  /// Specifies the vertical alignment of the emitter's origin.
+  ///
+  /// @return the vertical alignment of the emitter's origin.
   Valign originValign() default Valign.MIDDLE;
 
-  /**
-   * Specifies the required quality level for the emitter.
-   *
-   * @return the required quality level.
-   */
+  /// Specifies the required quality level for the emitter.
+  ///
+  /// @return the required quality level.
   Quality requiredQuality() default Quality.VERYLOW;
 
-  /**
-   * Specifies the type of particles emitted.
-   *
-   * @return the type of particles emitted.
-   */
+  /// Specifies the type of particles emitted.
+  ///
+  /// @return the type of particles emitted.
   ParticleType particleType() default ParticleType.RECTANGLE;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Entity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Entity.java
@@ -343,11 +343,9 @@ public abstract class Entity implements IEntity, EntityRenderListener, Tweenable
     setLocation(new Point2D.Double(x, y));
   }
 
-  /**
-   * Sets the map location.
-   *
-   * @param location the new map location
-   */
+  /// Sets the map location.
+  ///
+  /// @param location the new map location
   @Override
   public void setLocation(final Point2D location) {
     if (location.equals(getLocation())) {
@@ -358,9 +356,7 @@ public abstract class Entity implements IEntity, EntityRenderListener, Tweenable
     fireLocationChangedEvent();
   }
 
-  /**
-   * Sets an id which should only be filled when an entity gets added due to map information.
-   */
+  /// Sets an id which should only be filled when an entity gets added due to map information.
   @Override
   public void setMapId(final int mapId) {
     this.mapId = mapId;
@@ -611,9 +607,7 @@ public abstract class Entity implements IEntity, EntityRenderListener, Tweenable
     return event;
   }
 
-  /**
-   * Registers all default actions that are annotated with a {@code EntityAction} annotation.
-   */
+  /// Registers all default actions that are annotated with a `EntityAction` annotation.
   private void registerActions() {
     List<Method> methods =
       ReflectionUtilities.getMethodsAnnotatedWith(this.getClass(), Action.class);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityActionMap.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityActionMap.java
@@ -5,9 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Stores the named {@link EntityAction} instances registered on an {@link Entity}. Provides registration, lookup and removal by name.
- */
+/// Stores the named [EntityAction] instances registered on an [Entity]. Provides registration, lookup and removal by name.
 public final class EntityActionMap {
   private final Map<String, EntityAction> actions;
 
@@ -15,13 +13,11 @@ public final class EntityActionMap {
     this.actions = new ConcurrentHashMap<>();
   }
 
-  /**
-   * Registers a new {@link EntityAction} backed by the supplied runnable.
-   *
-   * @param name   the action name
-   * @param action the runnable executed when the action is triggered
-   * @return the registered action, or {@code null} if the parameters are invalid
-   */
+  /// Registers a new [EntityAction] backed by the supplied runnable.
+  ///
+  /// @param name   the action name
+  /// @param action the runnable executed when the action is triggered
+  /// @return the registered action, or `null` if the parameters are invalid
   public EntityAction register(String name, Runnable action) {
     if (name == null || name.isEmpty() || action == null) {
       return null;
@@ -32,11 +28,9 @@ public final class EntityActionMap {
     return entityAction;
   }
 
-  /**
-   * Registers the supplied {@link EntityAction}.
-   *
-   * @param action the action to register; ignored if {@code null}
-   */
+  /// Registers the supplied [EntityAction].
+  ///
+  /// @param action the action to register; ignored if `null`
   public void register(EntityAction action) {
     if (action == null) {
       return;
@@ -45,11 +39,9 @@ public final class EntityActionMap {
     this.actions.put(action.getName(), action);
   }
 
-  /**
-   * Unregisters the supplied {@link EntityAction}.
-   *
-   * @param action the action to unregister; ignored if {@code null}
-   */
+  /// Unregisters the supplied [EntityAction].
+  ///
+  /// @param action the action to unregister; ignored if `null`
   public void unregister(EntityAction action) {
     if (action == null) {
       return;
@@ -58,11 +50,9 @@ public final class EntityActionMap {
     this.unregister(action.getName());
   }
 
-  /**
-   * Unregisters the {@link EntityAction} with the supplied name.
-   *
-   * @param actionName the action name; ignored if blank
-   */
+  /// Unregisters the [EntityAction] with the supplied name.
+  ///
+  /// @param actionName the action name; ignored if blank
   public void unregister(String actionName) {
     if (actionName == null || actionName.isEmpty()) {
       return;
@@ -71,31 +61,25 @@ public final class EntityActionMap {
     this.actions.remove(actionName);
   }
 
-  /**
-   * Returns an unmodifiable view of all registered actions.
-   *
-   * @return the registered actions
-   */
+  /// Returns an unmodifiable view of all registered actions.
+  ///
+  /// @return the registered actions
   public Collection<EntityAction> getActions() {
     return Collections.unmodifiableCollection(this.actions.values());
   }
 
-  /**
-   * Returns the action registered under the supplied name.
-   *
-   * @param actionName the action name
-   * @return the action, or {@code null} if not found
-   */
+  /// Returns the action registered under the supplied name.
+  ///
+  /// @param actionName the action name
+  /// @return the action, or `null` if not found
   public EntityAction get(String actionName) {
     return this.actions.getOrDefault(actionName, null);
   }
 
-  /**
-   * Returns whether an action with the supplied name is registered.
-   *
-   * @param actionName the action name
-   * @return {@code true} if registered
-   */
+  /// Returns whether an action with the supplied name is registered.
+  ///
+  /// @param actionName the action name
+  /// @return `true` if registered
   public boolean exists(String actionName) {
     return this.actions.containsKey(actionName);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityControllers.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityControllers.java
@@ -5,10 +5,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * This class holds all controllers for the entities in the game. It is used as a single hub to access and manage all
- * the controllers.
- */
+/// This class holds all controllers for the entities in the game. It is used as a single hub to access and manage all
+/// the controllers.
 public final class EntityControllers {
   private final Map<Class<? extends IEntityController>, IEntityController> controllers;
   private IEntityAnimationController<?> animationController;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityDistanceComparator.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityDistanceComparator.java
@@ -2,12 +2,10 @@ package de.gurkenlabs.litiengine.entities;
 
 public class EntityDistanceComparator extends RelativeEntityComparator {
 
-  /**
-   * Initializes a new instance of the {@code EntityDistanceComparator} class.
-   *
-   * @param relativeEntity
-   *          The entity that is used as reference for distance comparison.
-   */
+  /// Initializes a new instance of the `EntityDistanceComparator` class.
+  ///
+  /// @param relativeEntity
+  /// The entity that is used as reference for distance comparison.
   public EntityDistanceComparator(final IEntity relativeEntity) {
     super(relativeEntity);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityHitEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityHitEvent.java
@@ -5,25 +5,19 @@ import de.gurkenlabs.litiengine.abilities.Ability;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * Event dispatched whenever an {@link ICombatEntity} is hit. Carries the executor of the hit, the hit entity, the optional triggering ability, the
- * dealt damage and the resulting kill flag.
- */
+/// Event dispatched whenever an [ICombatEntity] is hit. Carries the executor of the hit, the hit entity, the optional triggering ability, the
+/// dealt damage and the resulting kill flag.
 public class EntityHitEvent extends EventObject {
   @Serial private static final long serialVersionUID = 1582822545149624579L;
-  /**
-   * The dealt damage.
-   */
+  /// The dealt damage.
   private final int damage;
 
-  /**
-   * Whether the hit killed the target.
-   */
+  /// Whether the hit killed the target.
   private final boolean kill;
   private final transient ICombatEntity executor;
   private final transient ICombatEntity hitEntity;
   private final transient Ability ability;
-  /** Game-time timestamp at which the event was dispatched. */
+  /// Game-time timestamp at which the event was dispatched.
   private final long time;
 
   EntityHitEvent(final ICombatEntity hitEntity, final Ability ability, final int damage, final boolean kill) {
@@ -36,56 +30,44 @@ public class EntityHitEvent extends EventObject {
     this.time = Game.time().now();
   }
 
-  /**
-   * Gets the damage dealt by the hit.
-   *
-   * @return the damage
-   */
+  /// Gets the damage dealt by the hit.
+  ///
+  /// @return the damage
   public int getDamage() {
     return this.damage;
   }
 
-  /**
-   * Gets the entity that caused the hit (the executor of the triggering ability).
-   *
-   * @return the executor, or {@code null} if no ability triggered the hit
-   */
+  /// Gets the entity that caused the hit (the executor of the triggering ability).
+  ///
+  /// @return the executor, or `null` if no ability triggered the hit
   public ICombatEntity getExecutor() {
     return this.executor;
   }
 
-  /**
-   * Gets the entity that was hit.
-   *
-   * @return the hit entity
-   */
+  /// Gets the entity that was hit.
+  ///
+  /// @return the hit entity
   public ICombatEntity getHitEntity() {
     return this.hitEntity;
   }
 
-  /**
-   * Returns whether the hit killed the target.
-   *
-   * @return {@code true} if the target was killed
-   */
+  /// Returns whether the hit killed the target.
+  ///
+  /// @return `true` if the target was killed
   public boolean wasKilled() {
     return this.kill;
   }
 
-  /**
-   * Gets the ability that triggered the hit, if any.
-   *
-   * @return the triggering ability, or {@code null}
-   */
+  /// Gets the ability that triggered the hit, if any.
+  ///
+  /// @return the triggering ability, or `null`
   public Ability getAbility() {
     return this.ability;
   }
 
-  /**
-   * Gets the game-time timestamp at which the event was dispatched.
-   *
-   * @return the timestamp
-   */
+  /// Gets the game-time timestamp at which the event was dispatched.
+  ///
+  /// @return the timestamp
   public long getTime() {
     return time;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityInfo.java
@@ -7,53 +7,41 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation contains default values for an entity implementation.
- * It can be used to specify default properties such as height, width, render type,
- * custom map object type, and whether the entity should be rendered with a layer.
- */
+/// This annotation contains default values for an entity implementation.
+/// It can be used to specify default properties such as height, width, render type,
+/// custom map object type, and whether the entity should be rendered with a layer.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface EntityInfo {
 
-  /**
-   * Specifies the default height of the entity.
-   * Defaults to 32.
-   *
-   * @return the default height of the entity
-   */
+  /// Specifies the default height of the entity.
+  /// Defaults to 32.
+  ///
+  /// @return the default height of the entity
   float height() default 32;
 
-  /**
-   * Specifies the default render type of the entity.
-   *  Defaults to {@link RenderType#NORMAL}.
-   *
-   * @return the default render type of the entity
-   */
+  /// Specifies the default render type of the entity.
+  /// Defaults to [RenderType#NORMAL].
+  ///
+  /// @return the default render type of the entity
   RenderType renderType() default RenderType.NORMAL;
 
-  /**
-   * Specifies the default width of the entity.
-   * Defaults to 32.
-   *
-   * @return the default width of the entity
-   */
+  /// Specifies the default width of the entity.
+  /// Defaults to 32.
+  ///
+  /// @return the default width of the entity
   float width() default 32;
 
-  /**
-   * Specifies a custom map object type for the entity.
-   * Defaults to an empty string.
-   *
-   * @return the custom map object type of the entity
-   */
+  /// Specifies a custom map object type for the entity.
+  /// Defaults to an empty string.
+  ///
+  /// @return the custom map object type of the entity
   String customMapObjectType() default "";
 
-  /**
-   * Specifies whether the entity should be rendered with a layer.
-   * Defaults to false.
-   *
-   * @return true if the entity should be rendered with a layer, false otherwise
-   */
+  /// Specifies whether the entity should be rendered with a layer.
+  /// Defaults to false.
+  ///
+  /// @return true if the entity should be rendered with a layer, false otherwise
   boolean renderWithLayer() default false;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityMessageEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityMessageEvent.java
@@ -3,11 +3,9 @@ package de.gurkenlabs.litiengine.entities;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * This implementation is used for events that contain information about a received message.
- *
- * @see IEntity#sendMessage(Object, String)
- */
+/// This implementation is used for events that contain information about a received message.
+///
+/// @see IEntity#sendMessage(Object, String)
 public class EntityMessageEvent extends EventObject {
   @Serial private static final long serialVersionUID = 5131621546037429725L;
   private final transient IEntity entity;
@@ -19,20 +17,16 @@ public class EntityMessageEvent extends EventObject {
     this.message = message;
   }
 
-  /**
-   * Gets the entity that received the message.
-   *
-   * @return The entity that received the message.
-   */
+  /// Gets the entity that received the message.
+  ///
+  /// @return The entity that received the message.
   public IEntity getEntity() {
     return this.entity;
   }
 
-  /**
-   * Gets the message that was received.
-   *
-   * @return The message.
-   */
+  /// Gets the message that was received.
+  ///
+  /// @return The message.
   public String getMessage() {
     return this.message;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityMessageListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityMessageListener.java
@@ -2,15 +2,13 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/** This listener provides callbacks for when an {@code Entity} received a message. */
+/// This listener provides callbacks for when an `Entity` received a message.
 @FunctionalInterface
 public interface EntityMessageListener extends EventListener {
 
-  /**
-   * This method is called whenever a message is received by {@link IEntity#sendMessage(Object, String)}.
-   *
-   * @param event
-   *          The event data that contains information about the received message and sender.
-   */
+  /// This method is called whenever a message is received by [String)][IEntity#sendMessage(Object,].
+  ///
+  /// @param event
+  /// The event data that contains information about the received message and sender.
   void messageReceived(EntityMessageEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityMovedEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityMovedEvent.java
@@ -3,10 +3,8 @@ package de.gurkenlabs.litiengine.entities;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * Event dispatched whenever an {@link IMobileEntity} moves. Carries the moved entity along with the X / Y delta and the resulting travelled
- * distance.
- */
+/// Event dispatched whenever an [IMobileEntity] moves. Carries the moved entity along with the X / Y delta and the resulting travelled
+/// distance.
 public class EntityMovedEvent extends EventObject {
   @Serial private static final long serialVersionUID = 2931711179495514204L;
   private final transient IMobileEntity entity;
@@ -14,13 +12,11 @@ public class EntityMovedEvent extends EventObject {
   private final double deltaY;
   private final double distance;
 
-  /**
-   * Constructs a new {@code EntityMovedEvent}.
-   *
-   * @param entity the moved entity
-   * @param deltaX the X delta of the movement
-   * @param deltaY the Y delta of the movement
-   */
+  /// Constructs a new `EntityMovedEvent`.
+  ///
+  /// @param entity the moved entity
+  /// @param deltaX the X delta of the movement
+  /// @param deltaY the Y delta of the movement
   public EntityMovedEvent(IMobileEntity entity, double deltaX, double deltaY) {
     super(entity);
     this.entity = entity;
@@ -29,38 +25,30 @@ public class EntityMovedEvent extends EventObject {
     this.distance = Math.sqrt(Math.pow(this.deltaX, 2) + Math.pow(this.deltaY, 2));
   }
 
-  /**
-   * Gets the entity that moved.
-   *
-   * @return the moved entity
-   */
+  /// Gets the entity that moved.
+  ///
+  /// @return the moved entity
   public IMobileEntity getEntity() {
     return this.entity;
   }
 
-  /**
-   * Gets the X delta of the movement.
-   *
-   * @return the X delta
-   */
+  /// Gets the X delta of the movement.
+  ///
+  /// @return the X delta
   public double getDeltaX() {
     return this.deltaX;
   }
 
-  /**
-   * Gets the Y delta of the movement.
-   *
-   * @return the Y delta
-   */
+  /// Gets the Y delta of the movement.
+  ///
+  /// @return the Y delta
   public double getDeltaY() {
     return this.deltaY;
   }
 
-  /**
-   * Gets the travelled Euclidean distance.
-   *
-   * @return the distance
-   */
+  /// Gets the travelled Euclidean distance.
+  ///
+  /// @return the distance
   public double getDistance() {
     return this.distance;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityPivot.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityPivot.java
@@ -7,10 +7,8 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.Valign;
 import java.awt.geom.Point2D;
 
-/**
- * The {@code EntityPivot} class represents a pivot point for an entity, which can be used to determine the entity's position relative to a specific
- * alignment or offset. This is particularly useful for positioning entities in the game world with precision.
- */
+/// The `EntityPivot` class represents a pivot point for an entity, which can be used to determine the entity's position relative to a specific
+/// alignment or offset. This is particularly useful for positioning entities in the game world with precision.
 public class EntityPivot {
   private final IEntity entity;
   private final EntityPivotType type;
@@ -18,16 +16,14 @@ public class EntityPivot {
   private double offsetX;
   private double offsetY;
 
-  /**
-   * Constructs a new {@code EntityPivot} with a specified entity, pivot type, and offsets. This constructor allows for the creation of a pivot based
-   * on a predefined pivot type, which can include the center of the entity's collision box or an offset from its current position.
-   *
-   * @param entity  The entity to which this pivot is associated.
-   * @param type    The type of pivot, determining how the pivot point is calculated.
-   * @param offsetX The horizontal offset from the calculated pivot point.
-   * @param offsetY The vertical offset from the calculated pivot point.
-   * @throws IllegalArgumentException If the pivot type is COLLISIONBOX_CENTER but the entity is not a collision entity.
-   */
+  /// Constructs a new `EntityPivot` with a specified entity, pivot type, and offsets. This constructor allows for the creation of a pivot based
+  /// on a predefined pivot type, which can include the center of the entity's collision box or an offset from its current position.
+  ///
+  /// @param entity  The entity to which this pivot is associated.
+  /// @param type    The type of pivot, determining how the pivot point is calculated.
+  /// @param offsetX The horizontal offset from the calculated pivot point.
+  /// @param offsetY The vertical offset from the calculated pivot point.
+  /// @throws IllegalArgumentException If the pivot type is COLLISIONBOX_CENTER but the entity is not a collision entity.
   public EntityPivot(IEntity entity, EntityPivotType type, double offsetX, double offsetY) {
     this.entity = entity;
     this.type = type;
@@ -39,73 +35,59 @@ public class EntityPivot {
     }
   }
 
-  /**
-   * Constructs a new {@code EntityPivot} with a specified entity and alignment/vertical alignment, but without specific offsets. This constructor is
-   * a convenience method that defaults the offsets to 0, effectively placing the pivot point directly at the specified alignment within the entity.
-   * It delegates to the primary constructor with offset parameters set to 0.
-   *
-   * @param entity The entity to which this pivot is associated.
-   * @param align  The horizontal alignment for the pivot, determining its horizontal position relative to the entity.
-   * @param valign The vertical alignment for the pivot, determining its vertical position relative to the entity.
-   */
+  /// Constructs a new `EntityPivot` with a specified entity and alignment/vertical alignment, but without specific offsets. This constructor is
+  /// a convenience method that defaults the offsets to 0, effectively placing the pivot point directly at the specified alignment within the entity.
+  /// It delegates to the primary constructor with offset parameters set to 0.
+  ///
+  /// @param entity The entity to which this pivot is associated.
+  /// @param align  The horizontal alignment for the pivot, determining its horizontal position relative to the entity.
+  /// @param valign The vertical alignment for the pivot, determining its vertical position relative to the entity.
   public EntityPivot(IEntity entity, Align align, Valign valign) {
     this(entity, align, valign, 0, 0);
   }
 
-  /**
-   * Constructs a new {@code EntityPivot} with a specified entity and alignment/vertical alignment. This constructor is a convenience method that
-   * allows for the creation of a pivot based on alignment parameters, which are then converted into offset values.
-   *
-   * @param entity The entity to which this pivot is associated.
-   * @param align  The horizontal alignment for the pivot.
-   * @param valign The vertical alignment for the pivot.
-   */
+  /// Constructs a new `EntityPivot` with a specified entity and alignment/vertical alignment. This constructor is a convenience method that
+  /// allows for the creation of a pivot based on alignment parameters, which are then converted into offset values.
+  ///
+  /// @param entity The entity to which this pivot is associated.
+  /// @param align  The horizontal alignment for the pivot.
+  /// @param valign The vertical alignment for the pivot.
   public EntityPivot(IEntity entity, Align align, Valign valign, double offsetX, double offsetY) {
     this(entity, EntityPivotType.LOCATION, align.getValue(entity.getWidth()) + offsetX, valign.getValue(entity.getHeight()) + offsetY);
   }
 
-  /**
-   * Gets the associated entity for this pivot.
-   *
-   * @return The entity associated with this pivot.
-   */
+  /// Gets the associated entity for this pivot.
+  ///
+  /// @return The entity associated with this pivot.
   public IEntity getEntity() {
     return this.entity;
   }
 
-  /**
-   * Gets the type of pivot.
-   *
-   * @return The pivot type.
-   */
+  /// Gets the type of pivot.
+  ///
+  /// @return The pivot type.
   public EntityPivotType getType() {
     return this.type;
   }
 
-  /**
-   * Gets the horizontal offset for this pivot.
-   *
-   * @return The horizontal offset.
-   */
+  /// Gets the horizontal offset for this pivot.
+  ///
+  /// @return The horizontal offset.
   public double getOffsetX() {
     return this.offsetX;
   }
 
-  /**
-   * Gets the vertical offset for this pivot.
-   *
-   * @return The vertical offset.
-   */
+  /// Gets the vertical offset for this pivot.
+  ///
+  /// @return The vertical offset.
   public double getOffsetY() {
     return this.offsetY;
   }
 
-  /**
-   * Calculates and returns the pivot point based on the pivot type and offsets. This method determines the exact location of the pivot point, taking
-   * into account the entity's current position, size, and the specified offsets.
-   *
-   * @return The calculated pivot point as a {@code Point2D} object.
-   */
+  /// Calculates and returns the pivot point based on the pivot type and offsets. This method determines the exact location of the pivot point, taking
+  /// into account the entity's current position, size, and the specified offsets.
+  ///
+  /// @return The calculated pivot point as a `Point2D` object.
   public Point2D getPoint() {
     EntityPivotType pivot = getType();
     return switch (pivot) {
@@ -119,29 +101,23 @@ public class EntityPivot {
     };
   }
 
-  /**
-   * Sets the horizontal offset for this pivot.
-   *
-   * @param offsetX The new horizontal offset.
-   */
+  /// Sets the horizontal offset for this pivot.
+  ///
+  /// @param offsetX The new horizontal offset.
   public void setOffsetX(double offsetX) {
     this.offsetX = offsetX;
   }
 
-  /**
-   * Sets the vertical offset for this pivot.
-   *
-   * @param offsetY The new vertical offset.
-   */
+  /// Sets the vertical offset for this pivot.
+  ///
+  /// @param offsetY The new vertical offset.
   public void setOffsetY(double offsetY) {
     this.offsetY = offsetY;
   }
 
-  /**
-   * Sets both the horizontal and vertical offsets for this pivot.
-   *
-   * @param offset A {@code Point2D} representing the new offsets.
-   */
+  /// Sets both the horizontal and vertical offsets for this pivot.
+  ///
+  /// @param offset A `Point2D` representing the new offsets.
   public void setOffset(Point2D offset) {
     this.setOffsetX(offset.getX());
     this.setOffsetY(offset.getY());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityPivotType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityPivotType.java
@@ -1,29 +1,19 @@
 package de.gurkenlabs.litiengine.entities;
 
-/**
- * The {@code EntityPivotType} enum defines the types of pivot points that can be used for entities within the game. A pivot point determines the
- * reference point for positioning and rotating entities.
- */
+/// The `EntityPivotType` enum defines the types of pivot points that can be used for entities within the game. A pivot point determines the
+/// reference point for positioning and rotating entities.
 public enum EntityPivotType {
-  /**
-   * Represents the center of the entity's collision box. This pivot type is useful for entities where interactions or collisions are centered around
-   * the entity's collision box rather than its entity dimensions.
-   */
+  /// Represents the center of the entity's collision box. This pivot type is useful for entities where interactions or collisions are centered around
+  /// the entity's collision box rather than its entity dimensions.
   COLLISIONBOX_CENTER,
-  /**
-   * Represents the center of the entity's dimensions. This is commonly used for graphical alignment, ensuring that rotations or scaling operations
-   * are centered on the visual representation of the entity.
-   */
+  /// Represents the center of the entity's dimensions. This is commonly used for graphical alignment, ensuring that rotations or scaling operations
+  /// are centered on the visual representation of the entity.
   DIMENSION_CENTER,
-  /**
-   * Represents the entity's current location, defined as its top left corner. This pivot type is typically used for simple positioning where the
-   * reference object has the same dimensions as the reference entity.
-   */
+  /// Represents the entity's current location, defined as its top left corner. This pivot type is typically used for simple positioning where the
+  /// reference object has the same dimensions as the reference entity.
   LOCATION,
-  /**
-   * Represents a distribution or spread of entities or effects over the entire bounding box of the reference entity. This pivot type can be used for
-   * scenarios where an entity's effect or presence needs to be distributed across an area, rather than focused on a single point. For example, it
-   * could be used for area-of-effect spells, explosions, or spreading Props or Creatures in a game environment.
-   */
+  /// Represents a distribution or spread of entities or effects over the entire bounding box of the reference entity. This pivot type can be used for
+  /// scenarios where an entity's effect or presence needs to be distributed across an area, rather than focused on a single point. For example, it
+  /// could be used for area-of-effect spells, explosions, or spreading Props or Creatures in a game environment.
   SPREAD
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityQuery.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityQuery.java
@@ -12,51 +12,103 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /// A reusable, fluent query for selecting entities without game-specific collection boilerplate.
+///
+/// Filters are cumulative. Calling [#sorted(Comparator)] or [#nearestTo(Point2D)] replaces any
+/// previously selected ordering. Terminal operations evaluate the current contents of the source
+/// collection; [#list()] returns an unmodifiable snapshot.
+///
+/// @param <T> The type of value selected by this query.
+/// @see Environment#query(Class)
 public final class EntityQuery<T> {
   private final Collection<T> source;
   private Predicate<T> predicate = entity -> true;
   private Comparator<T> comparator;
 
+  /// Creates a query over a collection.
+  ///
+  /// @param source The live source collection, or `null` for an empty query.
   public EntityQuery(Collection<T> source) {
     this.source = source == null ? List.of() : source;
   }
 
+  /// Adds a predicate to the filters already configured on this query.
+  ///
+  /// @param filter The predicate to add.
+  /// @return This query.
+  /// @throws NullPointerException if `filter` is `null`.
   public EntityQuery<T> matching(Predicate<T> filter) {
     this.predicate = this.predicate.and(Objects.requireNonNull(filter));
     return this;
   }
 
+  /// Keeps entities that have the specified tag.
+  ///
+  /// @param tag The tag to match.
+  /// @return This query.
   public EntityQuery<T> tagged(String tag) {
     return this.matching(entity -> entity instanceof IEntity candidate && candidate.hasTag(tag));
   }
 
+  /// Keeps entities whose name equals the specified name.
+  ///
+  /// @param name The name to match; may be `null`.
+  /// @return This query.
   public EntityQuery<T> named(String name) {
     return this.matching(entity -> entity instanceof IEntity candidate && Objects.equals(candidate.getName(), name));
   }
 
+  /// Excludes dead combat entities while retaining values that are not combat entities.
+  ///
+  /// @return This query.
   public EntityQuery<T> alive() {
     return this.matching(entity -> !(entity instanceof ICombatEntity combat) || !combat.isDead());
   }
 
+  /// Keeps only dead combat entities.
+  ///
+  /// @return This query.
   public EntityQuery<T> dead() {
     return this.matching(entity -> entity instanceof ICombatEntity combat && combat.isDead());
   }
 
+  /// Keeps only combat entities assigned to a team.
+  ///
+  /// @param team The team identifier to match.
+  /// @return This query.
   public EntityQuery<T> team(int team) {
     return this.matching(entity -> entity instanceof ICombatEntity combat && combat.getTeam() == team);
   }
 
+  /// Keeps combat entities whose team differs from the reference entity's team.
+  ///
+  /// @param entity The entity whose team is considered friendly.
+  /// @return This query.
+  /// @throws NullPointerException if `entity` is `null`.
   public EntityQuery<T> enemyOf(ICombatEntity entity) {
     Objects.requireNonNull(entity);
     return this.matching(candidate -> candidate instanceof ICombatEntity combat && combat.getTeam() != entity.getTeam());
   }
 
+  /// Keeps entities whose center is at most the specified distance from a point.
+  ///
+  /// @param point The center of the search area in map coordinates.
+  /// @param distance The inclusive maximum distance in map units.
+  /// @return This query.
+  /// @throws NullPointerException if `point` is `null`.
+  /// @throws IllegalArgumentException if `distance` is negative.
   public EntityQuery<T> within(Point2D point, double distance) {
     Objects.requireNonNull(point);
     if (distance < 0) throw new IllegalArgumentException("Distance must not be negative.");
     return this.matching(entity -> entity instanceof IEntity candidate && candidate.getCenter().distance(point) <= distance);
   }
 
+  /// Orders entities by increasing distance from a point.
+  ///
+  /// Values that are not entities sort after all entities.
+  ///
+  /// @param point The reference point in map coordinates.
+  /// @return This query.
+  /// @throws NullPointerException if `point` is `null`.
   public EntityQuery<T> nearestTo(Point2D point) {
     Objects.requireNonNull(point);
     this.comparator = Comparator.comparingDouble(entity -> entity instanceof IEntity candidate
@@ -64,17 +116,28 @@ public final class EntityQuery<T> {
     return this;
   }
 
+  /// Replaces the current ordering with a comparator.
+  ///
+  /// @param order The comparator to use.
+  /// @return This query.
+  /// @throws NullPointerException if `order` is `null`.
   public EntityQuery<T> sorted(Comparator<T> order) {
     this.comparator = Objects.requireNonNull(order);
     return this;
   }
 
+  /// Evaluates this query and returns its matching values.
+  ///
+  /// @return An unmodifiable result list in the configured order.
   public List<T> list() {
     Stream<T> stream = this.source.stream().filter(this.predicate);
     if (this.comparator != null) stream = stream.sorted(this.comparator);
     return stream.toList();
   }
 
+  /// Finds the first matching value in configured or source order.
+  ///
+  /// @return The first match, or an empty optional when nothing matches.
   public Optional<T> first() {
     if (this.comparator != null) {
       return this.list().stream().findFirst();
@@ -82,14 +145,27 @@ public final class EntityQuery<T> {
     return this.source.stream().filter(this.predicate).findFirst();
   }
 
+  /// Counts matching values without applying the configured ordering.
+  ///
+  /// @return The number of matching values.
   public long count() {
     return this.source.stream().filter(this.predicate).count();
   }
 
+  /// Tests whether this query has no matching values.
+  ///
+  /// @return `true` when no value matches.
   public boolean isEmpty() {
     return !this.source.stream().anyMatch(this.predicate);
   }
 
+  /// Creates a query over all entities of a type in an environment.
+  ///
+  /// @param environment The environment to query.
+  /// @param type The requested entity type.
+  /// @param <T> The requested entity type.
+  /// @return A query over the environment's matching entities.
+  /// @throws NullPointerException if `environment` or `type` is `null`.
   public static <T> EntityQuery<T> in(Environment environment, Class<? extends T> type) {
     Objects.requireNonNull(environment);
     Objects.requireNonNull(type);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityQuery.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityQuery.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-/** A reusable, fluent query for selecting entities without game-specific collection boilerplate. */
+/// A reusable, fluent query for selecting entities without game-specific collection boilerplate.
 public final class EntityQuery<T> {
   private final Collection<T> source;
   private Predicate<T> predicate = entity -> true;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityRenderEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityRenderEvent.java
@@ -5,11 +5,9 @@ import java.awt.Graphics2D;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * This {@code EventObject} contains data about the rendering process of an entity.
- *
- * @see RenderEngine#renderEntity(Graphics2D, IEntity)
- */
+/// This `EventObject` contains data about the rendering process of an entity.
+///
+/// @see RenderEngine#renderEntity(Graphics2D, IEntity)
 public class EntityRenderEvent extends EventObject {
   @Serial private static final long serialVersionUID = 6397005859146712222L;
 
@@ -23,20 +21,16 @@ public class EntityRenderEvent extends EventObject {
     this.entity = entity;
   }
 
-  /**
-   * Gets the graphics object on which the entity is rendered.
-   *
-   * @return The graphics object on which the entity is rendered.
-   */
+  /// Gets the graphics object on which the entity is rendered.
+  ///
+  /// @return The graphics object on which the entity is rendered.
   public Graphics2D getGraphics() {
     return this.graphics;
   }
 
-  /**
-   * Get the entity involved with the rendering process.
-   *
-   * @return The entity involved with the rendering process.
-   */
+  /// Get the entity involved with the rendering process.
+  ///
+  /// @return The entity involved with the rendering process.
   public IEntity getEntity() {
     return this.entity;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityRenderListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityRenderListener.java
@@ -2,30 +2,24 @@ package de.gurkenlabs.litiengine.entities;
 
 import de.gurkenlabs.litiengine.graphics.RenderEngine;
 
-/**
- * This listener interface is used for receiving events during an entity's rendering process from the game's
- * {@code RenderEngine}.
- *
- * @see RenderEngine#renderEntity(java.awt.Graphics2D, IEntity)
- */
+/// This listener interface is used for receiving events during an entity's rendering process from the game's
+/// `RenderEngine`.
+///
+/// @see RenderEngine#renderEntity(java.awt.Graphics2D, IEntity)
 public interface EntityRenderListener extends EntityRenderedListener {
-  /**
-   * This method gets called after all rendering checks have successfully passed and right before the entity is about to
-   * be rendered.
-   *
-   * @param event
-   *          The event that contains the render data.
-   */
+  /// This method gets called after all rendering checks have successfully passed and right before the entity is about to
+  /// be rendered.
+  ///
+  /// @param event
+  /// The event that contains the render data.
   default void rendering(EntityRenderEvent event) {}
 
-  /**
-   * This method gets called before an {@code Entity} is about to be rendered. Returning false prevents the rendering of
-   * the specified entity.
-   *
-   * @param entity
-   *          The entity to be rendered.
-   * @return True if the entity should be rendered; otherwise false.
-   */
+  /// This method gets called before an `Entity` is about to be rendered. Returning false prevents the rendering of
+  /// the specified entity.
+  ///
+  /// @param entity
+  /// The entity to be rendered.
+  /// @return True if the entity should be rendered; otherwise false.
   default boolean canRender(IEntity entity) {
     return true;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityRenderedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityRenderedListener.java
@@ -3,19 +3,15 @@ package de.gurkenlabs.litiengine.entities;
 import de.gurkenlabs.litiengine.graphics.RenderEngine;
 import java.util.EventListener;
 
-/**
- * This listener interface is used for receiving events after an entity was rendered with the game's
- * {@code RenderEngine}.
- *
- * @see RenderEngine#renderEntity(java.awt.Graphics2D, IEntity)
- */
+/// This listener interface is used for receiving events after an entity was rendered with the game's
+/// `RenderEngine`.
+///
+/// @see RenderEngine#renderEntity(java.awt.Graphics2D, IEntity)
 @FunctionalInterface
 public interface EntityRenderedListener extends EventListener {
-  /**
-   * This method gets called after an entity was rendered.
-   *
-   * @param event
-   *          The event that contains the render data.
-   */
+  /// This method gets called after an entity was rendered.
+  ///
+  /// @param event
+  /// The event that contains the render data.
   void rendered(EntityRenderEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntitySpawnedEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntitySpawnedEvent.java
@@ -3,41 +3,33 @@ package de.gurkenlabs.litiengine.entities;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * Represents an event that is triggered when an entity is spawned.
- */
+/// Represents an event that is triggered when an entity is spawned.
 public class EntitySpawnedEvent extends EventObject {
 
   @Serial private static final long serialVersionUID = 3168131857377255247L;
   private final transient Spawnpoint spawnpoint;
   private final transient IEntity spawnedEntity;
 
-  /**
-   * Constructs a new EntitySpawnedEvent.
-   *
-   * @param source The spawnpoint that triggered this event.
-   * @param entity The entity that was spawned.
-   */
+  /// Constructs a new EntitySpawnedEvent.
+  ///
+  /// @param source The spawnpoint that triggered this event.
+  /// @param entity The entity that was spawned.
   EntitySpawnedEvent(Spawnpoint source, IEntity entity) {
     super(source);
     this.spawnpoint = source;
     this.spawnedEntity = entity;
   }
 
-  /**
-   * Gets the spawnpoint that triggered this event.
-   *
-   * @return The spawnpoint that triggered this event.
-   */
+  /// Gets the spawnpoint that triggered this event.
+  ///
+  /// @return The spawnpoint that triggered this event.
   public Spawnpoint getSpawnpoint() {
     return this.spawnpoint;
   }
 
-  /**
-   * Gets the entity that was spawned.
-   *
-   * @return The entity that was spawned.
-   */
+  /// Gets the entity that was spawned.
+  ///
+  /// @return The entity that was spawned.
   public IEntity getSpawnedEntity() {
     return this.spawnedEntity;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityTransformListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityTransformListener.java
@@ -2,29 +2,25 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/** This listener provides callbacks for when an {@code Entity} was moved or changed its size. */
+/// This listener provides callbacks for when an `Entity` was moved or changed its size.
 public interface EntityTransformListener extends EventListener {
 
-  /**
-   * This method is called whenever the location of an {@code IEntity} was changed.
-   *
-   * @param entity
-   *          The entity that changed its location.
-   * @see IEntity#setLocation(java.awt.geom.Point2D)
-   * @see IEntity#setLocation(double, double)
-   * @see IEntity#setX(double)
-   * @see IEntity#setY(double)
-   */
+  /// This method is called whenever the location of an `IEntity` was changed.
+  ///
+  /// @param entity
+  /// The entity that changed its location.
+  /// @see IEntity#setLocation(java.awt.geom.Point2D)
+  /// @see IEntity#setLocation(double, double)
+  /// @see IEntity#setX(double)
+  /// @see IEntity#setY(double)
   default void locationChanged(IEntity entity) {}
 
-  /**
-   * This method is called whenever the size of an {@code IEntity} was changed.
-   *
-   * @param entity
-   *          The entity that changed its size.
-   * @see IEntity#setSize(double, double)
-   * @see IEntity#setHeight(double)
-   * @see IEntity#setWidth(double)
-   */
+  /// This method is called whenever the size of an `IEntity` was changed.
+  ///
+  /// @param entity
+  /// The entity that changed its size.
+  /// @see IEntity#setSize(double, double)
+  /// @see IEntity#setHeight(double)
+  /// @see IEntity#setWidth(double)
   default void sizeChanged(IEntity entity) {}
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityYComparator.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/EntityYComparator.java
@@ -2,14 +2,12 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.Comparator;
 
-/**
- * This {@code Comparator} implementation sorts entities by the max y-coordinate of their collision box (if its a {@code ICollisionEntity}) or of
- * their bounding box.
- *
- * @see ICollisionEntity#getCollisionBox()
- * @see IEntity#getBoundingBox()
- * @see Double#compareTo(Double)
- */
+/// This `Comparator` implementation sorts entities by the max y-coordinate of their collision box (if its a `ICollisionEntity`) or of
+/// their bounding box.
+///
+/// @see ICollisionEntity#getCollisionBox()
+/// @see IEntity#getBoundingBox()
+/// @see Double#compareTo(Double)
 public class EntityYComparator implements Comparator<IEntity> {
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/ICollisionEntity.java
@@ -8,147 +8,109 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
 public interface ICollisionEntity extends IEntity {
-  /**
-   * Registers a {@link CollisionListener} to this entity. The listener will be notified whenever this entity collides with another
-   * {@link ICollisionEntity}.
-   *
-   * @param listener The {@link CollisionListener} to be added to this entity. It should not be {@code null}.
-   */
+  /// Registers a [CollisionListener] to this entity. The listener will be notified whenever this entity collides with another
+  /// [ICollisionEntity].
+  ///
+  /// @param listener The [CollisionListener] to be added to this entity. It should not be `null`.
   void onCollision(CollisionListener listener);
 
-  /**
-   * Removes a previously registered {@link CollisionListener} from this entity. After removal, the listener will no longer receive collision events
-   * involving this entity.
-   *
-   * @param listener The {@link CollisionListener} to be removed. It should match a listener that was previously added with
-   *                 {@link #onCollision(CollisionListener)}.
-   */
+  /// Removes a previously registered [CollisionListener] from this entity. After removal, the listener will no longer receive collision events
+  /// involving this entity.
+  ///
+  /// @param listener The [CollisionListener] to be removed. It should match a listener that was previously added with
+  /// [#onCollision(CollisionListener)].
   void removeCollisionListener(CollisionListener listener);
 
-  /**
-   * Triggers a collision event for this entity. This method is used to manually fire a collision event, which can be useful for custom collision
-   * handling or for simulating collisions in specific scenarios.
-   *
-   * @param event The {@link CollisionEvent} that encapsulates the details of the collision. This includes information such as the entities involved
-   *              in the collision and the collision's impact point.
-   */
+  /// Triggers a collision event for this entity. This method is used to manually fire a collision event, which can be useful for custom collision
+  /// handling or for simulating collisions in specific scenarios.
+  ///
+  /// @param event The [CollisionEvent] that encapsulates the details of the collision. This includes information such as the entities involved
+  /// in the collision and the collision's impact point.
   void fireCollisionEvent(CollisionEvent event);
 
-  /**
-   * Determines if this entity can collide with another specified {@link ICollisionEntity}. This method should be implemented to define custom
-   * collision logic between entities.
-   *
-   * @param otherEntity The other {@link ICollisionEntity} to check collision capability with.
-   * @return {@code true} if this entity can collide with the specified entity; {@code false} otherwise.
-   */
+  /// Determines if this entity can collide with another specified [ICollisionEntity]. This method should be implemented to define custom
+  /// collision logic between entities.
+  ///
+  /// @param otherEntity The other [ICollisionEntity] to check collision capability with.
+  /// @return `true` if this entity can collide with the specified entity; `false` otherwise.
   boolean canCollideWith(ICollisionEntity otherEntity);
 
-  /**
-   * Gets the collision box.
-   *
-   * @return the collision box
-   */
+  /// Gets the collision box.
+  ///
+  /// @return the collision box
   Rectangle2D getCollisionBox();
 
-  /**
-   * Gets the collision box.
-   *
-   * @param location the location
-   * @return the collision box
-   */
+  /// Gets the collision box.
+  ///
+  /// @param location the location
+  /// @return the collision box
   Rectangle2D getCollisionBox(Point2D location);
 
-  /**
-   * Gets the center {@link Point2D} of the entities collision box.
-   *
-   * @return The center {@link Point2D} of the entities collision box
-   */
+  /// Gets the center [Point2D] of the entities collision box.
+  ///
+  /// @return The center [Point2D] of the entities collision box
   Point2D getCollisionBoxCenter();
 
-  /**
-   * Retrieves the vertical alignment of the entity's collision box. This alignment determines the vertical positioning of the collision box relative
-   * to the entity's location.
-   *
-   * @return The {@link Valign} representing the vertical alignment of the collision box.
-   */
+  /// Retrieves the vertical alignment of the entity's collision box. This alignment determines the vertical positioning of the collision box relative
+  /// to the entity's location.
+  ///
+  /// @return The [Valign] representing the vertical alignment of the collision box.
   Valign getCollisionBoxValign();
 
-  /**
-   * Retrieves the horizontal alignment of the entity's collision box. This alignment determines the horizontal positioning of the collision box
-   * relative to the entity's location.
-   *
-   * @return The {@link Align} representing the horizontal alignment of the collision box.
-   */
+  /// Retrieves the horizontal alignment of the entity's collision box. This alignment determines the horizontal positioning of the collision box
+  /// relative to the entity's location.
+  ///
+  /// @return The [Align] representing the horizontal alignment of the collision box.
   Align getCollisionBoxAlign();
 
-  /**
-   * Retrieves the collision type of this entity. The collision type defines how this entity interacts with other entities in terms of physical
-   * collisions.
-   *
-   * @return The {@link Collision} type of this entity, indicating how it should be treated in collision detection and handling.
-   */
+  /// Retrieves the collision type of this entity. The collision type defines how this entity interacts with other entities in terms of physical
+  /// collisions.
+  ///
+  /// @return The [Collision] type of this entity, indicating how it should be treated in collision detection and handling.
   Collision getCollisionType();
 
-  /**
-   * Retrieves the height of the entity's collision box. This height is used in collision detection to determine the vertical bounds of the entity.
-   *
-   * @return The height of the collision box in pixels.
-   */
+  /// Retrieves the height of the entity's collision box. This height is used in collision detection to determine the vertical bounds of the entity.
+  ///
+  /// @return The height of the collision box in pixels.
   double getCollisionBoxHeight();
 
-  /**
-   * Retrieves the width of the entity's collision box. This width is used in collision detection to determine the horizontal bounds of the entity.
-   *
-   * @return The width of the collision box in pixels.
-   */
+  /// Retrieves the width of the entity's collision box. This width is used in collision detection to determine the horizontal bounds of the entity.
+  ///
+  /// @return The width of the collision box in pixels.
   double getCollisionBoxWidth();
 
-  /**
-   * Checks if the entity has collision enabled.
-   *
-   * @return {@code true} if the entity has collision enabled; {@code false} otherwise.
-   */
+  /// Checks if the entity has collision enabled.
+  ///
+  /// @return `true` if the entity has collision enabled; `false` otherwise.
   boolean hasCollision();
 
-  /**
-   * Sets the collision state of the entity.
-   *
-   * @param collision The collision state to set. {@code true} to enable collision; {@code false} to disable it.
-   */
+  /// Sets the collision state of the entity.
+  ///
+  /// @param collision The collision state to set. `true` to enable collision; `false` to disable it.
   void setCollision(boolean collision);
 
-  /**
-   * Sets the height of the entity's collision box.
-   *
-   * @param collisionBoxHeight The height of the collision box in pixels.
-   */
+  /// Sets the height of the entity's collision box.
+  ///
+  /// @param collisionBoxHeight The height of the collision box in pixels.
   void setCollisionBoxHeight(final double collisionBoxHeight);
 
-  /**
-   * Sets the width of the entity's collision box.
-   *
-   * @param collisionBoxWidth The width of the collision box in pixels.
-   */
+  /// Sets the width of the entity's collision box.
+  ///
+  /// @param collisionBoxWidth The width of the collision box in pixels.
   void setCollisionBoxWidth(final double collisionBoxWidth);
 
-  /**
-   * Sets the horizontal alignment of the entity's collision box.
-   *
-   * @param align The {@link Align} representing the horizontal alignment of the collision box.
-   */
+  /// Sets the horizontal alignment of the entity's collision box.
+  ///
+  /// @param align The [Align] representing the horizontal alignment of the collision box.
   void setCollisionBoxAlign(final Align align);
 
-  /**
-   * Sets the vertical alignment of the entity's collision box.
-   *
-   * @param valign The {@link Valign} representing the vertical alignment of the collision box.
-   */
+  /// Sets the vertical alignment of the entity's collision box.
+  ///
+  /// @param valign The [Valign] representing the vertical alignment of the collision box.
   void setCollisionBoxValign(final Valign valign);
 
-  /**
-   * Sets the collision type of this entity.
-   *
-   * @param collisionType The {@link Collision} type indicating how this entity should be treated in collision detection and handling.
-   */
+  /// Sets the collision type of this entity.
+  ///
+  /// @param collisionType The [Collision] type indicating how this entity should be treated in collision detection and handling.
   void setCollisionType(Collision collisionType);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/ICombatEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/ICombatEntity.java
@@ -6,181 +6,129 @@ import de.gurkenlabs.litiengine.attributes.RangeAttribute;
 import java.awt.Shape;
 import java.util.List;
 
-/**
- * The ICombatEntity interface defines the methods required for an entity that can engage in combat. It extends the ICollisionEntity interface.
- */
+/// The ICombatEntity interface defines the methods required for an entity that can engage in combat. It extends the ICollisionEntity interface.
 public interface ICombatEntity extends ICollisionEntity {
-  /**
-   * Adds a CombatEntityListener to this entity.
-   *
-   * @param listener the listener to add
-   */
+  /// Adds a CombatEntityListener to this entity.
+  ///
+  /// @param listener the listener to add
   void addCombatEntityListener(CombatEntityListener listener);
 
-  /**
-   * Removes a CombatEntityListener from this entity.
-   *
-   * @param listener the listener to remove
-   */
+  /// Removes a CombatEntityListener from this entity.
+  ///
+  /// @param listener the listener to remove
   void removeCombatEntityListener(CombatEntityListener listener);
 
-  /**
-   * Registers a listener to be called when this entity is hit.
-   *
-   * @param listener the listener to register
-   */
+  /// Registers a listener to be called when this entity is hit.
+  ///
+  /// @param listener the listener to register
   void onHit(CombatEntityHitListener listener);
 
-  /**
-   * Removes a hit listener from this entity.
-   *
-   * @param listener the listener to remove
-   */
+  /// Removes a hit listener from this entity.
+  ///
+  /// @param listener the listener to remove
   void removeListener(CombatEntityHitListener listener);
 
-  /**
-   * Registers a listener to be called when this entity dies.
-   *
-   * @param listener the listener to register
-   */
+  /// Registers a listener to be called when this entity dies.
+  ///
+  /// @param listener the listener to register
   void onDeath(CombatEntityDeathListener listener);
 
-  /**
-   * Removes a death listener from this entity.
-   *
-   * @param listener the listener to remove
-   */
+  /// Removes a death listener from this entity.
+  ///
+  /// @param listener the listener to remove
   void removeListener(CombatEntityDeathListener listener);
 
-  /**
-   * Registers a listener to be called when this entity is resurrected.
-   *
-   * @param listener the listener to register
-   */
+  /// Registers a listener to be called when this entity is resurrected.
+  ///
+  /// @param listener the listener to register
   void onResurrect(CombatEntityResurrectListener listener);
 
-  /**
-   * Removes a resurrect listener from this entity.
-   *
-   * @param listener the listener to remove
-   */
+  /// Removes a resurrect listener from this entity.
+  ///
+  /// @param listener the listener to remove
   void removeListener(CombatEntityResurrectListener listener);
 
-  /**
-   * Causes this entity to die.
-   */
+  /// Causes this entity to die.
   void die();
 
-  /**
-   * Gets the list of effects currently applied to this entity.
-   *
-   * @return a list of applied effects
-   */
+  /// Gets the list of effects currently applied to this entity.
+  ///
+  /// @return a list of applied effects
   List<Effect> getAppliedEffects();
 
-  /**
-   * Gets the hit points of this entity.
-   *
-   * @return the hit points as a RangeAttribute
-   */
+  /// Gets the hit points of this entity.
+  ///
+  /// @return the hit points as a RangeAttribute
   RangeAttribute<Integer> getHitPoints();
 
-  /**
-   * Gets the hit box of this entity.
-   *
-   * @return the hit box as a Shape
-   */
+  /// Gets the hit box of this entity.
+  ///
+  /// @return the hit box as a Shape
   Shape getHitBox();
 
-  /**
-   * Gets the current target of this entity.
-   *
-   * @return the target entity
-   */
+  /// Gets the current target of this entity.
+  ///
+  /// @return the target entity
   ICombatEntity getTarget();
 
-  /**
-   * Gets the team of this entity.
-   *
-   * @return the team as an integer
-   */
+  /// Gets the team of this entity.
+  ///
+  /// @return the team as an integer
   int getTeam();
 
-  /**
-   * Inflicts damage to this entity.
-   *
-   * @param damage the amount of damage to inflict
-   */
+  /// Inflicts damage to this entity.
+  ///
+  /// @param damage the amount of damage to inflict
   void hit(int damage);
 
-  /**
-   * Inflicts damage to this entity with a specific ability.
-   *
-   * @param damage  the amount of damage to inflict
-   * @param ability the ability causing the damage
-   */
+  /// Inflicts damage to this entity with a specific ability.
+  ///
+  /// @param damage  the amount of damage to inflict
+  /// @param ability the ability causing the damage
   void hit(int damage, Ability ability);
 
-  /**
-   * Checks if this entity is dead.
-   *
-   * @return true if the entity is dead, false otherwise
-   */
+  /// Checks if this entity is dead.
+  ///
+  /// @return true if the entity is dead, false otherwise
   boolean isDead();
 
-  /**
-   * Checks if this entity is friendly to another entity.
-   *
-   * @param entity the entity to check against
-   * @return true if the entity is friendly, false otherwise
-   */
+  /// Checks if this entity is friendly to another entity.
+  ///
+  /// @param entity the entity to check against
+  /// @return true if the entity is friendly, false otherwise
   boolean isFriendly(final ICombatEntity entity);
 
-  /**
-   * Checks if this entity is indestructible.
-   *
-   * @return true if the entity is indestructible, false otherwise
-   */
+  /// Checks if this entity is indestructible.
+  ///
+  /// @return true if the entity is indestructible, false otherwise
   boolean isIndestructible();
 
-  /**
-   * Checks if this entity is neutral.
-   *
-   * @return true if the entity is neutral, false otherwise
-   */
+  /// Checks if this entity is neutral.
+  ///
+  /// @return true if the entity is neutral, false otherwise
   boolean isNeutral();
 
-  /**
-   * Resurrects this entity.
-   */
+  /// Resurrects this entity.
   void resurrect();
 
-  /**
-   * Sets the indestructible state of this entity.
-   *
-   * @param indestructible the indestructible state to set
-   */
+  /// Sets the indestructible state of this entity.
+  ///
+  /// @param indestructible the indestructible state to set
   void setIndestructible(final boolean indestructible);
 
-  /**
-   * Sets the target of this entity.
-   *
-   * @param target the target entity to set
-   */
+  /// Sets the target of this entity.
+  ///
+  /// @param target the target entity to set
   void setTarget(final ICombatEntity target);
 
-  /**
-   * Sets the team of this entity.
-   *
-   * @param team the team to set
-   */
+  /// Sets the team of this entity.
+  ///
+  /// @param team the team to set
   void setTeam(int team);
 
-  /**
-   * Checks if this entity was hit within a specific time span.
-   *
-   * @param timeSpan the time span to check
-   * @return true if the entity was hit within the time span, false otherwise
-   */
+  /// Checks if this entity was hit within a specific time span.
+  ///
+  /// @param timeSpan the time span to check
+  /// @return true if the entity was hit within the time span, false otherwise
   boolean wasHit(int timeSpan);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/IEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/IEntity.java
@@ -14,6 +14,16 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
 
+/// A positioned object that can be added to an [Environment], updated by controllers, and rendered.
+///
+/// [Entity] provides the standard implementation of identity, transforms, tags, listeners, and
+/// controller ownership. Specialized implementations include [Creature], [Prop], and [MapArea].
+/// Coordinates exposed by this interface are map coordinates; rendering converts them through the
+/// active camera.
+///
+/// @see Entity
+/// @see Environment#add(IEntity)
+/// @see GameWorld
 public interface IEntity {
   /// Adds a [EntityMessageListener] to receive messages sent to this entity.
   ///
@@ -71,6 +81,9 @@ public interface IEntity {
   /// @param listener The [EntityRenderListener] to remove.
   void removeListener(final EntityRenderListener listener);
 
+  /// Returns the direction in which this entity is facing.
+  ///
+  /// @return The angle in degrees.
   double getAngle();
 
   /// Sets the angle (in degrees) in which the entity is directed.
@@ -119,6 +132,8 @@ public interface IEntity {
   <T extends IEntityController> T getController(Class<T> clss);
 
   /// Returns the controller that owns this entity's declarative script bindings, if one is configured.
+  ///
+  /// @return The script controller, or `null` when none is configured.
   default EntityScriptController<?> scripts() {
     return this.getController(EntityScriptController.class);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/IEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/IEntity.java
@@ -15,450 +15,332 @@ import java.awt.geom.Rectangle2D;
 import java.util.List;
 
 public interface IEntity {
-  /**
-   * Adds a {@link EntityMessageListener} to receive messages sent to this entity.
-   *
-   * @param listener The {@link EntityMessageListener} to add.
-   */
+  /// Adds a [EntityMessageListener] to receive messages sent to this entity.
+  ///
+  /// @param listener The [EntityMessageListener] to add.
   void onMessage(EntityMessageListener listener);
 
-  /**
-   * Adds a {@link EntityMessageListener} to receive messages with a specific content sent to this entity.
-   *
-   * @param message  The message content to listen for.
-   * @param listener The {@link EntityMessageListener} to add.
-   */
+  /// Adds a [EntityMessageListener] to receive messages with a specific content sent to this entity.
+  ///
+  /// @param message  The message content to listen for.
+  /// @param listener The [EntityMessageListener] to add.
   void onMessage(String message, EntityMessageListener listener);
 
-  /**
-   * Adds a {@link EntityTransformListener} to receive transform events for this entity.
-   *
-   * @param listener The {@link EntityTransformListener} to add.
-   */
+  /// Adds a [EntityTransformListener] to receive transform events for this entity.
+  ///
+  /// @param listener The [EntityTransformListener] to add.
   void addTransformListener(EntityTransformListener listener);
 
-  /**
-   * Adds a {@link EntityListener} to this entity that fires whenever the entity is added to or removed from the environment.
-   *
-   * @param listener The {@link EntityListener} to add.
-   */
+  /// Adds a [EntityListener] to this entity that fires whenever the entity is added to or removed from the environment.
+  ///
+  /// @param listener The [EntityListener] to add.
   void addListener(EntityListener listener);
 
-  /**
-   * Removes a {@link EntityMessageListener} from this entity.
-   *
-   * @param listener The {@link EntityMessageListener} to remove.
-   */
+  /// Removes a [EntityMessageListener] from this entity.
+  ///
+  /// @param listener The [EntityMessageListener] to remove.
   void removeListener(EntityMessageListener listener);
 
-  /**
-   * Removes a {@link EntityTransformListener} from this entity.
-   *
-   * @param listener The {@link EntityTransformListener} to remove.
-   */
+  /// Removes a [EntityTransformListener] from this entity.
+  ///
+  /// @param listener The [EntityTransformListener] to remove.
   void removeListener(EntityTransformListener listener);
 
-  /**
-   * Removes a {@link EntityListener} from this entity.
-   *
-   * @param listener The {@link EntityListener} to remove.
-   */
+  /// Removes a [EntityListener] from this entity.
+  ///
+  /// @param listener The [EntityListener] to remove.
   void removeListener(EntityListener listener);
 
-  /**
-   * Adds the specified {@link EntityRenderedListener} to receive events when entities were rendered.
-   *
-   * @param listener The {@link EntityRenderedListener} to add.
-   */
+  /// Adds the specified [EntityRenderedListener] to receive events when entities were rendered.
+  ///
+  /// @param listener The [EntityRenderedListener] to add.
   void onRendered(final EntityRenderedListener listener);
 
-  /**
-   * Removes the specified {@link EntityRenderedListener}.
-   *
-   * @param listener The {@link EntityRenderedListener} to remove.
-   */
+  /// Removes the specified [EntityRenderedListener].
+  ///
+  /// @param listener The [EntityRenderedListener] to remove.
   void removeListener(final EntityRenderedListener listener);
 
-  /**
-   * Adds the specified {@link EntityRenderListener} to receive events and callbacks about the rendering process of entities.
-   *
-   * @param listener The {@link EntityRenderListener} to add.
-   */
+  /// Adds the specified [EntityRenderListener] to receive events and callbacks about the rendering process of entities.
+  ///
+  /// @param listener The [EntityRenderListener] to add.
   void addEntityRenderListener(final EntityRenderListener listener);
 
-  /**
-   * Removes the specified {@link EntityRenderListener}.
-   *
-   * @param listener The {@link EntityRenderListener} to remove.
-   */
+  /// Removes the specified [EntityRenderListener].
+  ///
+  /// @param listener The [EntityRenderListener] to remove.
   void removeListener(final EntityRenderListener listener);
 
   double getAngle();
 
-  /**
-   * Sets the angle (in degrees) in which the entity is directed.
-   *
-   * @param angle the new angle in degrees
-   */
+  /// Sets the angle (in degrees) in which the entity is directed.
+  ///
+  /// @param angle the new angle in degrees
   void setAngle(double angle);
 
-  /**
-   * Gets the entities animation controller.
-   *
-   * @return The entities animation controller or null if none was registered.
-   * @see RenderEngine#renderEntity(java.awt.Graphics2D, IEntity)
-   */
+  /// Gets the entities animation controller.
+  ///
+  /// @return The entities animation controller or null if none was registered.
+  /// @see RenderEngine#renderEntity(java.awt.Graphics2D, IEntity)
   IEntityAnimationController<?> animations();
 
-  /**
-   * Checks if the entity is visible.
-   *
-   * @return True if the entity is visible; otherwise false.
-   */
+  /// Checks if the entity is visible.
+  ///
+  /// @return True if the entity is visible; otherwise false.
   boolean isVisible();
 
-  /**
-   * Sets the visibility of the entity.
-   *
-   * @param visible True to make the entity visible; false to make it invisible.
-   */
+  /// Sets the visibility of the entity.
+  ///
+  /// @param visible True to make the entity visible; false to make it invisible.
   void setVisible(boolean visible);
 
-  /**
-   * Gets the behavior controller of the entity.
-   *
-   * @return The behavior controller of the entity.
-   */
+  /// Gets the behavior controller of the entity.
+  ///
+  /// @return The behavior controller of the entity.
   IBehaviorController behavior();
 
-  /**
-   * Adds a controller to the entity.
-   *
-   * @param controller The controller to add.
-   */
+  /// Adds a controller to the entity.
+  ///
+  /// @param controller The controller to add.
   void addController(IEntityController controller);
 
-  /**
-   * Sets a specific controller for the entity.
-   *
-   * @param <T>        The type of the controller.
-   * @param clss       The class of the controller.
-   * @param controller The controller to set.
-   */
+  /// Sets a specific controller for the entity.
+  ///
+  /// @param <T>        The type of the controller.
+  /// @param clss       The class of the controller.
+  /// @param controller The controller to set.
   <T extends IEntityController> void setController(Class<T> clss, T controller);
 
-  /**
-   * Gets a specific controller of the entity.
-   *
-   * @param <T>  The type of the controller.
-   * @param clss The class of the controller.
-   * @return The controller of the specified type.
-   */
+  /// Gets a specific controller of the entity.
+  ///
+  /// @param <T>  The type of the controller.
+  /// @param clss The class of the controller.
+  /// @return The controller of the specified type.
   <T extends IEntityController> T getController(Class<T> clss);
 
-  /** Returns the controller that owns this entity's declarative script bindings, if one is configured. */
+  /// Returns the controller that owns this entity's declarative script bindings, if one is configured.
   default EntityScriptController<?> scripts() {
     return this.getController(EntityScriptController.class);
   }
 
-  /**
-   * All registered actions of this entity.
-   *
-   * @return The EntityActionMap that holds all registered EntityActions for this instance.
-   * @see EntityActionMap
-   * @see IEntity#register(String, Runnable)
-   */
+  /// All registered actions of this entity.
+  ///
+  /// @return The EntityActionMap that holds all registered EntityActions for this instance.
+  /// @see EntityActionMap
+  /// @see IEntity#register(String, Runnable)
   EntityActionMap actions();
 
-  /**
-   * Performs an {@code EntityAction} that was previously registered for this entity.
-   *
-   * <p>
-   * <i>Does nothing in case no action has been registered for the specified {@code
-   * actionName}.</i>
-   *
-   * @param actionName The name of the action to be performed.
-   * @see IEntity#actions()
-   * @see IEntity#register(String, Runnable)
-   */
+  /// Performs an `EntityAction` that was previously registered for this entity.
+  ///
+  /// *Does nothing in case no action has been registered for the specified `actionName`.*
+  ///
+  /// @param actionName The name of the action to be performed.
+  /// @see IEntity#actions()
+  /// @see IEntity#register(String, Runnable)
   void perform(String actionName);
 
-  /**
-   * Registers a listener to be notified whenever an action is performed on this entity.
-   *
-   * @param listener the action listener
-   */
+  /// Registers a listener to be notified whenever an action is performed on this entity.
+  ///
+  /// @param listener the action listener
   void onActionPerformed(java.util.function.Consumer<String> listener);
 
-  /**
-   * Removes a registered action performed listener.
-   *
-   * @param listener the action listener
-   */
+  /// Removes a registered action performed listener.
+  ///
+  /// @param listener the action listener
   void removeActionPerformedListener(java.util.function.Consumer<String> listener);
 
-  /**
-   * Registers an {@code EntityAction} with the specified name. It's later possible to execute these actions on the entity by using the
-   * {@code Entity.perform(String actionName)} method.
-   *
-   * @param name   The name of the action to be registered.
-   * @param action The action to be performed by the entity.
-   * @return The created EntityAction instance; or null if the name or action parameter were invalid.
-   * @see IEntity#perform(String)
-   * @see IEntity#actions()
-   */
+  /// Registers an `EntityAction` with the specified name. It's later possible to execute these actions on the entity by using the
+  /// `Entity.perform(String actionName)` method.
+  ///
+  /// @param name   The name of the action to be registered.
+  /// @param action The action to be performed by the entity.
+  /// @return The created EntityAction instance; or null if the name or action parameter were invalid.
+  /// @see IEntity#perform(String)
+  /// @see IEntity#actions()
   EntityAction register(String name, Runnable action);
 
-  /**
-   * Detaches all controllers from this entity.
-   */
+  /// Detaches all controllers from this entity.
   void detachControllers();
 
-  /**
-   * Attaches all controllers to this entity.
-   */
+  /// Attaches all controllers to this entity.
   void attachControllers();
 
-  /**
-   * Gets the bounding box of the entity.
-   *
-   * @return The bounding box of the entity.
-   */
+  /// Gets the bounding box of the entity.
+  ///
+  /// @return The bounding box of the entity.
   Rectangle2D getBoundingBox();
 
-  /**
-   * Gets the center point of the entity.
-   *
-   * @return The center point of the entity.
-   */
+  /// Gets the center point of the entity.
+  ///
+  /// @return The center point of the entity.
   Point2D getCenter();
 
-  /**
-   * Gets the height of the entity.
-   *
-   * @return The height of the entity.
-   */
+  /// Gets the height of the entity.
+  ///
+  /// @return The height of the entity.
   double getHeight();
 
-  /**
-   * Gets the location of the entity.
-   *
-   * @return The location of the entity.
-   */
+  /// Gets the location of the entity.
+  ///
+  /// @return The location of the entity.
   Point2D getLocation();
 
-  /**
-   * Gets the map ID of the entity.
-   *
-   * @return The map ID of the entity.
-   */
+  /// Gets the map ID of the entity.
+  ///
+  /// @return The map ID of the entity.
   int getMapId();
 
-  /***
-   * Gets the name of this entity.
-   *
-   * @return The name of this entity.
-   */
+  /// Gets the name of this entity.
+  ///
+  /// @return The name of this entity.
   String getName();
 
-  /**
-   * Gets the render type of the entity.
-   *
-   * @return The render type of the entity.
-   */
+  /// Gets the render type of the entity.
+  ///
+  /// @return The render type of the entity.
   RenderType getRenderType();
 
-  /**
-   * Determines whether this entity is being rendered with the layer it's originating from. This ignores the specified {@code RenderType} and makes
-   * the entity dependent upon the visibility of its layer.
-   *
-   * <p>
-   * This can only be used, of course, if the entity is related to a {@code MapObject}. <br> This defaults to {@code false} if not explicitly set on
-   * the {@code MapObject}.
-   *
-   * @return True if the entity should be rendered with the layer of the corresponding map object; otherwise false.
-   * @see ILayer#isVisible()
-   * @see IMapObjectLayer#getMapObjects()
-   * @see Environment#getEntitiesByLayer(int)
-   * @see Environment#getEntitiesByLayer(String)
-   */
+  /// Determines whether this entity is being rendered with the layer it's originating from. This ignores the specified `RenderType` and makes
+  /// the entity dependent upon the visibility of its layer.
+  ///
+  /// This can only be used, of course, if the entity is related to a `MapObject`.
+  /// This defaults to `false` if not explicitly set on
+  /// the `MapObject`.
+  ///
+  /// @return True if the entity should be rendered with the layer of the corresponding map object; otherwise false.
+  /// @see ILayer#isVisible()
+  /// @see IMapObjectLayer#getMapObjects()
+  /// @see Environment#getEntitiesByLayer(int)
+  /// @see Environment#getEntitiesByLayer(String)
   boolean renderWithLayer();
 
-  /**
-   * Gets the width of the entity.
-   *
-   * @return The width of the entity.
-   */
+  /// Gets the width of the entity.
+  ///
+  /// @return The width of the entity.
   double getWidth();
 
-  /**
-   * Gets the X coordinate of the entity.
-   *
-   * @return The X coordinate of the entity.
-   */
+  /// Gets the X coordinate of the entity.
+  ///
+  /// @return The X coordinate of the entity.
   double getX();
 
-  /**
-   * Gets the Y coordinate of the entity.
-   *
-   * @return The Y coordinate of the entity.
-   */
+  /// Gets the Y coordinate of the entity.
+  ///
+  /// @return The Y coordinate of the entity.
   double getY();
 
-  /**
-   * Sends a message from the specified sender to this entity.
-   *
-   * @param sender  The sender of the message.
-   * @param message The message to send.
-   * @return The response to the message.
-   */
+  /// Sends a message from the specified sender to this entity.
+  ///
+  /// @param sender  The sender of the message.
+  /// @param message The message to send.
+  /// @return The response to the message.
   String sendMessage(Object sender, String message);
 
-  /**
-   * Sets the height of the entity.
-   *
-   * @param height The new height of the entity.
-   */
+  /// Sets the height of the entity.
+  ///
+  /// @param height The new height of the entity.
   void setHeight(double height);
 
-  /**
-   * Sets the location of the entity.
-   *
-   * @param x The X coordinate of the new location.
-   * @param y The Y coordinate of the new location.
-   */
+  /// Sets the location of the entity.
+  ///
+  /// @param x The X coordinate of the new location.
+  /// @param y The Y coordinate of the new location.
   void setLocation(double x, double y);
 
-  /**
-   * Checks if the entity has the specified tag.
-   *
-   * @param tag The tag to check for.
-   * @return True if the entity has the tag; otherwise false.
-   */
+  /// Checks if the entity has the specified tag.
+  ///
+  /// @param tag The tag to check for.
+  /// @return True if the entity has the tag; otherwise false.
   boolean hasTag(String tag);
 
-  /**
-   * Gets the list of tags associated with the entity.
-   *
-   * @return A list of tags associated with the entity.
-   */
+  /// Gets the list of tags associated with the entity.
+  ///
+  /// @return A list of tags associated with the entity.
   List<String> getTags();
 
-  /**
-   * Adds a tag to the entity.
-   *
-   * @param tag The tag to add.
-   */
+  /// Adds a tag to the entity.
+  ///
+  /// @param tag The tag to add.
   void addTag(String tag);
 
-  /**
-   * Removes a tag from the entity.
-   *
-   * @param tag The tag to remove.
-   */
+  /// Removes a tag from the entity.
+  ///
+  /// @param tag The tag to remove.
   void removeTag(String tag);
 
-  /**
-   * Sets the map location.
-   *
-   * @param location the new map location
-   */
+  /// Sets the map location.
+  ///
+  /// @param location the new map location
   void setLocation(Point2D location);
 
-  /**
-   * Sets an id which should only be filled when an entity gets added due to map information.
-   *
-   * @param mapId The unique map ID for this {@link IEntity}
-   */
+  /// Sets an id which should only be filled when an entity gets added due to map information.
+  ///
+  /// @param mapId The unique map ID for this [IEntity]
   void setMapId(int mapId);
 
-  /**
-   * Sets the name of the entity.
-   *
-   * @param name The new name of the entity.
-   */
+  /// Sets the name of the entity.
+  ///
+  /// @param name The new name of the entity.
   void setName(String name);
 
-  /**
-   * Sets the render type of the entity.
-   *
-   * @param renderType The new render type of the entity.
-   */
+  /// Sets the render type of the entity.
+  ///
+  /// @param renderType The new render type of the entity.
   void setRenderType(RenderType renderType);
 
-  /**
-   * Sets whether the entity should be rendered with its layer.
-   *
-   * @param renderWithLayer True to render with the layer; otherwise false.
-   */
+  /// Sets whether the entity should be rendered with its layer.
+  ///
+  /// @param renderWithLayer True to render with the layer; otherwise false.
   void setRenderWithLayer(boolean renderWithLayer);
 
-  /**
-   * Sets the size of the entity.
-   *
-   * @param width  The new width of the entity.
-   * @param height The new height of the entity.
-   */
+  /// Sets the size of the entity.
+  ///
+  /// @param width  The new width of the entity.
+  /// @param height The new height of the entity.
   void setSize(double width, double height);
 
-  /**
-   * Sets the width of the entity.
-   *
-   * @param width The new width of the entity.
-   */
+  /// Sets the width of the entity.
+  ///
+  /// @param width The new width of the entity.
   void setWidth(double width);
 
-  /**
-   * Sets the X coordinate of the entity.
-   *
-   * @param x The new X coordinate of the entity.
-   */
+  /// Sets the X coordinate of the entity.
+  ///
+  /// @param x The new X coordinate of the entity.
   void setX(double x);
 
-  /**
-   * Sets the Y coordinate of the entity.
-   *
-   * @param y The new Y coordinate of the entity.
-   */
+  /// Sets the Y coordinate of the entity.
+  ///
+  /// @param y The new Y coordinate of the entity.
   void setY(double y);
 
-  /**
-   * Gets the custom properties of the entity.
-   *
-   * @return The custom property provider of the entity.
-   */
+  /// Gets the custom properties of the entity.
+  ///
+  /// @return The custom property provider of the entity.
   ICustomPropertyProvider getProperties();
 
-  /**
-   * Gets the environment the entity was loaded to or null if it is not loaded.
-   *
-   * @return The entity's environment.
-   */
+  /// Gets the environment the entity was loaded to or null if it is not loaded.
+  ///
+  /// @return The entity's environment.
   Environment getEnvironment();
 
-  /**
-   * This method provides the possibility to implement behavior whenever this entity was added to the environment.
-   *
-   * @param environment The environment that the entity was added to
-   * @see IEntity#addListener(EntityListener)
-   */
+  /// This method provides the possibility to implement behavior whenever this entity was added to the environment.
+  ///
+  /// @param environment The environment that the entity was added to
+  /// @see IEntity#addListener(EntityListener)
   void loaded(Environment environment);
 
-  /**
-   * This method provides the possibility to implement behavior whenever this entity was removed from the environment.
-   *
-   * @param environment The environment that the entity was removed from
-   * @see IEntity#addListener(EntityListener)
-   */
+  /// This method provides the possibility to implement behavior whenever this entity was removed from the environment.
+  ///
+  /// @param environment The environment that the entity was removed from
+  /// @see IEntity#addListener(EntityListener)
   void removed(Environment environment);
 
-  /**
-   * Indicates whether this entity is loaded on the currently active environment.
-   *
-   * @return True if the entity is loaded on the game's currently active environment; otherwise false.
-   * @see GameWorld#environment()
-   * @see IEntity#loaded(Environment)
-   * @see IEntity#removed(Environment)
-   */
+  /// Indicates whether this entity is loaded on the currently active environment.
+  ///
+  /// @return True if the entity is loaded on the game's currently active environment; otherwise false.
+  /// @see GameWorld#environment()
+  /// @see IEntity#loaded(Environment)
+  /// @see IEntity#removed(Environment)
   boolean isLoaded();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/IMobileEntity.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/IMobileEntity.java
@@ -6,40 +6,31 @@ import java.util.EventListener;
 
 public interface IMobileEntity extends ICollisionEntity {
 
-  /**
-   * Adds the specified entity moved listener to receive events when this entity was moved.
-   *
-   * <p>
-   * In comparison to the {@link EntityTransformListener#locationChanged(IEntity)} event, this provides some additional
-   * information about the movement (e.g. distance) and is only fired if the entity instance is currently loaded.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified entity moved listener to receive events when this entity was moved.
+  ///
+  /// In comparison to the [EntityTransformListener#locationChanged(IEntity)] event, this provides some additional
+  /// information about the movement (e.g. distance) and is only fired if the entity instance is currently loaded.
+  ///
+  /// @param listener
+  /// The listener to add.
   void onMoved(EntityMovedListener listener);
 
-  /**
-   * Removes the specified entity moved listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Removes the specified entity moved listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMovedListener(EntityMovedListener listener);
 
-  /**
-   * Gets a value that defines how long it takes the entity to reach the full velocity (in ms).
-   *
-   * @return the acceleration value
-   */
+  /// Gets a value that defines how long it takes the entity to reach the full velocity (in ms).
+  ///
+  /// @return the acceleration value
   int getAcceleration();
 
-  /**
-   * Gets the corrected acceleration velocity for movement calculations
-   *
-   * @param deltaTime
-   *          Delta time
-   * @return the corrected acceleration value
-   */
+  /// Gets the corrected acceleration velocity for movement calculations
+  ///
+  /// @param deltaTime
+  /// Delta time
+  /// @return the corrected acceleration value
   default double getAcceleration(double deltaTime) {
     // max distance an entity can travel within one tick
     float maxPixelsPerTick = getTickVelocity();
@@ -47,22 +38,18 @@ public interface IMobileEntity extends ICollisionEntity {
     return acceleration == 0 ? maxPixelsPerTick : deltaTime / acceleration * maxPixelsPerTick;
   }
 
-  /**
-   * Gets a value that defines how long it takes the entity to stop when slowing down from movements (in ms).
-   *
-   * @return the deceleration value
-   */
+  /// Gets a value that defines how long it takes the entity to stop when slowing down from movements (in ms).
+  ///
+  /// @return the deceleration value
   int getDeceleration();
 
-  /**
-   * Gets the corrected deceleration velocity for movement calculations
-   *
-   * @param deltaTime
-   *          Delta time
-   * @param velocity
-   *          Current velocity
-   * @return the corrected deceleration value
-   */
+  /// Gets the corrected deceleration velocity for movement calculations
+  ///
+  /// @param deltaTime
+  /// Delta time
+  /// @param velocity
+  /// Current velocity
+  /// @return the corrected deceleration value
   default double getDeceleration(double deltaTime, double velocity) {
     // max distance an entity can travel within one tick
     float maxPixelsPerTick = getTickVelocity();
@@ -70,85 +57,65 @@ public interface IMobileEntity extends ICollisionEntity {
     return deceleration == 0 ? velocity : deltaTime / deceleration * maxPixelsPerTick;
   }
 
-  /**
-   * Gets the entity's velocity in PIXELS per Second.
-   *
-   * @return the velocity in pixel per second.
-   */
+  /// Gets the entity's velocity in PIXELS per Second.
+  ///
+  /// @return the velocity in pixel per second.
   Attribute<Float> getVelocity();
 
-  /**
-   * Gets the entity's velocity in PIXELS per tick.
-   *
-   * @return The velocity in pixel per tick.
-   */
+  /// Gets the entity's velocity in PIXELS per tick.
+  ///
+  /// @return The velocity in pixel per tick.
   float getTickVelocity();
 
-  /**
-   * Gets the movement controller.
-   *
-   * @return the movement controller
-   */
+  /// Gets the movement controller.
+  ///
+  /// @return the movement controller
   IMovementController movement();
 
-  /**
-   * Sets the acceleration for this entity. Acceleration is a value that defines how long it takes the entity to reach the
-   * full velocity when starting to move (in ms). *
-   *
-   * @param acceleration
-   *          the new acceleration
-   */
+  /// Sets the acceleration for this entity. Acceleration is a value that defines how long it takes the entity to reach the
+  /// full velocity when starting to move (in ms). *
+  ///
+  /// @param acceleration
+  /// the new acceleration
   void setAcceleration(int acceleration);
 
-  /**
-   * Sets the deceleration for this entity. deceleration is a value that defines how long it takes the entity to stop when
-   * slowing down from movements (in ms).
-   *
-   * @param deceleration
-   *          the new deceleration
-   */
+  /// Sets the deceleration for this entity. deceleration is a value that defines how long it takes the entity to stop when
+  /// slowing down from movements (in ms).
+  ///
+  /// @param deceleration
+  /// the new deceleration
   void setDeceleration(int deceleration);
 
-  /**
-   * Sets the turn on move parameter for this entity. It specifies if the entity will change its angle to the direction of
-   * the move destination when moved.
-   *
-   * @param turn
-   *          the new turn on move parameter.
-   */
+  /// Sets the turn on move parameter for this entity. It specifies if the entity will change its angle to the direction of
+  /// the move destination when moved.
+  ///
+  /// @param turn
+  /// the new turn on move parameter.
   void setTurnOnMove(boolean turn);
 
-  /**
-   * Sets the base value on the velocity attribute of this instance.
-   *
-   * @param velocity
-   *          The velocity to be set.
-   * @see #getVelocity()
-   */
+  /// Sets the base value on the velocity attribute of this instance.
+  ///
+  /// @param velocity
+  /// The velocity to be set.
+  /// @see #getVelocity()
   void setVelocity(float velocity);
 
-  /**
-   * Gets the turn on move parameter for this entity. It specifies if the entity will change its angle to the direction of
-   * the move destination when moved.
-   *
-   * @return true, if the entity will change its angle to the direction of the move destination when being moved
-   */
+  /// Gets the turn on move parameter for this entity. It specifies if the entity will change its angle to the direction of
+  /// the move destination when moved.
+  ///
+  /// @return true, if the entity will change its angle to the direction of the move destination when being moved
   boolean turnOnMove();
 
-  /**
-   * This listener interface receives events when an entity was moved.
-   *
-   * @see IMovementController
-   * @see IMobileEntity#onMoved(EntityMovedListener)
-   */
+  /// This listener interface receives events when an entity was moved.
+  ///
+  /// @see IMovementController
+  /// @see IMobileEntity#onMoved(EntityMovedListener)
   @FunctionalInterface
   interface EntityMovedListener extends EventListener {
-    /**
-     * Invoked after an entity was moved.
-     *
-     * @param event
-     *          The entity moved event.
-     */
+    /// Invoked after an entity was moved.
+    ///
+    /// @param event
+    /// The entity moved event.
     void moved(EntityMovedEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/LightSource.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/LightSource.java
@@ -23,41 +23,29 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.function.Predicate;
 
-/**
- * This class represents a light source in an environment. It extends the Entity class and implements IRenderable interface. It provides methods to
- * render light sources and shadows.
- */
+/// This class represents a light source in an environment. It extends the Entity class and implements IRenderable interface. It provides methods to
+/// render light sources and shadows.
 @EntityInfo(renderType = RenderType.OVERLAY)
 @TmxType(MapObjectType.LIGHTSOURCE)
 public class LightSource extends Entity implements IRenderable {
-  /**
-   * Enum representing the type of light source.
-   */
+  /// Enum representing the type of light source.
   public enum Type {
-    /**
-     * Ellipse-shaped light source.
-     */
+    /// Ellipse-shaped light source.
     ELLIPSE,
-    /**
-     * Rectangle-shaped light source.
-     */
+    /// Rectangle-shaped light source.
     RECTANGLE
   }
 
-  /** Message identifier used to toggle this light source via the engine's messaging system. */
+  /// Message identifier used to toggle this light source via the engine's messaging system.
   public static final String TOGGLE_MESSAGE = "toggle";
-  /** Default light intensity used when none is specified. */
+  /// Default light intensity used when none is specified.
   public static final int DEFAULT_INTENSITY = 100;
 
   private static final float OBSTRUCTED_VISION_RADIUS = 200f;
   private static final float SHADOW_GRADIENT_SIZE = 100f;
-  /**
-   * The fractions for our shadow gradient, going from 0.0 (black) to 1.0 (transparent).
-   */
+  /// The fractions for our shadow gradient, going from 0.0 (black) to 1.0 (transparent).
   private static final float[] SHADOW_GRADIENT_FRACTIONS = new float[] {0f, 1f};
-  /**
-   * The colors for our shadow, going from opaque black to transparent black.
-   */
+  /// The colors for our shadow, going from opaque black to transparent black.
   private static final Color[] SHADOW_GRADIENT_COLORS =
     new Color[] {new Color(0, 0, 0, .3f), new Color(0f, 0f, 0f, 0f)};
 
@@ -73,14 +61,12 @@ public class LightSource extends Entity implements IRenderable {
   private Color color;
   private Shape lightShape;
 
-  /**
-   * Constructor for the LightSource class.
-   *
-   * @param intensity  The intensity of this instance.
-   * @param lightColor The color of this instance.
-   * @param shapeType  The shape type of this instance.
-   * @param activated  A flag indicating whether this light is activated by default.
-   */
+  /// Constructor for the LightSource class.
+  ///
+  /// @param intensity  The intensity of this instance.
+  /// @param lightColor The color of this instance.
+  /// @param shapeType  The shape type of this instance.
+  /// @param activated  A flag indicating whether this light is activated by default.
   public LightSource(final int intensity, final Color lightColor, final Type shapeType, boolean activated) {
     super();
     this.color = lightColor;
@@ -90,9 +76,7 @@ public class LightSource extends Entity implements IRenderable {
     this.activated = activated;
   }
 
-  /**
-   * Activates the light source.
-   */
+  /// Activates the light source.
   public void activate() {
     if (isActive()) {
       return;
@@ -101,9 +85,7 @@ public class LightSource extends Entity implements IRenderable {
     updateAmbientLayers();
   }
 
-  /**
-   * Deactivates the light source.
-   */
+  /// Deactivates the light source.
   public void deactivate() {
     if (!isActive()) {
       return;
@@ -113,20 +95,16 @@ public class LightSource extends Entity implements IRenderable {
     updateAmbientLayers();
   }
 
-  /**
-   * Gets the color of the light emitted by this source.
-   *
-   * @return the light color
-   */
+  /// Gets the color of the light emitted by this source.
+  ///
+  /// @return the light color
   public Color getColor() {
     return color;
   }
 
-  /**
-   * Builds the radial gradient paint used to render the light cone, fading from the source color outwards.
-   *
-   * @return the gradient paint
-   */
+  /// Builds the radial gradient paint used to render the light cone, fading from the source color outwards.
+  ///
+  /// @return the gradient paint
   public RadialGradientPaint getGradientPaint() {
     final Color[] transColors =
       new Color[] {
@@ -140,67 +118,53 @@ public class LightSource extends Entity implements IRenderable {
   }
 
 
-  /**
-   * Gets the light intensity. Returns {@code 0} when the light source is inactive.
-   *
-   * @return the current intensity
-   */
+  /// Gets the light intensity. Returns `0` when the light source is inactive.
+  ///
+  /// @return the current intensity
   public int getIntensity() {
     return isActive() ? intensity : 0;
   }
 
-  /**
-   * Gets the geometric shape representing this light source's emission area.
-   *
-   * @return the light shape
-   */
+  /// Gets the geometric shape representing this light source's emission area.
+  ///
+  /// @return the light shape
   public Shape getLightShape() {
     return lightShape;
   }
 
-  /**
-   * Gets the type of shape used by this light source.
-   *
-   * @return the shape type
-   */
+  /// Gets the type of shape used by this light source.
+  ///
+  /// @return the shape type
   public Type getLightShapeType() {
     return lightShapeType;
   }
 
-  /**
-   * Returns whether the light source is currently active.
-   *
-   * @return {@code true} if active
-   */
+  /// Returns whether the light source is currently active.
+  ///
+  /// @return `true` if active
   public boolean isActive() {
     return activated;
   }
 
-  /**
-   * Sets the color of the light emitted by this source and refreshes the affected ambient layers.
-   *
-   * @param color the new color
-   */
+  /// Sets the color of the light emitted by this source and refreshes the affected ambient layers.
+  ///
+  /// @param color the new color
   public void setColor(final Color color) {
     this.color = color;
     updateAmbientLayers();
   }
 
-  /**
-   * Sets the intensity of the light and refreshes the affected ambient layers.
-   *
-   * @param intensity the new intensity
-   */
+  /// Sets the intensity of the light and refreshes the affected ambient layers.
+  ///
+  /// @param intensity the new intensity
   public void setIntensity(final int intensity) {
     this.intensity = intensity;
     updateAmbientLayers();
   }
 
-  /**
-   * Sets the shape type of the light source.
-   *
-   * @param shapeType the new shape type
-   */
+  /// Sets the shape type of the light source.
+  ///
+  /// @param shapeType the new shape type
   public void setLightShapeType(final Type shapeType) {
     this.lightShapeType = shapeType;
   }
@@ -221,9 +185,7 @@ public class LightSource extends Entity implements IRenderable {
     updateAmbientLayers(previousBounds.createUnion(getBoundingBox()));
   }
 
-  /**
-   * Toggles the light source between active and inactive states.
-   */
+  /// Toggles the light source between active and inactive states.
   public void toggle() {
     this.activated = !this.activated;
     updateAmbientLayers();
@@ -251,9 +213,7 @@ public class LightSource extends Entity implements IRenderable {
   }
 
 
-  /**
-   * Updates the ambient layers of the environment.
-   */
+  /// Updates the ambient layers of the environment.
   private void updateAmbientLayers() {
     updateAmbientLayers(getBoundingBox());
   }
@@ -274,9 +234,7 @@ public class LightSource extends Entity implements IRenderable {
     }
   }
 
-  /**
-   * Updates the shape of the light source based on its type.
-   */
+  /// Updates the shape of the light source based on its type.
   private void updateShape() {
     if (getLightShapeType() == Type.RECTANGLE) {
       this.lightShape =
@@ -287,31 +245,29 @@ public class LightSource extends Entity implements IRenderable {
     }
   }
 
-  /**
-   * Renders the shadows using simple vector math. The steps are as follows:
-   *
-   * <pre>
-   * for each entity
-   *     if entity is not moving:
-   *         ignore entity
-   *     if entity is too far from mouse:
-   *         ignore entity
-   *
-   *     determine unit vector from mouse to entity center
-   *     get perpendicular of unit vector
-   *
-   *     Create Points A + B:
-   *         extrude perpendicular in either direction, by the half-size of the entity
-   *     Create Points C + D:
-   *         extrude A + B away from mouse location
-   *
-   *     construct polygon with points A, B, C, D
-   *
-   *     render with RadialGradientPaint to give it a "fade-out" appearance
-   * </pre>
-   *
-   * @param graphic the graphics to use for rendering
-   */
+  /// Renders the shadows using simple vector math. The steps are as follows:
+  ///
+  /// ```
+  /// for each entity
+  ///     if entity is not moving:
+  ///         ignore entity
+  ///     if entity is too far from mouse:
+  ///         ignore entity
+  ///
+  ///     determine unit vector from mouse to entity center
+  ///     get perpendicular of unit vector
+  ///
+  ///     Create Points A + B:
+  ///         extrude perpendicular in either direction, by the half-size of the entity
+  ///     Create Points C + D:
+  ///         extrude A + B away from mouse location
+  ///
+  ///     construct polygon with points A, B, C, D
+  ///
+  ///     render with RadialGradientPaint to give it a "fade-out" appearance
+  /// ```
+  ///
+  /// @param graphic the graphics to use for rendering
   private void renderShadows(final Graphics2D graphic) {
     if (Game.world().environment().getCombatEntities().stream()
       .noneMatch(isInRange(getCenter()))) {
@@ -355,13 +311,11 @@ public class LightSource extends Entity implements IRenderable {
       .contains(mob.getCenter());
   }
 
-  /**
-   * Gets the area of obstructed vision for a given entity.
-   *
-   * @param entity The entity for which to get the obstructed vision area.
-   * @param center The center point of the light source.
-   * @return The area of obstructed vision.
-   */
+  /// Gets the area of obstructed vision for a given entity.
+  ///
+  /// @param entity The entity for which to get the obstructed vision area.
+  /// @param center The center point of the light source.
+  /// @return The area of obstructed vision.
   private static Area getObstructedVisionArea(final IEntity entity, final Point2D center) {
     final Polygon shadowPolygon = new Polygon();
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/MapArea.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/MapArea.java
@@ -10,43 +10,37 @@ import java.awt.Shape;
 public class MapArea extends Entity {
   Shape shape;
 
-  /**
-   * Instantiates a new {@code MapArea} entity.
-   */
+  /// Instantiates a new `MapArea` entity.
   public MapArea() {}
 
-  /**
-   * Instantiates a new {@code MapArea} entity.
-   *
-   * @param x
-   *          The x-coordinate of this instance.
-   * @param y
-   *          The y-coordinate of this instance.
-   * @param width
-   *          The width of this instance.
-   * @param height
-   *          The height of this instance.
-   */
+  /// Instantiates a new `MapArea` entity.
+  ///
+  /// @param x
+  /// The x-coordinate of this instance.
+  /// @param y
+  /// The y-coordinate of this instance.
+  /// @param width
+  /// The width of this instance.
+  /// @param height
+  /// The height of this instance.
   public MapArea(final double x, final double y, final double width, final double height) {
     this(0, null, x, y, width, height);
   }
 
-  /**
-   * Instantiates a new {@code MapArea} entity.
-   *
-   * @param id
-   *          The id of this instance.
-   * @param name
-   *          The name of this instance.
-   * @param x
-   *          The x-coordinate of this instance.
-   * @param y
-   *          The y-coordinate of this instance.
-   * @param width
-   *          The width of this instance.
-   * @param height
-   *          The height of this instance.
-   */
+  /// Instantiates a new `MapArea` entity.
+  ///
+  /// @param id
+  /// The id of this instance.
+  /// @param name
+  /// The name of this instance.
+  /// @param x
+  /// The x-coordinate of this instance.
+  /// @param y
+  /// The y-coordinate of this instance.
+  /// @param width
+  /// The width of this instance.
+  /// @param height
+  /// The height of this instance.
   public MapArea(
       final int id,
       final String name,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Material.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Material.java
@@ -5,52 +5,42 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Describes the physical material of an entity (e.g. {@link #WOOD}, {@link #STONE}). Materials are looked up by name and are typically used by the
- * engine to drive damage and sound interactions. Custom materials can be created by instantiating this class.
- */
+/// Describes the physical material of an entity (e.g. [#WOOD], [#STONE]). Materials are looked up by name and are typically used by the
+/// engine to drive damage and sound interactions. Custom materials can be created by instantiating this class.
 public class Material extends CustomPropertyProvider {
   private static final Map<String, Material> materials = new ConcurrentHashMap<>();
-  /**
-   * Default fall-back material used when no specific material is assigned.
-   */
+  /// Default fall-back material used when no specific material is assigned.
   public static final Material UNDEFINED = new Material("UNDEFINED");
-  /**
-   * Ceramic material.
-   */
+  /// Ceramic material.
   public static final Material CERAMIC = new Material("CERAMIC");
-  /** Flesh material. */
+  /// Flesh material.
   public static final Material FLESH = new Material("FLESH");
-  /** Foliage material. */
+  /// Foliage material.
   public static final Material FOLIAGE = new Material("FOLIAGE");
-  /** Plastic material. */
+  /// Plastic material.
   public static final Material PLASTIC = new Material("PLASTIC");
-  /** Steel material. */
+  /// Steel material.
   public static final Material STEEL = new Material("STEEL");
-  /** Stone material. */
+  /// Stone material.
   public static final Material STONE = new Material("STONE");
-  /** Wood material. */
+  /// Wood material.
   public static final Material WOOD = new Material("WOOD");
 
   private final String name;
 
-  /**
-   * Initializes a new instance of the {@code Material} class.
-   *
-   * @param name
-   *          The name of the material.
-   */
+  /// Initializes a new instance of the `Material` class.
+  ///
+  /// @param name
+  /// The name of the material.
   public Material(String name) {
     this.name = name;
     materials.put(name.toLowerCase(), this);
   }
 
-  /**
-   * Returns the material registered under the supplied name (case-insensitive), or {@link #UNDEFINED} if no such material exists.
-   *
-   * @param name the material name
-   * @return the matching material, or {@link #UNDEFINED}
-   */
+  /// Returns the material registered under the supplied name (case-insensitive), or [#UNDEFINED] if no such material exists.
+  ///
+  /// @param name the material name
+  /// @return the matching material, or [#UNDEFINED]
   public static Material get(String name) {
     if (name == null || name.isEmpty()) {
       return UNDEFINED;
@@ -59,20 +49,16 @@ public class Material extends CustomPropertyProvider {
     return materials.getOrDefault(name.toLowerCase(), UNDEFINED);
   }
 
-  /**
-   * Returns all registered materials, including any custom ones created at runtime.
-   *
-   * @return the registered materials
-   */
+  /// Returns all registered materials, including any custom ones created at runtime.
+  ///
+  /// @return the registered materials
   public static Collection<Material> getMaterials() {
     return materials.values();
   }
 
-  /**
-   * Returns the display name of this material.
-   *
-   * @return the material name
-   */
+  /// Returns the display name of this material.
+  ///
+  /// @return the material name
   public String getName() {
     return this.name;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/MovementInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/MovementInfo.java
@@ -6,45 +6,35 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation contains movement-related properties for an entity implementation.
- * It can be used to specify default properties such as acceleration, deceleration,
- * whether the entity should turn while moving, and the velocity.
- */
+/// This annotation contains movement-related properties for an entity implementation.
+/// It can be used to specify default properties such as acceleration, deceleration,
+/// whether the entity should turn while moving, and the velocity.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface MovementInfo {
 
-  /**
-   * Specifies the default acceleration of the entity.
-   * Defaults to 0.
-   *
-   * @return the default acceleration of the entity
-   */
+  /// Specifies the default acceleration of the entity.
+  /// Defaults to 0.
+  ///
+  /// @return the default acceleration of the entity
   int acceleration() default 0;
 
-  /**
-   * Specifies the default deceleration of the entity.
-   * Defaults to 0.
-   *
-   * @return the default deceleration of the entity
-   */
+  /// Specifies the default deceleration of the entity.
+  /// Defaults to 0.
+  ///
+  /// @return the default deceleration of the entity
   int deceleration() default 0;
 
-  /**
-   * Specifies whether the entity should turn while moving.
-   * Defaults to true.
-   *
-   * @return true if the entity should turn while moving, false otherwise
-   */
+  /// Specifies whether the entity should turn while moving.
+  /// Defaults to true.
+  ///
+  /// @return true if the entity should turn while moving, false otherwise
   boolean turnOnMove() default true;
 
-  /**
-   * Specifies the default velocity of the entity in pixels per second.
-   * Defaults to 100.
-   *
-   * @return the default velocity of the entity
-   */
+  /// Specifies the default velocity of the entity in pixels per second.
+  /// Defaults to 100.
+  ///
+  /// @return the default velocity of the entity
   float velocity() default 100;
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Prop.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Prop.java
@@ -9,10 +9,8 @@ import de.gurkenlabs.litiengine.graphics.animation.IEntityAnimationController;
 import de.gurkenlabs.litiengine.graphics.animation.PropAnimationController;
 import java.awt.geom.Point2D;
 
-/**
- * A static/destructible scenery entity rendered from a sprite. Props extend {@link CombatEntity} so they can take damage and be destroyed, and
- * support optional shadow rendering, sprite flipping/rotation and quality-based scaling.
- */
+/// A static/destructible scenery entity rendered from a sprite. Props extend [CombatEntity] so they can take damage and be destroyed, and
+/// support optional shadow rendering, sprite flipping/rotation and quality-based scaling.
 @AnimationInfo(spritePrefix = PropAnimationController.PROP_IDENTIFIER)
 @TmxType(MapObjectType.PROP)
 public class Prop extends CombatEntity {
@@ -38,68 +36,58 @@ public class Prop extends CombatEntity {
   @TmxProperty(name = MapObjectProperty.SPRITESHEETNAME)
   private String spritesheetName;
 
-  /**
-   * Instantiates a new {@code Prop} entity.
-   *
-   * @param spritesheetName
-   *          The spritesheet name of this prop.
-   */
+  /// Instantiates a new `Prop` entity.
+  ///
+  /// @param spritesheetName
+  /// The spritesheet name of this prop.
   public Prop(final String spritesheetName) {
     this(0, 0, spritesheetName);
   }
 
-  /**
-   * Instantiates a new {@code Prop} entity.
-   *
-   * @param x
-   *          The x-coordinate of this prop.
-   * @param y
-   *          The y-coordinate of this prop.
-   * @param spritesheetName
-   *          The spritesheet name of this prop.
-   */
+  /// Instantiates a new `Prop` entity.
+  ///
+  /// @param x
+  /// The x-coordinate of this prop.
+  /// @param y
+  /// The y-coordinate of this prop.
+  /// @param spritesheetName
+  /// The spritesheet name of this prop.
   public Prop(double x, double y, final String spritesheetName) {
     this(x, y, spritesheetName, Material.UNDEFINED);
   }
 
-  /**
-   * Instantiates a new {@code Prop} entity.
-   *
-   * @param x
-   *          The x-coordinate of this prop.
-   * @param y
-   *          The y-coordinate of this prop.
-   * @param spritesheetName
-   *          The spritesheet name of this prop.
-   * @param material
-   *          The material of this prop.
-   */
+  /// Instantiates a new `Prop` entity.
+  ///
+  /// @param x
+  /// The x-coordinate of this prop.
+  /// @param y
+  /// The y-coordinate of this prop.
+  /// @param spritesheetName
+  /// The spritesheet name of this prop.
+  /// @param material
+  /// The material of this prop.
   public Prop(double x, double y, final String spritesheetName, final Material material) {
     this(new Point2D.Double(x, y), spritesheetName, material);
   }
 
-  /**
-   * Instantiates a new {@code Prop} entity.
-   *
-   * @param location
-   *          The location of this prop.
-   * @param spritesheetName
-   *          The spritesheet name of this prop.
-   */
+  /// Instantiates a new `Prop` entity.
+  ///
+  /// @param location
+  /// The location of this prop.
+  /// @param spritesheetName
+  /// The spritesheet name of this prop.
   public Prop(final Point2D location, final String spritesheetName) {
     this(location, spritesheetName, Material.UNDEFINED);
   }
 
-  /**
-   * Instantiates a new {@code Prop} entity.
-   *
-   * @param location
-   *          The location of this prop.
-   * @param spritesheetName
-   *          The spritesheet name of this prop.
-   * @param material
-   *          The material of this prop.
-   */
+  /// Instantiates a new `Prop` entity.
+  ///
+  /// @param location
+  /// The location of this prop.
+  /// @param spritesheetName
+  /// The spritesheet name of this prop.
+  /// @param material
+  /// The material of this prop.
   public Prop(final Point2D location, final String spritesheetName, final Material material) {
     super();
     this.rotation = Rotation.NONE;
@@ -109,29 +97,23 @@ public class Prop extends CombatEntity {
     this.updateAnimationController();
   }
 
-  /**
-   * Gets the material of this prop.
-   *
-   * @return the material
-   */
+  /// Gets the material of this prop.
+  ///
+  /// @return the material
   public Material getMaterial() {
     return this.material;
   }
 
-  /**
-   * Gets the name of the spritesheet used to render this prop.
-   *
-   * @return the spritesheet name
-   */
+  /// Gets the name of the spritesheet used to render this prop.
+  ///
+  /// @return the spritesheet name
   public String getSpritesheetName() {
     return this.spritesheetName;
   }
 
-  /**
-   * Gets the state.
-   *
-   * @return the state
-   */
+  /// Gets the state.
+  ///
+  /// @return the state
   public PropState getState() {
     if (!this.isIndestructible() && this.getHitPoints().getModifiedValue() <= 0) {
       return PropState.DESTROYED;
@@ -143,84 +125,66 @@ public class Prop extends CombatEntity {
     }
   }
 
-  /**
-   * Returns whether this prop should cast a shadow.
-   *
-   * @return {@code true} if a shadow is rendered
-   */
+  /// Returns whether this prop should cast a shadow.
+  ///
+  /// @return `true` if a shadow is rendered
   public boolean isAddShadow() {
     return this.addShadow;
   }
 
-  /**
-   * Returns whether this prop's sprite is scaled to its bounding box.
-   *
-   * @return {@code true} if scaling is enabled
-   */
+  /// Returns whether this prop's sprite is scaled to its bounding box.
+  ///
+  /// @return `true` if scaling is enabled
   public boolean isScaling() {
     return this.scaling;
   }
 
-  /**
-   * Returns whether this prop's sprite is flipped horizontally.
-   *
-   * @return {@code true} if flipped horizontally
-   */
+  /// Returns whether this prop's sprite is flipped horizontally.
+  ///
+  /// @return `true` if flipped horizontally
   public boolean flipHorizontally() {
     return flipHorizontally;
   }
 
-  /**
-   * Returns whether this prop's sprite is flipped vertically.
-   *
-   * @return {@code true} if flipped vertically
-   */
+  /// Returns whether this prop's sprite is flipped vertically.
+  ///
+  /// @return `true` if flipped vertically
   public boolean flipVertically() {
     return flipVertically;
   }
 
-  /**
-   * Gets the sprite rotation applied to this prop.
-   *
-   * @return the sprite rotation
-   */
+  /// Gets the sprite rotation applied to this prop.
+  ///
+  /// @return the sprite rotation
   public Rotation getSpriteRotation() {
     return rotation;
   }
 
-  /**
-   * Sets the material of this prop.
-   *
-   * @param material the material to set
-   */
+  /// Sets the material of this prop.
+  ///
+  /// @param material the material to set
   public void setMaterial(final Material material) {
     this.material = material;
   }
 
-  /**
-   * Sets the name of the spritesheet used to render this prop and updates the animation controller.
-   *
-   * @param spriteName the new spritesheet name
-   */
+  /// Sets the name of the spritesheet used to render this prop and updates the animation controller.
+  ///
+  /// @param spriteName the new spritesheet name
   public void setSpritesheetName(final String spriteName) {
     this.spritesheetName = spriteName;
     this.updateAnimationController();
   }
 
-  /**
-   * Sets whether this prop should cast a shadow.
-   *
-   * @param addShadow {@code true} to render a shadow
-   */
+  /// Sets whether this prop should cast a shadow.
+  ///
+  /// @param addShadow `true` to render a shadow
   public void setAddShadow(boolean addShadow) {
     this.addShadow = addShadow;
   }
 
-  /**
-   * Sets whether this prop's sprite should be scaled to its bounding box.
-   *
-   * @param scaling {@code true} to enable scaling
-   */
+  /// Sets whether this prop's sprite should be scaled to its bounding box.
+  ///
+  /// @param scaling `true` to enable scaling
   public void setScaling(boolean scaling) {
     this.scaling = scaling;
   }
@@ -233,29 +197,23 @@ public class Prop extends CombatEntity {
     return this.getHitPoints().getModifiedValue() <= 0;
   }
 
-  /**
-   * Sets the sprite rotation applied to this prop.
-   *
-   * @param spriteRotation the rotation to set
-   */
+  /// Sets the sprite rotation applied to this prop.
+  ///
+  /// @param spriteRotation the rotation to set
   public void setSpriteRotation(Rotation spriteRotation) {
     this.rotation = spriteRotation;
   }
 
-  /**
-   * Sets whether this prop's sprite is flipped horizontally.
-   *
-   * @param flipHorizontally {@code true} to flip horizontally
-   */
+  /// Sets whether this prop's sprite is flipped horizontally.
+  ///
+  /// @param flipHorizontally `true` to flip horizontally
   public void setFlipHorizontally(boolean flipHorizontally) {
     this.flipHorizontally = flipHorizontally;
   }
 
-  /**
-   * Sets whether this prop's sprite is flipped vertically.
-   *
-   * @param flipVertically {@code true} to flip vertically
-   */
+  /// Sets whether this prop's sprite is flipped vertically.
+  ///
+  /// @param flipVertically `true` to flip vertically
   public void setFlipVertically(boolean flipVertically) {
     this.flipVertically = flipVertically;
   }
@@ -275,11 +233,9 @@ public class Prop extends CombatEntity {
     return str;
   }
 
-  /**
-   * Creates the animation controller used to render this prop. Subclasses may override this method to provide a custom controller implementation.
-   *
-   * @return the new animation controller
-   */
+  /// Creates the animation controller used to render this prop. Subclasses may override this method to provide a custom controller implementation.
+  ///
+  /// @return the new animation controller
   protected IEntityAnimationController<?> createAnimationController() {
     return new PropAnimationController<>(this);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/SoundSource.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/SoundSource.java
@@ -12,9 +12,7 @@ import de.gurkenlabs.litiengine.sound.SFXPlayback;
 import de.gurkenlabs.litiengine.sound.Sound;
 import de.gurkenlabs.litiengine.sound.SoundEngine;
 
-/**
- * This is an Entity that can play or loop ambient sound effects within a given range and with a given volume.
- */
+/// This is an Entity that can play or loop ambient sound effects within a given range and with a given volume.
 @EntityInfo(renderType = RenderType.OVERLAY)
 @CollisionInfo(collision = false, collisionType = Collision.NONE)
 @TmxType(MapObjectType.SOUNDSOURCE)
@@ -27,160 +25,130 @@ public class SoundSource extends Entity {
   private Sound sound;
   private SFXPlayback playback;
 
-  /** An empty constructor that just calls the super constructor of {@link Entity}. */
+  /// An empty constructor that just calls the super constructor of [Entity].
   public SoundSource() {
     super();
   }
 
-  /**
-   * Initialize a SoundSource with a Sound.
-   *
-   * @param sound
-   *          The sound used for playback
-   */
+  /// Initialize a SoundSource with a Sound.
+  ///
+  /// @param sound
+  /// The sound used for playback
   public SoundSource(Sound sound) {
     this.setSound(sound);
   }
 
-  /**
-   * Initialize a SoundSource with the name of a sound which will then be fetched from the {@code
-   * Resources.sounds()}.
-   *
-   * @param name
-   *          The name of the sound used for playback
-   * @see Sounds#get(String)
-   */
+  /// Initialize a SoundSource with the name of a sound which will then be fetched from the `Resources.sounds()`.
+  ///
+  /// @param name
+  /// The name of the sound used for playback
+  /// @see Sounds#get(String)
   public SoundSource(String name) {
     this.setSound(name);
   }
 
-  /**
-   * Initialize a SoundSource at a certain location.
-   *
-   * @param x
-   *          The x coordinate
-   * @param y
-   *          The y coordinate
-   */
+  /// Initialize a SoundSource at a certain location.
+  ///
+  /// @param x
+  /// The x coordinate
+  /// @param y
+  /// The y coordinate
   public SoundSource(double x, double y) {
     this.setX(x);
     this.setY(y);
   }
 
-  /**
-   * Initialize a SoundSource at a certain location with a given size. The size is irrelevant for the sound playback.
-   *
-   * @param x
-   *          The x coordinate
-   * @param y
-   *          The y coordinate
-   * @param width
-   *          The entity width
-   * @param height
-   *          The entity height
-   */
+  /// Initialize a SoundSource at a certain location with a given size. The size is irrelevant for the sound playback.
+  ///
+  /// @param x
+  /// The x coordinate
+  /// @param y
+  /// The y coordinate
+  /// @param width
+  /// The entity width
+  /// @param height
+  /// The entity height
   public SoundSource(double x, double y, double width, double height) {
     this(x, y);
     this.setWidth(width);
     this.setHeight(height);
   }
 
-  /**
-   * Get the volume modifier. The volume modifier is multiplied with the global sound volume defined by
-   * {@link SoundConfiguration#getSoundVolume()}.
-   *
-   * @return a float determining how much louder or quieter the sound is played back. 1.0 is the standard playback volume.
-   */
+  /// Get the volume modifier. The volume modifier is multiplied with the global sound volume defined by
+  /// [SoundConfiguration#getSoundVolume()].
+  ///
+  /// @return a float determining how much louder or quieter the sound is played back. 1.0 is the standard playback volume.
   public float getVolume() {
     return volume;
   }
 
-  /**
-   * Set the volume modifier. The volume modifier is multiplied with the global sound volume defined by
-   * {@link SoundConfiguration#getSoundVolume()}.
-   *
-   * @param volume
-   *          a float determining how much louder or quieter the sound is played back. 1.0 is the standard playback
-   *          volume.
-   */
+  /// Set the volume modifier. The volume modifier is multiplied with the global sound volume defined by
+  /// [SoundConfiguration#getSoundVolume()].
+  ///
+  /// @param volume
+  /// a float determining how much louder or quieter the sound is played back. 1.0 is the standard playback
+  /// volume.
   public void setVolume(float volume) {
     this.volume = volume;
   }
 
-  /**
-   * Boolean determining if the sound is looped or only played back once.
-   *
-   * @return {@code true}, if the sound is looped when calling {@link #play()}. {@code false}, if it is played back just
-   *         once.
-   */
+  /// Boolean determining if the sound is looped or only played back once.
+  ///
+  /// @return `true`, if the sound is looped when calling [#play()]. `false`, if it is played back just
+  /// once.
   public boolean isLoop() {
     return loop;
   }
 
-  /**
-   * Toggles looping for the sound playback.
-   *
-   * @param loop
-   *          {@code true}, if the sound should be looped when calling {@link #play()}. {@code
-   *     false}, if it should be played back just once.
-   */
+  /// Toggles looping for the sound playback.
+  ///
+  /// @param loop
+  /// `true`, if the sound should be looped when calling [#play()]. `false`, if it should be played back just once.
   public void setLoop(boolean loop) {
     this.loop = loop;
   }
 
-  /**
-   * The sound to be played.
-   *
-   * @return the sound instance used for playback.
-   */
+  /// The sound to be played.
+  ///
+  /// @return the sound instance used for playback.
   public Sound getSound() {
     return sound;
   }
 
-  /**
-   * The playback used for playing the sound.
-   *
-   * @return the playback instance.
-   */
+  /// The playback used for playing the sound.
+  ///
+  /// @return the playback instance.
   public SFXPlayback getPlayback() {
     return this.playback;
   }
 
-  /**
-   * The name of the currently set sound.
-   *
-   * @return A String containing the sound name.
-   */
+  /// The name of the currently set sound.
+  ///
+  /// @return A String containing the sound name.
   public String getSoundName() {
     return this.sound.getName();
   }
 
-  /**
-   * The range in pixels for which the sound can be heard.
-   *
-   * @return an {@code int} representing the range in pixels.
-   */
+  /// The range in pixels for which the sound can be heard.
+  ///
+  /// @return an `int` representing the range in pixels.
   public int getRange() {
     return range;
   }
 
-  /**
-   * Sets the range in pixels for which the sound can be heard.
-   *
-   * @param range
-   *          an {@code int} representing the range in pixels.
-   */
+  /// Sets the range in pixels for which the sound can be heard.
+  ///
+  /// @param range
+  /// an `int` representing the range in pixels.
   public void setRange(int range) {
     this.range = range;
   }
 
-  /**
-   * Sets the sound by fetching a sound resource with a given name.
-   *
-   * @param name
-   *          The name of the Sound resource.
-   * @see Sounds#get(String)
-   */
+  /// Sets the sound by fetching a sound resource with a given name.
+  ///
+  /// @param name
+  /// The name of the Sound resource.
+  /// @see Sounds#get(String)
   public void setSound(String name) {
     if (name == null) {
       return;
@@ -188,52 +156,42 @@ public class SoundSource extends Entity {
     this.sound = Resources.sounds().get(name);
   }
 
-  /**
-   * Sets the sound to be played.
-   *
-   * @param sound
-   *          The sound to be played
-   */
+  /// Sets the sound to be played.
+  ///
+  /// @param sound
+  /// The sound to be played
   public void setSound(Sound sound) {
     this.sound = sound;
   }
 
-  /**
-   * Starts a new playback in the SoundEngine and saves a reference to it in the SoundSource instance. The playback
-   * reference can be called with {@link #getPlayback()}.
-   *
-   * @see SoundEngine#playSound(Sound, IEntity, boolean, int, float)
-   * @see SFXPlayback
-   */
+  /// Starts a new playback in the SoundEngine and saves a reference to it in the SoundSource instance. The playback
+  /// reference can be called with [#getPlayback()].
+  ///
+  /// @see SoundEngine#playSound(Sound, IEntity, boolean, int, float)
+  /// @see SFXPlayback
   public void play() {
     this.playback =
         Game.audio()
             .playSound(this.getSound(), this, this.isLoop(), this.getRange(), this.getVolume());
   }
 
-  /**
-   * Pauses the current playback.
-   *
-   * @see SFXPlayback#pausePlayback()
-   */
+  /// Pauses the current playback.
+  ///
+  /// @see SFXPlayback#pausePlayback()
   public void pause() {
     this.getPlayback().pausePlayback();
   }
 
-  /**
-   * Resumes the current playback if it was paused.
-   *
-   * @see SFXPlayback#resumePlayback()
-   */
+  /// Resumes the current playback if it was paused.
+  ///
+  /// @see SFXPlayback#resumePlayback()
   public void resume() {
     this.getPlayback().resumePlayback();
   }
 
-  /**
-   * Cancels the current playback.
-   *
-   * @see SFXPlayback#cancel()
-   */
+  /// Cancels the current playback.
+  ///
+  /// @see SFXPlayback#cancel()
   public void stop() {
     if (getPlayback() == null) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Spawnpoint.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Spawnpoint.java
@@ -27,19 +27,15 @@ import java.util.concurrent.ConcurrentHashMap;
 
   @TmxProperty(name = MapObjectProperty.SPAWN_PIVOT_OFFSETY) private double spawnOffsetY;
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
   public Spawnpoint() {
     this.setSize(1, 1);
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param x The x-coordinate of this instance.
-   * @param y The y-coordinate of this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param x The x-coordinate of this instance.
+  /// @param y The y-coordinate of this instance.
   public Spawnpoint(double x, double y) {
     this(0, x, y);
   }
@@ -56,192 +52,153 @@ import java.util.concurrent.ConcurrentHashMap;
     this(0, location, direction);
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param mapId The map id of this instance.
-   * @param x     The x-coordinate of this instance.
-   * @param y     The y-coordinate of this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param mapId The map id of this instance.
+  /// @param x     The x-coordinate of this instance.
+  /// @param y     The y-coordinate of this instance.
   public Spawnpoint(int mapId, double x, double y) {
     this(mapId, new Point2D.Double(x, y));
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param mapId    The map id of this instance.
-   * @param location The location of this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param mapId    The map id of this instance.
+  /// @param location The location of this instance.
   public Spawnpoint(int mapId, Point2D location) {
     super(mapId);
     this.setSize(1, 1);
     this.setLocation(location);
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param mapId     The map id of this instance.
-   * @param x         The x-coordinate of this instance.
-   * @param y         The y-coordinate of this instance.
-   * @param direction The direction in which entities will be spawned by this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param mapId     The map id of this instance.
+  /// @param x         The x-coordinate of this instance.
+  /// @param y         The y-coordinate of this instance.
+  /// @param direction The direction in which entities will be spawned by this instance.
   public Spawnpoint(int mapId, double x, double y, Direction direction) {
     this(mapId, new Point2D.Double(x, y), direction);
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param mapId     The map id of this instance.
-   * @param location  The location of this instance.
-   * @param direction The direction in which entities will be spawned by this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param mapId     The map id of this instance.
+  /// @param location  The location of this instance.
+  /// @param direction The direction in which entities will be spawned by this instance.
   public Spawnpoint(int mapId, Point2D location, Direction direction) {
     this(mapId, location);
     this.setDirection(direction);
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param direction The direction in which entities will be spawned by this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param direction The direction in which entities will be spawned by this instance.
   public Spawnpoint(Direction direction) {
     this.setDirection(direction);
   }
 
-  /**
-   * Instantiates a new {@code Spawnpoint} entity.
-   *
-   * @param direction The direction in which entities will be spawned by this instance.
-   * @param spawnType The type that defines additional information about the entities spawned by this instance.
-   */
+  /// Instantiates a new `Spawnpoint` entity.
+  ///
+  /// @param direction The direction in which entities will be spawned by this instance.
+  /// @param spawnType The type that defines additional information about the entities spawned by this instance.
   public Spawnpoint(Direction direction, String spawnType) {
     this(direction);
     this.setSpawnInfo(spawnType);
   }
 
-  /**
-   * Adds the specified entity spawned listener to receive events when entities are spawned by this instance.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified entity spawned listener to receive events when entities are spawned by this instance.
+  ///
+  /// @param listener The listener to add.
   public void onSpawned(EntitySpawnedListener listener) {
     this.spawnedListeners.add(listener);
   }
 
-  /**
-   * Removes the specified entity spawned listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified entity spawned listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeSpawnedListener(EntitySpawnedListener listener) {
     this.spawnedListeners.remove(listener);
   }
 
-  /**
-   * Gets the direction in which entities will be spawned by this instance.
-   *
-   * @return the spawn direction
-   */
+  /// Gets the direction in which entities will be spawned by this instance.
+  ///
+  /// @return the spawn direction
   public Direction getDirection() {
     return direction;
   }
 
-  /**
-   * Sets the direction in which entities will be spawned by this instance.
-   *
-   * @param direction the new spawn direction
-   */
+  /// Sets the direction in which entities will be spawned by this instance.
+  ///
+  /// @param direction the new spawn direction
   public void setDirection(Direction direction) {
     this.direction = direction;
   }
 
-  /**
-   * Gets the spawn information for this instance.
-   *
-   * @return the spawn information
-   */
+  /// Gets the spawn information for this instance.
+  ///
+  /// @return the spawn information
   public String getSpawnInfo() {
     return spawnInfo;
   }
 
-  /**
-   * Sets the spawn information for this instance.
-   *
-   * @param spawnInfo the new spawn information
-   */
+  /// Sets the spawn information for this instance.
+  ///
+  /// @param spawnInfo the new spawn information
   public void setSpawnInfo(String spawnInfo) {
     this.spawnInfo = spawnInfo;
   }
 
-  /**
-   * Gets the spawn pivot type for this instance.
-   *
-   * @return the spawn pivot type
-   */
+  /// Gets the spawn pivot type for this instance.
+  ///
+  /// @return the spawn pivot type
   public EntityPivotType getSpawnPivotType() {
     return spawnPivotType;
   }
 
-  /**
-   * Sets the spawn pivot type for this instance.
-   *
-   * @param spawnPivotType the new spawn pivot type
-   */
+  /// Sets the spawn pivot type for this instance.
+  ///
+  /// @param spawnPivotType the new spawn pivot type
   public void setSpawnPivotType(EntityPivotType spawnPivotType) {
     this.spawnPivotType = spawnPivotType;
   }
 
-  /**
-   * Gets the spawn offset on the X-axis for this instance.
-   *
-   * @return the spawn offset on the X-axis
-   */
+  /// Gets the spawn offset on the X-axis for this instance.
+  ///
+  /// @return the spawn offset on the X-axis
   public double getSpawnOffsetX() {
     return spawnOffsetX;
   }
 
-  /**
-   * Sets the spawn offset on the X-axis for this instance.
-   *
-   * @param spawnOffsetX the new spawn offset on the X-axis
-   */
+  /// Sets the spawn offset on the X-axis for this instance.
+  ///
+  /// @param spawnOffsetX the new spawn offset on the X-axis
   public void setSpawnOffsetX(double spawnOffsetX) {
     this.spawnOffsetX = spawnOffsetX;
   }
 
-  /**
-   * Gets the spawn offset on the Y-axis for this instance.
-   *
-   * @return the spawn offset on the Y-axis
-   */
+  /// Gets the spawn offset on the Y-axis for this instance.
+  ///
+  /// @return the spawn offset on the Y-axis
   public double getSpawnOffsetY() {
     return spawnOffsetY;
   }
 
-  /**
-   * Sets the spawn offset on the Y-axis for this instance.
-   *
-   * @param spawnOffsetY the new spawn offset on the Y-axis
-   */
+  /// Sets the spawn offset on the Y-axis for this instance.
+  ///
+  /// @param spawnOffsetY the new spawn offset on the Y-axis
   public void setSpawnOffsetY(double spawnOffsetY) {
     this.spawnOffsetY = spawnOffsetY;
   }
 
-  /**
-   * Spawns the specified entity to the {@code Environment} of the {@code Spawnpoint} or the currently active {@code Environment}.
-   *
-   * <p>
-   * Spawning will set the location of the entity to the location defined by the spawnpoint and optionally also set the angle of the entity, if a
-   * spawn direction is defined.
-   *
-   * @param entity The entity to spawn at the specified location.
-   * @return True if the entity was spawned; otherwise false, which is typically the case if no environment is loaded.
-   * @see GameWorld#environment()
-   */
+  /// Spawns the specified entity to the `Environment` of the `Spawnpoint` or the currently active `Environment`.
+  ///
+  /// Spawning will set the location of the entity to the location defined by the spawnpoint and optionally also set the angle of the entity, if a
+  /// spawn direction is defined.
+  ///
+  /// @param entity The entity to spawn at the specified location.
+  /// @return True if the entity was spawned; otherwise false, which is typically the case if no environment is loaded.
+  /// @see GameWorld#environment()
   public boolean spawn(IEntity entity) {
     Environment env = Optional.ofNullable(getEnvironment()).orElse(Game.world().environment());
     if (env == null) {
@@ -266,12 +223,10 @@ import java.util.concurrent.ConcurrentHashMap;
     return true;
   }
 
-  /**
-   * Gets the location of the entity based on the spawn pivot type.
-   *
-   * @param entity The entity for which to get the location.
-   * @return The location of the entity based on the spawn pivot type.
-   */
+  /// Gets the location of the entity based on the spawn pivot type.
+  ///
+  /// @param entity The entity for which to get the location.
+  /// @return The location of the entity based on the spawn pivot type.
   private Point2D getEntityLocationByPivot(IEntity entity) {
     if (getSpawnPivotType() == null || getSpawnPivotType() == EntityPivotType.LOCATION) {
       return getLocation();
@@ -282,16 +237,12 @@ import java.util.concurrent.ConcurrentHashMap;
     return pivot.getPoint();
   }
 
-  /**
-   * Functional interface for listening to entity spawned events.
-   */
+  /// Functional interface for listening to entity spawned events.
   @FunctionalInterface
   public interface EntitySpawnedListener extends EventListener {
-    /**
-     * Invoked when an entity is spawned.
-     *
-     * @param event The event that contains information about the spawned entity.
-     */
+    /// Invoked when an entity is spawned.
+    ///
+    /// @param event The event that contains information about the spawned entity.
     void spawned(EntitySpawnedEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/StaticShadow.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/StaticShadow.java
@@ -22,67 +22,57 @@ public class StaticShadow extends MapArea {
   private final CollisionBox origin;
   private Area area;
 
-  /**
-   * Instantiates a new {@code StaticShadow} entity.
-   *
-   * @param shadowType The type of the static shadow.
-   * @param offset     The offset for the shadow.
-   */
+  /// Instantiates a new `StaticShadow` entity.
+  ///
+  /// @param shadowType The type of the static shadow.
+  /// @param offset     The offset for the shadow.
   public StaticShadow(StaticShadowType shadowType, int offset) {
     this.shadowType = shadowType;
     this.shadowOffset = offset;
     this.origin = null;
   }
 
-  /**
-   * Instantiates a new {@code StaticShadow} entity.
-   *
-   * @param shadowType The type of the static shadow.
-   */
+  /// Instantiates a new `StaticShadow` entity.
+  ///
+  /// @param shadowType The type of the static shadow.
   public StaticShadow(StaticShadowType shadowType) {
     this.shadowType = shadowType;
     this.shadowOffset = DEFAULT_OFFSET;
     this.origin = null;
   }
 
-  /**
-   * Instantiates a new {@code StaticShadow} entity.
-   *
-   * @param x          The x-coordinate of this instance.
-   * @param y          The y-coordinate of this instance.
-   * @param width      The width of this instance.
-   * @param height     The height of this instance.
-   * @param shadowType The type of the static shadow.
-   */
+  /// Instantiates a new `StaticShadow` entity.
+  ///
+  /// @param x          The x-coordinate of this instance.
+  /// @param y          The y-coordinate of this instance.
+  /// @param width      The width of this instance.
+  /// @param height     The height of this instance.
+  /// @param shadowType The type of the static shadow.
   public StaticShadow(double x, double y, float width, float height, StaticShadowType shadowType) {
     this(0, null, x, y, width, height, shadowType);
   }
 
-  /**
-   * Instantiates a new {@code StaticShadow} entity.
-   *
-   * @param id         The id of this entity.
-   * @param x          The x-coordinate of this instance.
-   * @param y          The y-coordinate of this instance.
-   * @param width      The width of this instance.
-   * @param height     The height of this instance.
-   * @param shadowType The type of the static shadow.
-   */
+  /// Instantiates a new `StaticShadow` entity.
+  ///
+  /// @param id         The id of this entity.
+  /// @param x          The x-coordinate of this instance.
+  /// @param y          The y-coordinate of this instance.
+  /// @param width      The width of this instance.
+  /// @param height     The height of this instance.
+  /// @param shadowType The type of the static shadow.
   public StaticShadow(int id, double x, double y, float width, float height, StaticShadowType shadowType) {
     this(id, null, x, y, width, height, shadowType);
   }
 
-  /**
-   * Instantiates a new {@code StaticShadow} entity.
-   *
-   * @param id         The id of this entity.
-   * @param name       The name of this entity.
-   * @param x          The x-coordinate of this instance.
-   * @param y          The y-coordinate of this instance.
-   * @param width      The width of this instance.
-   * @param height     The height of this instance.
-   * @param shadowType The type of the static shadow.
-   */
+  /// Instantiates a new `StaticShadow` entity.
+  ///
+  /// @param id         The id of this entity.
+  /// @param name       The name of this entity.
+  /// @param x          The x-coordinate of this instance.
+  /// @param y          The y-coordinate of this instance.
+  /// @param width      The width of this instance.
+  /// @param height     The height of this instance.
+  /// @param shadowType The type of the static shadow.
   public StaticShadow(int id, String name, double x, double y, float width, float height, StaticShadowType shadowType) {
     super(id, name, x, y, width, height);
     this.setShadowType(shadowType);
@@ -90,11 +80,9 @@ public class StaticShadow extends MapArea {
     this.shadowOffset = DEFAULT_OFFSET;
   }
 
-  /**
-   * Instantiates a new {@code StaticShadow} entity.
-   *
-   * @param collisionBox The collision box from which this shadow instance originates from.
-   */
+  /// Instantiates a new `StaticShadow` entity.
+  ///
+  /// @param collisionBox The collision box from which this shadow instance originates from.
   public StaticShadow(CollisionBox collisionBox) {
     super(0, null, collisionBox.getX(), collisionBox.getY(), collisionBox.getWidth(), collisionBox.getHeight());
     this.setShadowType(StaticShadowType.NONE);
@@ -102,20 +90,16 @@ public class StaticShadow extends MapArea {
     this.shadowOffset = DEFAULT_OFFSET;
   }
 
-  /**
-   * Gets the type of the static shadow.
-   *
-   * @return the current shadow type.
-   */
+  /// Gets the type of the static shadow.
+  ///
+  /// @return the current shadow type.
   public StaticShadowType getShadowType() {
     return this.shadowType;
   }
 
-  /**
-   * Sets the type of the static shadow and invalidates the current area.
-   *
-   * @param shadowType the new shadow type to set.
-   */
+  /// Sets the type of the static shadow and invalidates the current area.
+  ///
+  /// @param shadowType the new shadow type to set.
   public void setShadowType(final StaticShadowType shadowType) {
     this.shadowType = shadowType;
     this.area = null;
@@ -146,21 +130,17 @@ public class StaticShadow extends MapArea {
     this.area = null;
   }
 
-  /**
-   * Gets the origin collision box of this static shadow.
-   *
-   * @return the origin collision box, or null if there is no origin.
-   */
+  /// Gets the origin collision box of this static shadow.
+  ///
+  /// @return the origin collision box, or null if there is no origin.
   public CollisionBox getOrigin() {
     return this.origin;
   }
 
-  /**
-   * Returns a string representation of this static shadow. If the origin is not null, the string representation includes the origin's string
-   * representation.
-   *
-   * @return a string representation of this static shadow.
-   */
+  /// Returns a string representation of this static shadow. If the origin is not null, the string representation includes the origin's string
+  /// representation.
+  ///
+  /// @return a string representation of this static shadow.
   @Override public String toString() {
     if (this.getOrigin() == null) {
       return super.toString();
@@ -169,12 +149,10 @@ public class StaticShadow extends MapArea {
     return "[" + this.getOrigin().toString() + "] -> " + super.toString();
   }
 
-  /**
-   * Gets the area of the static shadow. If the shadow type is NONE, returns null. If the area is not already created, it calls the
-   * {@link StaticShadow#createArea()} method to generate it.
-   *
-   * @return the area of the static shadow, or null if the shadow type is NONE.
-   */
+  /// Gets the area of the static shadow. If the shadow type is NONE, returns null. If the area is not already created, it calls the
+  /// [StaticShadow#createArea()] method to generate it.
+  ///
+  /// @return the area of the static shadow, or null if the shadow type is NONE.
   public Area getArea() {
     if (getShadowType() == StaticShadowType.NONE) {
       return null;
@@ -186,9 +164,7 @@ public class StaticShadow extends MapArea {
     return area;
   }
 
-  /**
-   * Creates the area for the static shadow based on its type and dimensions. This method constructs a parallelogram shape and sets it as the area.
-   */
+  /// Creates the area for the static shadow based on its type and dimensions. This method constructs a parallelogram shape and sets it as the area.
   private void createArea() {
     if (getShadowType() == StaticShadowType.NONE) {
       return;
@@ -266,20 +242,16 @@ public class StaticShadow extends MapArea {
     this.area = new Area(parallelogram);
   }
 
-  /**
-   * Gets the offset for the shadow.
-   *
-   * @return the shadow offset.
-   */
+  /// Gets the offset for the shadow.
+  ///
+  /// @return the shadow offset.
   public int getOffset() {
     return shadowOffset;
   }
 
-  /**
-   * Sets the offset for the shadow and invalidates the current area.
-   *
-   * @param shadowOffset the new shadow offset to set.
-   */
+  /// Sets the offset for the shadow and invalidates the current area.
+  ///
+  /// @param shadowOffset the new shadow offset to set.
   public void setOffset(int shadowOffset) {
     this.shadowOffset = shadowOffset;
     this.area = null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Tag.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Tag.java
@@ -7,12 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This attribute provides initial values for Entity tags. Annotate an Entity with one or multiple Tags to add them
- * automatically when the constructor is called.
- *
- * @see IEntity#addTag(String)
- */
+/// This attribute provides initial values for Entity tags. Annotate an Entity with one or multiple Tags to add them
+/// automatically when the constructor is called.
+///
+/// @see IEntity#addTag(String)
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Tags.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Tags.java
@@ -6,14 +6,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This attribute provides initial values for Entity tags. Annotate an Entity with one or multiple Tags to add them
- * automatically when the constructor is called. {@code Tags} is just intended as a container class, use the repeatable
- * {@code Tag} annotation instead.
- *
- * @see IEntity#addTag(String)
- * @see Tag
- */
+/// This attribute provides initial values for Entity tags. Annotate an Entity with one or multiple Tags to add them
+/// automatically when the constructor is called. `Tags` is just intended as a container class, use the repeatable
+/// `Tag` annotation instead.
+///
+/// @see IEntity#addTag(String)
+/// @see Tag
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Trigger.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Trigger.java
@@ -17,9 +17,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * TODO: Triggers should be able to call entity actions (similar to the current message approach)
- */
+/// TODO: Triggers should be able to call entity actions (similar to the current message approach)
 @CollisionInfo(collision = false)
 @EntityInfo(renderType = RenderType.OVERLAY)
 @TmxType(MapObjectType.TRIGGER)
@@ -59,34 +57,28 @@ public class Trigger extends CollisionEntity implements IUpdateable {
   private long lastActivation;
   private boolean isActivated;
 
-  /**
-   * Instantiates a new {@code Trigger} entity.
-   *
-   * @param activation The activation method for this trigger.
-   * @param message    The message that gets sent by this trigger upon activation.
-   */
+  /// Instantiates a new `Trigger` entity.
+  ///
+  /// @param activation The activation method for this trigger.
+  /// @param message    The message that gets sent by this trigger upon activation.
   public Trigger(final TriggerActivation activation, final String message) {
     this(activation, null, message);
   }
 
-  /**
-   * Instantiates a new {@code Trigger} entity.
-   *
-   * @param activation The activation method for this trigger.
-   * @param name       The name of this trigger.
-   * @param message    The message that gets sent by this trigger upon activation.
-   */
+  /// Instantiates a new `Trigger` entity.
+  ///
+  /// @param activation The activation method for this trigger.
+  /// @param name       The name of this trigger.
+  /// @param message    The message that gets sent by this trigger upon activation.
   public Trigger(final TriggerActivation activation, final String name, final String message) {
     this(activation, name, message, false);
   }
 
-  /**
-   * Instantiates a new {@code Trigger} entity.
-   *
-   * @param activation The activation method for this trigger.
-   * @param message    The message that gets sent by this trigger upon activation.
-   * @param isOneTime  A flag, indicating whether this instance can only be triggered once.
-   */
+  /// Instantiates a new `Trigger` entity.
+  ///
+  /// @param activation The activation method for this trigger.
+  /// @param message    The message that gets sent by this trigger upon activation.
+  /// @param isOneTime  A flag, indicating whether this instance can only be triggered once.
   public Trigger(
     final TriggerActivation activation, final String message, final boolean isOneTime) {
     this.message = message;
@@ -96,14 +88,12 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     this.setCollisionBoxHeight(this.getHeight());
   }
 
-  /**
-   * Instantiates a new {@code Trigger} entity.
-   *
-   * @param activation The activation method for this trigger.
-   * @param name       The name of this trigger.
-   * @param message    The message that gets sent by this trigger upon activation.
-   * @param isOneTime  A flag, indicating whether this instance can only be triggered once.
-   */
+  /// Instantiates a new `Trigger` entity.
+  ///
+  /// @param activation The activation method for this trigger.
+  /// @param name       The name of this trigger.
+  /// @param message    The message that gets sent by this trigger upon activation.
+  /// @param isOneTime  A flag, indicating whether this instance can only be triggered once.
   public Trigger(
     final TriggerActivation activation,
     final String name,
@@ -113,14 +103,12 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     this.setName(name);
   }
 
-  /**
-   * Initializes a new instance of the {@code Trigger} class.
-   *
-   * @param activation The activation method for this trigger.
-   * @param message    The message that gets sent by this trigger upon activation.
-   * @param isOneTime  A flag, indicating whether this instance can only be triggered once.
-   * @param cooldown   The cooldown that needs to be respected between two activation events.
-   */
+  /// Initializes a new instance of the `Trigger` class.
+  ///
+  /// @param activation The activation method for this trigger.
+  /// @param message    The message that gets sent by this trigger upon activation.
+  /// @param isOneTime  A flag, indicating whether this instance can only be triggered once.
+  /// @param cooldown   The cooldown that needs to be respected between two activation events.
   public Trigger(
     final TriggerActivation activation,
     final String message,
@@ -130,200 +118,158 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     this.setCooldown(cooldown);
   }
 
-  /**
-   * Adds a {@link TriggerListener} to this trigger.
-   *
-   * @param listener the {@link TriggerListener} to add
-   */
+  /// Adds a [TriggerListener] to this trigger.
+  ///
+  /// @param listener the [TriggerListener] to add
   public void addTriggerListener(TriggerListener listener) {
     this.activatedListeners.add(listener);
     this.activatingConditions.add(listener);
     this.deactivatedListeners.add(listener);
   }
 
-  /**
-   * Removes a {@link TriggerListener} from this trigger.
-   *
-   * @param listener the {@link TriggerListener} to remove
-   */
+  /// Removes a [TriggerListener] from this trigger.
+  ///
+  /// @param listener the [TriggerListener] to remove
   public void removeTriggerListener(TriggerListener listener) {
     this.activatedListeners.remove(listener);
     this.activatingConditions.remove(listener);
     this.deactivatedListeners.remove(listener);
   }
 
-  /**
-   * Adds a {@link TriggerActivatedListener} to this trigger.
-   *
-   * @param listener the {@link TriggerActivatedListener} to add
-   */
+  /// Adds a [TriggerActivatedListener] to this trigger.
+  ///
+  /// @param listener the [TriggerActivatedListener] to add
   public void addActivatedListener(TriggerActivatedListener listener) {
     this.activatedListeners.add(listener);
   }
 
-  /**
-   * Removes a {@link TriggerActivatedListener} from this trigger.
-   *
-   * @param listener the {@link TriggerActivatedListener} to remove
-   */
+  /// Removes a [TriggerActivatedListener] from this trigger.
+  ///
+  /// @param listener the [TriggerActivatedListener] to remove
   public void removeActivatedListener(TriggerActivatedListener listener) {
     this.activatedListeners.remove(listener);
   }
 
-  /**
-   * Adds a {@link TriggerActivatingCondition} to this trigger.
-   *
-   * @param condition the {@link TriggerActivatingCondition} to add
-   */
+  /// Adds a [TriggerActivatingCondition] to this trigger.
+  ///
+  /// @param condition the [TriggerActivatingCondition] to add
   public void addActivatingCondition(TriggerActivatingCondition condition) {
     this.activatingConditions.add(condition);
   }
 
-  /**
-   * Removes a {@link TriggerActivatingCondition} from this trigger.
-   *
-   * @param condition the {@link TriggerActivatingCondition} to remove
-   */
+  /// Removes a [TriggerActivatingCondition] from this trigger.
+  ///
+  /// @param condition the [TriggerActivatingCondition] to remove
   public void removeActivatingCondition(TriggerActivatingCondition condition) {
     this.activatingConditions.remove(condition);
   }
 
-  /**
-   * Adds a {@link TriggerDeactivatedListener} to this trigger.
-   *
-   * @param listener the {@link TriggerDeactivatedListener} to add
-   */
+  /// Adds a [TriggerDeactivatedListener] to this trigger.
+  ///
+  /// @param listener the [TriggerDeactivatedListener] to add
   public void addDeactivatedListener(TriggerDeactivatedListener listener) {
     this.deactivatedListeners.add(listener);
   }
 
-  /**
-   * Removes a {@link TriggerDeactivatedListener} from this trigger.
-   *
-   * @param listener the {@link TriggerDeactivatedListener} to remove
-   */
+  /// Removes a [TriggerDeactivatedListener] from this trigger.
+  ///
+  /// @param listener the [TriggerDeactivatedListener] to remove
   public void removeDeactivatedListener(TriggerDeactivatedListener listener) {
     this.deactivatedListeners.remove(listener);
   }
 
-  /**
-   * Adds an activator by map ID.
-   *
-   * @param mapId the map ID of the activator to add
-   */
+  /// Adds an activator by map ID.
+  ///
+  /// @param mapId the map ID of the activator to add
   public void addActivator(final int mapId) {
     this.activators.add(mapId);
   }
 
-  /**
-   * Adds an activator entity.
-   *
-   * @param activator the activator entity to add
-   */
+  /// Adds an activator entity.
+  ///
+  /// @param activator the activator entity to add
   public void addActivator(final IEntity activator) {
     this.activators.add(activator.getMapId());
   }
 
-  /**
-   * Adds a target by map ID.
-   *
-   * @param mapId the map ID of the target to add
-   */
+  /// Adds a target by map ID.
+  ///
+  /// @param mapId the map ID of the target to add
   public void addTarget(final int mapId) {
     this.targets.add(mapId);
   }
 
-  /**
-   * Adds a target entity.
-   *
-   * @param target the target entity to add
-   */
+  /// Adds a target entity.
+  ///
+  /// @param target the target entity to add
   public void addTarget(final IEntity target) {
     this.targets.add(target.getMapId());
   }
 
-  /**
-   * Gets the activation type of this trigger.
-   *
-   * @return the activation type
-   */
+  /// Gets the activation type of this trigger.
+  ///
+  /// @return the activation type
   public TriggerActivation getActivationType() {
     return this.activationType;
   }
 
-  /**
-   * Gets the list of activators.
-   *
-   * @return the list of activators
-   */
+  /// Gets the list of activators.
+  ///
+  /// @return the list of activators
   public List<Integer> getActivators() {
     return this.activators;
   }
 
-  /**
-   * Gets the message sent by this trigger upon activation.
-   *
-   * @return the message
-   */
+  /// Gets the message sent by this trigger upon activation.
+  ///
+  /// @return the message
   public String getMessage() {
     return this.message;
   }
 
-  /**
-   * Gets the list of targets.
-   *
-   * @return the list of targets
-   */
+  /// Gets the list of targets.
+  ///
+  /// @return the list of targets
   public List<Integer> getTargets() {
     return this.targets;
   }
 
-  /**
-   * Gets the cooldown time between activations.
-   *
-   * @return the cooldown time
-   */
+  /// Gets the cooldown time between activations.
+  ///
+  /// @return the cooldown time
   public int getCooldown() {
     return this.cooldown;
   }
 
-  /**
-   * Checks whether the specified entity can interact with this trigger.
-   *
-   * @param entity The entity.
-   * @return True if the entity can interact with the trigger; otherwise false.
-   */
+  /// Checks whether the specified entity can interact with this trigger.
+  ///
+  /// @param entity The entity.
+  /// @return True if the entity can interact with the trigger; otherwise false.
   public boolean canTrigger(ICollisionEntity entity) {
     return entity.canCollideWith(this)
       && GeometricUtilities.intersects(this.getCollisionBox(), entity.getCollisionBox());
   }
 
-  /**
-   * Checks if this trigger can only be activated once.
-   *
-   * @return true if this is a one-time trigger, false otherwise.
-   */
+  /// Checks if this trigger can only be activated once.
+  ///
+  /// @return true if this is a one-time trigger, false otherwise.
   public boolean isOneTimeTrigger() {
     return this.isOneTimeTrigger;
   }
 
-  /**
-   * Checks if this trigger is currently activated.
-   *
-   * @return true if the trigger is activated, false otherwise.
-   */
+  /// Checks if this trigger is currently activated.
+  ///
+  /// @return true if the trigger is activated, false otherwise.
   public boolean isActivated() {
     return this.isActivated;
   }
 
-  /**
-   * Interacts with this trigger using the specified sender entity. If the activation type is COLLISION or the sender is null, the interaction will
-   * not proceed. If the activators list is empty or contains the sender's map ID, the trigger will be activated. Otherwise, a log message will be
-   * generated indicating that the sender was not allowed to activate the trigger.
-   *
-   * @param sender the entity attempting to interact with the trigger
-   * @return true if the trigger was successfully activated, false otherwise
-   */
+  /// Interacts with this trigger using the specified sender entity. If the activation type is COLLISION or the sender is null, the interaction will
+  /// not proceed. If the activators list is empty or contains the sender's map ID, the trigger will be activated. Otherwise, a log message will be
+  /// generated indicating that the sender was not allowed to activate the trigger.
+  ///
+  /// @param sender the entity attempting to interact with the trigger
+  /// @return true if the trigger was successfully activated, false otherwise
   public boolean interact(final IEntity sender) {
     if (this.activationType == TriggerActivation.COLLISION || sender == null) {
       return false;
@@ -340,11 +286,9 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     }
   }
 
-  /**
-   * Sets the message that gets sent by this trigger upon activation.
-   *
-   * @param message the message to set
-   */
+  /// Sets the message that gets sent by this trigger upon activation.
+  ///
+  /// @param message the message to set
   public void setMessage(final String message) {
     this.message = message;
   }
@@ -368,11 +312,9 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     super.setSize(width, height);
   }
 
-  /**
-   * Sets the cooldown time between activations.
-   *
-   * @param cooldown the cooldown time to set
-   */
+  /// Sets the cooldown time between activations.
+  ///
+  /// @param cooldown the cooldown time to set
   public void setCooldown(int cooldown) {
     this.cooldown = cooldown;
   }
@@ -415,13 +357,11 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     }
   }
 
-  /**
-   * Activates the trigger with the specified activator entity and target ID.
-   *
-   * @param activator the entity that activates the trigger
-   * @param tar       the target ID
-   * @return true if the trigger was successfully activated, false otherwise
-   */
+  /// Activates the trigger with the specified activator entity and target ID.
+  ///
+  /// @param activator the entity that activates the trigger
+  /// @param tar       the target ID
+  /// @return true if the trigger was successfully activated, false otherwise
   private boolean activate(final IEntity activator, final int tar) {
     if (!isLoaded()
       || isOneTimeTrigger() && isActivated()
@@ -475,12 +415,10 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     return true;
   }
 
-  /**
-   * Checks if the trigger is allowed to be activated based on the provided trigger event.
-   *
-   * @param te the trigger event to check
-   * @return true if the trigger can be activated, false otherwise
-   */
+  /// Checks if the trigger is allowed to be activated based on the provided trigger event.
+  ///
+  /// @param te the trigger event to check
+  /// @return true if the trigger can be activated, false otherwise
   private boolean checkActivationPredicates(TriggerEvent te) {
     // check if the trigger is allowed to be activated
     for (TriggerActivatingCondition condition : this.activatingConditions) {
@@ -498,11 +436,9 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     return true;
   }
 
-  /**
-   * Retrieves a list of entities that are in collision with this entity's collision box.
-   *
-   * @return a list of entities that intersect with this trigger's collision box
-   */
+  /// Retrieves a list of entities that are in collision with this entity's collision box.
+  ///
+  /// @return a list of entities that intersect with this trigger's collision box
   private List<IEntity> getEntitiesInCollisionBox() {
     final List<IEntity> collEntities = new CopyOnWriteArrayList<>();
     for (final ICollisionEntity coll : Game.physics().getCollisionEntities()) {
@@ -516,12 +452,10 @@ public class Trigger extends CollisionEntity implements IUpdateable {
     return collEntities;
   }
 
-  /**
-   * Retrieves a list of target IDs for this trigger. If there are no local targets, it will use the optional target provided.
-   *
-   * @param optionalTarget an optional target ID to use if no local targets are available
-   * @return a list of target IDs
-   */
+  /// Retrieves a list of target IDs for this trigger. If there are no local targets, it will use the optional target provided.
+  ///
+  /// @param optionalTarget an optional target ID to use if no local targets are available
+  /// @return a list of target IDs
   private List<Integer> getTargets(int optionalTarget) {
     List<Integer> localTargets = getTargets();
     if (optionalTarget > 0) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Trigger.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/Trigger.java
@@ -17,13 +17,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/// TODO: Triggers should be able to call entity actions (similar to the current message approach)
+/// An invisible map area that activates configured targets when an allowed entity collides or interacts.
+///
+/// Activator and target references are TMX map object IDs resolved when the environment loads.
+/// Conditions and listeners can further control or observe activation.
 @CollisionInfo(collision = false)
 @EntityInfo(renderType = RenderType.OVERLAY)
 @TmxType(MapObjectType.TRIGGER)
 public class Trigger extends CollisionEntity implements IUpdateable {
+  /// Selects the physical interaction that attempts to activate a trigger.
   public enum TriggerActivation {
+    /// Activate while an eligible entity overlaps the trigger area.
     COLLISION,
+    /// Activate when an eligible entity explicitly interacts with the trigger.
     INTERACT
   }
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerActivatedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerActivatedListener.java
@@ -2,16 +2,14 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/** This listener provides a callback for when a {@code Trigger} was activated. */
+/// This listener provides a callback for when a `Trigger` was activated.
 @FunctionalInterface
 public interface TriggerActivatedListener extends EventListener {
 
-  /**
-   * This method is called when a {@code Trigger} was activated.
-   *
-   * @param event
-   *          The event data that contains information about the trigger.
-   * @see Trigger#isActivated()
-   */
+  /// This method is called when a `Trigger` was activated.
+  ///
+  /// @param event
+  /// The event data that contains information about the trigger.
+  /// @see Trigger#isActivated()
   void activated(TriggerEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerActivatingCondition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerActivatingCondition.java
@@ -2,21 +2,16 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/**
- * This listener provides a callback that allows to check conditions for activating a {@code
- * Trigger} and prevent the activation if necessary.
- */
+/// This listener provides a callback that allows to check conditions for activating a `Trigger` and prevent the activation if necessary.
 @FunctionalInterface
 public interface TriggerActivatingCondition extends EventListener {
 
-  /**
-   * Allows to register functions that contain additional checks for the trigger activation. The return value of the
-   * function is considered the reason why the trigger cannot be activated. If the function returns anything else than
-   * null, the activation is cancelled and the result of the function is send to the activator entity.
-   *
-   * @param event
-   *          The event data that contains information about the trigger.
-   * @return The reason why the trigger cannot be activated or null if it can be activated.
-   */
+  /// Allows to register functions that contain additional checks for the trigger activation. The return value of the
+  /// function is considered the reason why the trigger cannot be activated. If the function returns anything else than
+  /// null, the activation is cancelled and the result of the function is send to the activator entity.
+  ///
+  /// @param event
+  /// The event data that contains information about the trigger.
+  /// @return The reason why the trigger cannot be activated or null if it can be activated.
   String canActivate(TriggerEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerDeactivatedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerDeactivatedListener.java
@@ -2,16 +2,14 @@ package de.gurkenlabs.litiengine.entities;
 
 import java.util.EventListener;
 
-/** This listener provides a callback for when a {@code Trigger} was deactivated. */
+/// This listener provides a callback for when a `Trigger` was deactivated.
 @FunctionalInterface
 public interface TriggerDeactivatedListener extends EventListener {
 
-  /**
-   * This method is called when a {@code Trigger} was deactivated.
-   *
-   * @param event
-   *          The event data that contains information about the trigger.
-   * @see Trigger#isActivated()
-   */
+  /// This method is called when a `Trigger` was deactivated.
+  ///
+  /// @param event
+  /// The event data that contains information about the trigger.
+  /// @see Trigger#isActivated()
   void deactivated(TriggerEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerEvent.java
@@ -4,9 +4,7 @@ import java.io.Serial;
 import java.util.EventObject;
 import java.util.List;
 
-/**
- * Represents an event triggered by a {@link Trigger} in the game.
- */
+/// Represents an event triggered by a [Trigger] in the game.
 public class TriggerEvent extends EventObject {
   @Serial private static final long serialVersionUID = 3624707673365488289L;
 
@@ -15,13 +13,11 @@ public class TriggerEvent extends EventObject {
   private final transient List<Integer> targets;
   private final transient Trigger trigger;
 
-  /**
-   * Constructs a new `TriggerEvent`.
-   *
-   * @param trigger The trigger that caused this event.
-   * @param entity  The entity that activated the trigger.
-   * @param targets The list of target IDs affected by the trigger.
-   */
+  /// Constructs a new `TriggerEvent`.
+  ///
+  /// @param trigger The trigger that caused this event.
+  /// @param entity  The entity that activated the trigger.
+  /// @param targets The list of target IDs affected by the trigger.
   TriggerEvent(final Trigger trigger, final IEntity entity, final List<Integer> targets) {
     super(trigger);
     this.trigger = trigger;
@@ -30,38 +26,30 @@ public class TriggerEvent extends EventObject {
     this.entity = entity;
   }
 
-  /**
-   * Get the entity that activated the Trigger.
-   *
-   * @return The entity that activated the trigger.
-   */
+  /// Get the entity that activated the Trigger.
+  ///
+  /// @return The entity that activated the trigger.
   public IEntity getEntity() {
     return this.entity;
   }
 
-  /**
-   * Get this Trigger's message.
-   *
-   * @return The trigger's message.
-   */
+  /// Get this Trigger's message.
+  ///
+  /// @return The trigger's message.
   public String getMessage() {
     return this.message;
   }
 
-  /**
-   * Get the entities that are affected by the Trigger.
-   *
-   * @return Target entities of the trigger.
-   */
+  /// Get the entities that are affected by the Trigger.
+  ///
+  /// @return Target entities of the trigger.
   public List<Integer> getTargets() {
     return this.targets;
   }
 
-  /**
-   * Get the Trigger affected by this event.
-   *
-   * @return The trigger.
-   */
+  /// Get the Trigger affected by this event.
+  ///
+  /// @return The trigger.
   public Trigger getTrigger() {
     return trigger;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/TriggerListener.java
@@ -1,5 +1,5 @@
 package de.gurkenlabs.litiengine.entities;
 
-/** This listener provides callbacks for when a {@code Trigger} gets activated or deactivated. */
+/// This listener provides callbacks for when a `Trigger` gets activated or deactivated.
 public interface TriggerListener
     extends TriggerActivatedListener, TriggerDeactivatedListener, TriggerActivatingCondition {}

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/AStarGrid.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/AStarGrid.java
@@ -13,20 +13,14 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Represents an A* grid used for pathfinding.
- *
- * <p>This class implements the {@link IRenderable} interface and provides methods for
- * managing and rendering a grid of A* nodes. It supports diagonal movement and allows updating the walkable state of nodes based on collisions.</p>
- */
+/// Represents an A* grid used for pathfinding.
+///
+/// This class implements the [IRenderable] interface and provides methods for
+/// managing and rendering a grid of A* nodes. It supports diagonal movement and allows updating the walkable state of nodes based on collisions.
 public class AStarGrid implements IRenderable {
-  /**
-   * The penalty value assigned to nodes that intersect with static, indestructible props.
-   */
+  /// The penalty value assigned to nodes that intersect with static, indestructible props.
   public static final double PENALTY_STATIC_PROP = 5;
-  /**
-   * The penalty value assigned to nodes that have non-walkable neighboring nodes.
-   */
+  /// The penalty value assigned to nodes that have non-walkable neighboring nodes.
   public static final double PENALTY_NOT_WALKABLE_NEIGHBOR = 4;
 
   private final AStarNode[][] grid;
@@ -36,23 +30,19 @@ public class AStarGrid implements IRenderable {
   private boolean allowDiagonalMovement = true;
   private boolean allowCuttingCorners;
 
-  /**
-   * Constructs an AStarGrid with the specified width, height, and node size.
-   *
-   * @param width    The width of the grid.
-   * @param height   The height of the grid.
-   * @param nodeSize The size of each node in the grid.
-   */
+  /// Constructs an AStarGrid with the specified width, height, and node size.
+  ///
+  /// @param width    The width of the grid.
+  /// @param height   The height of the grid.
+  /// @param nodeSize The size of each node in the grid.
   public AStarGrid(int width, int height, final int nodeSize) {
     this(new Dimension(width, height), nodeSize);
   }
 
-  /**
-   * Constructs an AStarGrid with the specified size and node size.
-   *
-   * @param size     The dimension of the grid.
-   * @param nodeSize The size of each node in the grid.
-   */
+  /// Constructs an AStarGrid with the specified size and node size.
+  ///
+  /// @param size     The dimension of the grid.
+  /// @param nodeSize The size of each node in the grid.
   public AStarGrid(final Dimension size, final int nodeSize) {
     this.size = size;
     this.nodeSize = nodeSize;
@@ -62,39 +52,31 @@ public class AStarGrid implements IRenderable {
     this.populateGrid(gridSizeX, gridSizeY);
   }
 
-  /**
-   * Checks if diagonal movement is allowed in the grid.
-   *
-   * @return True if diagonal movement is allowed; otherwise false.
-   */
+  /// Checks if diagonal movement is allowed in the grid.
+  ///
+  /// @return True if diagonal movement is allowed; otherwise false.
   public boolean isDiagonalMovementAllowed() {
     return this.allowDiagonalMovement;
   }
 
-  /**
-   * Checks if diagonal corner movement is allowed in the grid.
-   *
-   * @return True if diagonal corner movement is allowed; otherwise false.
-   */
+  /// Checks if diagonal corner movement is allowed in the grid.
+  ///
+  /// @return True if diagonal corner movement is allowed; otherwise false.
   public boolean isDiagonalCornerMovementAllowed() {
     return this.allowCuttingCorners;
   }
 
-  /**
-   * Gets the grid of A* nodes.
-   *
-   * @return A 2D array representing the grid of A* nodes.
-   */
+  /// Gets the grid of A* nodes.
+  ///
+  /// @return A 2D array representing the grid of A* nodes.
   public AStarNode[][] getGrid() {
     return this.grid;
   }
 
-  /**
-   * Gets the list of A* nodes that intersect with the specified rectangle.
-   *
-   * @param rectangle The rectangle to check for intersecting nodes.
-   * @return A list of A* nodes that intersect with the specified rectangle.
-   */
+  /// Gets the list of A* nodes that intersect with the specified rectangle.
+  ///
+  /// @param rectangle The rectangle to check for intersecting nodes.
+  /// @return A list of A* nodes that intersect with the specified rectangle.
   public List<AStarNode> getIntersectedNodes(final Rectangle2D rectangle) {
     final Point2D start = new Point2D.Double(rectangle.getMinX(), rectangle.getMinY());
     final Point2D end = new Point2D.Double(rectangle.getMaxX(), rectangle.getMaxY());
@@ -116,12 +98,10 @@ public class AStarGrid implements IRenderable {
     return nodes;
   }
 
-  /**
-   * Gets the list of neighboring A* nodes for the specified node.
-   *
-   * @param node The node for which to get the neighbors.
-   * @return A list of neighboring A* nodes.
-   */
+  /// Gets the list of neighboring A* nodes for the specified node.
+  ///
+  /// @param node The node for which to get the neighbors.
+  /// @return A list of neighboring A* nodes.
   public List<AStarNode> getNeighbors(final AStarNode node) {
     final List<AStarNode> newNeighbors = new ArrayList<>();
     final int x = node.getGridX();
@@ -151,23 +131,19 @@ public class AStarGrid implements IRenderable {
     return newNeighbors;
   }
 
-  /**
-   * Gets the A* node at the specified point.
-   *
-   * @param point The point for which to get the corresponding A* node.
-   * @return The A* node at the specified point, or null if the point is outside the grid.
-   */
+  /// Gets the A* node at the specified point.
+  ///
+  /// @param point The point for which to get the corresponding A* node.
+  /// @return The A* node at the specified point, or null if the point is outside the grid.
   public AStarNode getNode(final Point2D point) {
     return this.getNode(point.getX(), point.getY());
   }
 
-  /**
-   * Gets the A* node at the specified coordinates.
-   *
-   * @param x The x-coordinate of the point.
-   * @param y The y-coordinate of the point.
-   * @return The A* node at the specified coordinates, or null if the coordinates are outside the grid.
-   */
+  /// Gets the A* node at the specified coordinates.
+  ///
+  /// @param x The x-coordinate of the point.
+  /// @param y The y-coordinate of the point.
+  /// @return The A* node at the specified coordinates, or null if the coordinates are outside the grid.
   public AStarNode getNode(final double x, final double y) {
     int xNode = (int) (x / this.nodeSize);
     int yNode = (int) (y / this.nodeSize);
@@ -179,20 +155,16 @@ public class AStarGrid implements IRenderable {
     return this.getNode(xNode, yNode);
   }
 
-  /**
-   * Gets the size of each node in the grid.
-   *
-   * @return The size of each node in the grid.
-   */
+  /// Gets the size of each node in the grid.
+  ///
+  /// @return The size of each node in the grid.
   public int getNodeSize() {
     return this.nodeSize;
   }
 
-  /**
-   * Gets the dimension of the grid.
-   *
-   * @return The dimension of the grid.
-   */
+  /// Gets the dimension of the grid.
+  ///
+  /// @return The dimension of the grid.
   public Dimension getSize() {
     return this.size;
   }
@@ -220,43 +192,35 @@ public class AStarGrid implements IRenderable {
     }
   }
 
-  /**
-   * Sets whether diagonal movement is allowed in the grid.
-   *
-   * @param allowDiagonalMovement True to allow diagonal movement; otherwise false.
-   */
+  /// Sets whether diagonal movement is allowed in the grid.
+  ///
+  /// @param allowDiagonalMovement True to allow diagonal movement; otherwise false.
   public void setAllowDiagonalMovement(final boolean allowDiagonalMovement) {
     this.allowDiagonalMovement = allowDiagonalMovement;
   }
 
-  /**
-   * Sets whether cutting corners during diagonal movement is allowed in the grid.
-   *
-   * @param allowCuttingCorners True to allow cutting corners; otherwise false.
-   */
+  /// Sets whether cutting corners during diagonal movement is allowed in the grid.
+  ///
+  /// @param allowCuttingCorners True to allow cutting corners; otherwise false.
   public void setAllowCuttingCorners(final boolean allowCuttingCorners) {
     this.allowCuttingCorners = allowCuttingCorners;
   }
 
-  /**
-   * Updates the walkable attribute of nodes intersected by the specified rectangle.
-   *
-   * @param rectangle The rectangle within which the nodes should be updated.
-   */
+  /// Updates the walkable attribute of nodes intersected by the specified rectangle.
+  ///
+  /// @param rectangle The rectangle within which the nodes should be updated.
   public void updateWalkable(final Rectangle2D rectangle) {
     for (final AStarNode node : this.getIntersectedNodes(rectangle)) {
       node.setWalkable(!Game.physics().collides(node.getBounds(), Collision.STATIC));
     }
   }
 
-  /**
-   * Assigns a penalty to the specified A* node based on collisions and neighboring nodes.
-   *
-   * <p>If the node's location collides with a dynamic object, a penalty is calculated.
-   * The penalty is increased if the node intersects with indestructible props or has non-walkable neighbors.</p>
-   *
-   * @param node The A* node to which the penalty will be assigned.
-   */
+  /// Assigns a penalty to the specified A* node based on collisions and neighboring nodes.
+  ///
+  /// If the node's location collides with a dynamic object, a penalty is calculated.
+  /// The penalty is increased if the node intersects with indestructible props or has non-walkable neighbors.
+  ///
+  /// @param node The A* node to which the penalty will be assigned.
   protected void assignPenalty(AStarNode node) {
     if (!Game.physics().collides(node.getLocation(), Collision.DYNAMIC)) {
       return;
@@ -282,26 +246,22 @@ public class AStarGrid implements IRenderable {
     node.setPenalty(penalty);
   }
 
-  /**
-   * Adds the specified node to the list of neighbors if it is walkable.
-   *
-   * @param neighbors The list of neighboring A* nodes.
-   * @param node      The A* node to be added to the neighbors list.
-   */
+  /// Adds the specified node to the list of neighbors if it is walkable.
+  ///
+  /// @param neighbors The list of neighboring A* nodes.
+  /// @param node      The A* node to be added to the neighbors list.
   private static void addNode(final List<AStarNode> neighbors, AStarNode node) {
     if (node != null && node.isWalkable()) {
       neighbors.add(node);
     }
   }
 
-  /**
-   * Adds the specified diagonal node to the list of neighbors if it is walkable and not on a corner.
-   *
-   * @param neighbors         The list of neighboring A* nodes.
-   * @param node              The diagonal A* node to be added to the neighbors list.
-   * @param diagonalNeighbor1 The first neighboring node to check for corner condition.
-   * @param diagonalNeighbor2 The second neighboring node to check for corner condition.
-   */
+  /// Adds the specified diagonal node to the list of neighbors if it is walkable and not on a corner.
+  ///
+  /// @param neighbors         The list of neighboring A* nodes.
+  /// @param node              The diagonal A* node to be added to the neighbors list.
+  /// @param diagonalNeighbor1 The first neighboring node to check for corner condition.
+  /// @param diagonalNeighbor2 The second neighboring node to check for corner condition.
   private void addDiagonalNode(final List<AStarNode> neighbors, AStarNode node, AStarNode diagonalNeighbor1, AStarNode diagonalNeighbor2) {
     // only add diagonal neighbors when they are not on a corner
     if (node != null && this.isDiagonalCornerMovementAllowed()
@@ -310,33 +270,27 @@ public class AStarGrid implements IRenderable {
     }
   }
 
-  /**
-   * Clamps the x-coordinate to ensure it is within the valid range of the grid.
-   *
-   * @param x The x-coordinate to clamp.
-   * @return The clamped x-coordinate.
-   */
+  /// Clamps the x-coordinate to ensure it is within the valid range of the grid.
+  ///
+  /// @param x The x-coordinate to clamp.
+  /// @return The clamped x-coordinate.
   private int clampX(int x) {
     return Math.clamp(x, 0, this.getGrid().length - 1);
   }
 
-  /**
-   * Clamps the y-coordinate to ensure it is within the valid range of the grid.
-   *
-   * @param y The y-coordinate to clamp.
-   * @return The clamped y-coordinate.
-   */
+  /// Clamps the y-coordinate to ensure it is within the valid range of the grid.
+  ///
+  /// @param y The y-coordinate to clamp.
+  /// @return The clamped y-coordinate.
   private int clampY(int y) {
     return Math.clamp(y, 0, this.getGrid()[0].length - 1);
   }
 
-  /**
-   * Gets the A* node at the specified grid coordinates.
-   *
-   * @param x The x-coordinate of the node in the grid.
-   * @param y The y-coordinate of the node in the grid.
-   * @return The A* node at the specified coordinates, or null if the coordinates are outside the grid.
-   */
+  /// Gets the A* node at the specified grid coordinates.
+  ///
+  /// @param x The x-coordinate of the node in the grid.
+  /// @param y The y-coordinate of the node in the grid.
+  /// @return The A* node at the specified coordinates, or null if the coordinates are outside the grid.
   private AStarNode getNode(final int x, final int y) {
     if (x >= 0 && x < this.getGrid().length && y >= 0 && y < this.getGrid()[0].length) {
       return this.getGrid()[x][y];
@@ -345,12 +299,10 @@ public class AStarGrid implements IRenderable {
     return null;
   }
 
-  /**
-   * Populates the grid with A* nodes, initializing each node's walkable state and penalty.
-   *
-   * @param gridSizeX The number of nodes along the x-axis of the grid.
-   * @param gridSizeY The number of nodes along the y-axis of the grid.
-   */
+  /// Populates the grid with A* nodes, initializing each node's walkable state and penalty.
+  ///
+  /// @param gridSizeX The number of nodes along the x-axis of the grid.
+  /// @param gridSizeY The number of nodes along the y-axis of the grid.
   private void populateGrid(final int gridSizeX, final int gridSizeY) {
     for (int x = 0; x < gridSizeX; x++) {
       for (int y = 0; y < gridSizeY; y++) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/AStarNode.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/AStarNode.java
@@ -3,9 +3,7 @@ package de.gurkenlabs.litiengine.entities.behavior;
 import java.awt.Point;
 import java.awt.Rectangle;
 
-/**
- * Represents a node in the A* pathfinding algorithm. Each node contains information about its position, costs, and walkability.
- */
+/// Represents a node in the A* pathfinding algorithm. Each node contains information about its position, costs, and walkability.
 public class AStarNode {
   private static final double DIAGONAL_COST = 1.4;
   private final Rectangle bound;
@@ -17,14 +15,12 @@ public class AStarNode {
   private AStarNode predecessor;
   private boolean walkable;
 
-  /**
-   * Constructs a new AStarNode with the specified properties.
-   *
-   * @param walkable Whether the node is walkable.
-   * @param bound    The rectangular bounds of the node.
-   * @param gridX    The x-coordinate of the node in the grid.
-   * @param gridY    The y-coordinate of the node in the grid.
-   */
+  /// Constructs a new AStarNode with the specified properties.
+  ///
+  /// @param walkable Whether the node is walkable.
+  /// @param bound    The rectangular bounds of the node.
+  /// @param gridX    The x-coordinate of the node in the grid.
+  /// @param gridY    The y-coordinate of the node in the grid.
   public AStarNode(
     final boolean walkable, final Rectangle bound, final int gridX, final int gridY) {
     this.bound = bound;
@@ -33,21 +29,17 @@ public class AStarNode {
     this.walkable = walkable;
   }
 
-  /**
-   * Gets the rectangular bounds of this node.
-   *
-   * @return The bounds of the node.
-   */
+  /// Gets the rectangular bounds of this node.
+  ///
+  /// @return The bounds of the node.
   public Rectangle getBounds() {
     return this.bound;
   }
 
-  /**
-   * Calculates the movement cost from this node to the target node.
-   *
-   * @param target The target node.
-   * @return The movement cost to the target node.
-   */
+  /// Calculates the movement cost from this node to the target node.
+  ///
+  /// @param target The target node.
+  /// @return The movement cost to the target node.
   public double getCosts(final AStarNode target) {
     final int dstX = Math.abs(this.getGridX() - target.getGridX());
     final int dstY = Math.abs(this.getGridY() - target.getGridY());
@@ -59,146 +51,114 @@ public class AStarNode {
     return (DIAGONAL_COST * dstX) + (dstY - dstX) + this.getPenalty();
   }
 
-  /**
-   * Gets the total cost (f-cost) for this node. The f-cost is the sum of g-cost and h-cost.
-   *
-   * @return The total cost.
-   */
+  /// Gets the total cost (f-cost) for this node. The f-cost is the sum of g-cost and h-cost.
+  ///
+  /// @return The total cost.
   public double getFCost() {
     return this.getGCost() + this.getHCost();
   }
 
-  /**
-   * Gets the cost from the start node to this node (g-cost).
-   *
-   * @return The g-cost.
-   */
+  /// Gets the cost from the start node to this node (g-cost).
+  ///
+  /// @return The g-cost.
   public double getGCost() {
     return this.gCost;
   }
 
-  /**
-   * Gets the x-coordinate of this node in the grid.
-   *
-   * @return The x-coordinate.
-   */
+  /// Gets the x-coordinate of this node in the grid.
+  ///
+  /// @return The x-coordinate.
   public int getGridX() {
     return this.gridX;
   }
 
-  /**
-   * Gets the y-coordinate of this node in the grid.
-   *
-   * @return The y-coordinate.
-   */
+  /// Gets the y-coordinate of this node in the grid.
+  ///
+  /// @return The y-coordinate.
   public int getGridY() {
     return this.gridY;
   }
 
-  /**
-   * Gets the estimated cost from this node to the target node (h-cost).
-   *
-   * @return The h-cost.
-   */
+  /// Gets the estimated cost from this node to the target node (h-cost).
+  ///
+  /// @return The h-cost.
   public double getHCost() {
     return this.hCost;
   }
 
-  /**
-   * Gets the center location of this node as a Point.
-   *
-   * @return The center location of the node.
-   */
+  /// Gets the center location of this node as a Point.
+  ///
+  /// @return The center location of the node.
   public Point getLocation() {
     return new Point((int) this.getBounds().getCenterX(), (int) this.getBounds().getCenterY());
   }
 
-  /**
-   * Gets the penalty cost for this node.
-   *
-   * @return The penalty cost.
-   */
+  /// Gets the penalty cost for this node.
+  ///
+  /// @return The penalty cost.
   public double getPenalty() {
     return this.penalty;
   }
 
-  /**
-   * Gets the predecessor node in the path.
-   *
-   * @return The predecessor node.
-   */
+  /// Gets the predecessor node in the path.
+  ///
+  /// @return The predecessor node.
   public AStarNode getPredecessor() {
     return this.predecessor;
   }
 
-  /**
-   * Checks if this node is walkable.
-   *
-   * @return True if the node is walkable, false otherwise.
-   */
+  /// Checks if this node is walkable.
+  ///
+  /// @return True if the node is walkable, false otherwise.
   public boolean isWalkable() {
     return this.walkable;
   }
 
-  /**
-   * Sets the cost from the start node to this node (g-cost).
-   *
-   * @param gCost The g-cost to set.
-   */
+  /// Sets the cost from the start node to this node (g-cost).
+  ///
+  /// @param gCost The g-cost to set.
   public void setGCost(final double gCost) {
     this.gCost = gCost;
   }
 
-  /**
-   * Sets the estimated cost from this node to the target node (h-cost).
-   *
-   * @param hCost The h-cost to set.
-   */
+  /// Sets the estimated cost from this node to the target node (h-cost).
+  ///
+  /// @param hCost The h-cost to set.
   public void setHCost(final double hCost) {
     this.hCost = hCost;
   }
 
-  /**
-   * Sets the penalty cost for this node.
-   *
-   * @param penalty The penalty cost to set.
-   */
+  /// Sets the penalty cost for this node.
+  ///
+  /// @param penalty The penalty cost to set.
   public void setPenalty(final double penalty) {
     this.penalty = penalty;
   }
 
-  /**
-   * Sets the predecessor node in the path.
-   *
-   * @param predecessor The predecessor node to set.
-   */
+  /// Sets the predecessor node in the path.
+  ///
+  /// @param predecessor The predecessor node to set.
   public void setPredecessor(final AStarNode predecessor) {
     this.predecessor = predecessor;
   }
 
-  /**
-   * Sets whether this node is walkable.
-   *
-   * @param walkable True if the node is walkable, false otherwise.
-   */
+  /// Sets whether this node is walkable.
+  ///
+  /// @param walkable True if the node is walkable, false otherwise.
   public void setWalkable(final boolean walkable) {
     this.walkable = walkable;
   }
 
-  /**
-   * Clears the assigned costs and the predecessor for this node.
-   */
+  /// Clears the assigned costs and the predecessor for this node.
   public void clear() {
     this.setGCost(0);
     this.setHCost(0);
     this.setPredecessor(null);
   }
 
-  /**
-   * Returns a string representation of this node, including its grid position and costs.
-   *
-   * @return A string representation of the node.
-   */
+  /// Returns a string representation of this node, including its grid position and costs.
+  ///
+  /// @return A string representation of the node.
   @Override
   public String toString() {
     return "["

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/AStarPathFinder.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/AStarPathFinder.java
@@ -11,60 +11,48 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * A pathfinder implementation based on the A* algorithm. The A* algorithm is used to find the shortest path between two points on a grid, taking into
- * account obstacles and walkable areas.
- */
+/// A pathfinder implementation based on the A* algorithm. The A* algorithm is used to find the shortest path between two points on a grid, taking into
+/// account obstacles and walkable areas.
 public class AStarPathFinder extends PathFinder {
 
   private final AStarGrid grid;
 
-  /**
-   * Instantiates a new A* pathfinder with a predefined grid.
-   *
-   * @param grid the grid used for pathfinding
-   */
+  /// Instantiates a new A* pathfinder with a predefined grid.
+  ///
+  /// @param grid the grid used for pathfinding
   public AStarPathFinder(AStarGrid grid) {
     this.grid = grid;
   }
 
-  /**
-   * Instantiates a new A* pathfinder with a grid of the specified size and node size.
-   *
-   * @param size         the dimensions of the grid
-   * @param gridNodeSize the size of each grid node
-   */
+  /// Instantiates a new A* pathfinder with a grid of the specified size and node size.
+  ///
+  /// @param size         the dimensions of the grid
+  /// @param gridNodeSize the size of each grid node
   public AStarPathFinder(Dimension size, int gridNodeSize) {
     this.grid = new AStarGrid(size, gridNodeSize);
   }
 
-  /**
-   * Instantiates a new A* pathfinder using the map's size and a specified grid node size.
-   *
-   * @param map          the map used for pathfinding
-   * @param gridNodeSize the size of each grid node
-   */
+  /// Instantiates a new A* pathfinder using the map's size and a specified grid node size.
+  ///
+  /// @param map          the map used for pathfinding
+  /// @param gridNodeSize the size of each grid node
   public AStarPathFinder(final IMap map, final int gridNodeSize) {
     this(map.getSizeInPixels(), gridNodeSize);
   }
 
-  /**
-   * Instantiates a new A* pathfinder using the map's size and the map's tile size as the grid node size.
-   *
-   * @param map the map used for pathfinding
-   */
+  /// Instantiates a new A* pathfinder using the map's size and the map's tile size as the grid node size.
+  ///
+  /// @param map the map used for pathfinding
   public AStarPathFinder(final IMap map) {
     this(map.getSizeInPixels(), map.getTileSize().width);
   }
 
-  /**
-   * Finds a path from the entity's current position to the target using the A* algorithm. If no obstacles are present between the start and the
-   * target, a direct path is used.
-   *
-   * @param entity the mobile entity for which the path is calculated
-   * @param target the target point of the path
-   * @return the calculated path, or null if no path can be found
-   */
+  /// Finds a path from the entity's current position to the target using the A* algorithm. If no obstacles are present between the start and the
+  /// target, a direct path is used.
+  ///
+  /// @param entity the mobile entity for which the path is calculated
+  /// @param target the target point of the path
+  /// @return the calculated path, or null if no path can be found
   @Override public Path findPath(final IMobileEntity entity, final Point2D target) {
     // if there is no collision between the start and the target return a direct
     // path
@@ -102,23 +90,19 @@ public class AStarPathFinder extends PathFinder {
     return this.findAStarPath(startNode, targetNode);
   }
 
-  /**
-   * Gets the grid used by this A* pathfinder.
-   *
-   * @return the grid used for pathfinding
-   */
+  /// Gets the grid used by this A* pathfinder.
+  ///
+  /// @return the grid used for pathfinding
   public AStarGrid getGrid() {
     return this.grid;
   }
 
-  /**
-   * Finds the path from the start node to the target node using the A* algorithm. Opens and closes nodes during the process to determine the shortest
-   * path.
-   *
-   * @param startNode  the starting node of the path
-   * @param targetNode the target node of the path
-   * @return the calculated path, or null if no path is found
-   */
+  /// Finds the path from the start node to the target node using the A* algorithm. Opens and closes nodes during the process to determine the shortest
+  /// path.
+  ///
+  /// @param startNode  the starting node of the path
+  /// @param targetNode the target node of the path
+  /// @return the calculated path, or null if no path is found
   private Path findAStarPath(AStarNode startNode, AStarNode targetNode) {
     final List<AStarNode> opened = new ArrayList<>();
     final List<AStarNode> closed = new ArrayList<>();
@@ -149,16 +133,17 @@ public class AStarPathFinder extends PathFinder {
     return null;
   }
 
-  /**
-   * Updates the costs and the predecessor of all neighbors of the specified {@code currentNode}. <br> If a neighbor was previously not part of the
-   * {@code opened} list it will be added to it.<br> If a neighbor is already closed, it will be ignored.<br> If the {@link AStarNode#isWalkable()}
-   * method of a neighbor returns {@code false} it will also not be considered.
-   *
-   * @param currentNode The node for which the neighbors will be searched for.
-   * @param targetNode  The target node of the path-finding operation.
-   * @param opened      The list of all the opened nodes of the path-finding operation.
-   * @param closed      The list of all the closed nodes of the path-finding operation.
-   */
+  /// Updates the costs and the predecessor of all neighbors of the specified `currentNode`.
+  /// If a neighbor was previously not part of the
+  /// `opened` list it will be added to it.
+  /// If a neighbor is already closed, it will be ignored.
+  /// If the [AStarNode#isWalkable()]
+  /// method of a neighbor returns `false` it will also not be considered.
+  ///
+  /// @param currentNode The node for which the neighbors will be searched for.
+  /// @param targetNode  The target node of the path-finding operation.
+  /// @param opened      The list of all the opened nodes of the path-finding operation.
+  /// @param closed      The list of all the closed nodes of the path-finding operation.
   private void updateAndOpenNeighborNodes(AStarNode currentNode, AStarNode targetNode, List<AStarNode> opened, List<AStarNode> closed) {
     // check all neighbors for the potential next one
     for (final AStarNode neighbor : this.grid.getNeighbors(currentNode)) {
@@ -179,13 +164,11 @@ public class AStarPathFinder extends PathFinder {
     }
   }
 
-  /**
-   * Finds the node with the lowest cost in the open list. The cost is determined by the F-cost (G-cost + H-cost). If multiple nodes have the same
-   * F-cost, the H-cost is considered.
-   *
-   * @param openedNodes the list of nodes to evaluate
-   * @return the node with the lowest cost
-   */
+  /// Finds the node with the lowest cost in the open list. The cost is determined by the F-cost (G-cost + H-cost). If multiple nodes have the same
+  /// F-cost, the H-cost is considered.
+  ///
+  /// @param openedNodes the list of nodes to evaluate
+  /// @return the node with the lowest cost
   private static AStarNode findNodeWithLowestCost(List<AStarNode> openedNodes) {
     AStarNode lowestCostNode = openedNodes.getFirst();
     // find node with lowest cost
@@ -201,32 +184,26 @@ public class AStarPathFinder extends PathFinder {
     return lowestCostNode;
   }
 
-  /**
-   * Clears the list of nodes by resetting their state.
-   *
-   * @param nodes the list of nodes to clear
-   */
+  /// Clears the list of nodes by resetting their state.
+  ///
+  /// @param nodes the list of nodes to clear
   private static void clear(List<AStarNode> nodes) {
     for (AStarNode op : nodes) {
       op.clear();
     }
   }
 
-  /**
-   * Retraces the found path from the targetNode back to the startNode by making use of the {@link AStarNode#getPredecessor()}.
-   *
-   * <ol>
-   * <li>Adds all predecessors to a list of nodes that will be visited by the path.
-   * <li>Invert the list.
-   * <li>Create a new {@link Path2D} by iterating all nodes in the list.
-   * <li>Wrap the {@link Path2D} object into a {@link Path} to provide information about the start, target and points of
-   * the path.
-   * </ol>
-   *
-   * @param startNode  The start node for the path.
-   * @param targetNode The target node for the path.
-   * @return The found {@link Path}
-   */
+  /// Retraces the found path from the targetNode back to the startNode by making use of the [AStarNode#getPredecessor()].
+  ///
+  /// 1. Adds all predecessors to a list of nodes that will be visited by the path.
+  /// 2. Invert the list.
+  /// 3. Create a new [Path2D] by iterating all nodes in the list.
+  /// 4. Wrap the [Path2D] object into a [Path] to provide information about the start, target and points of
+  /// the path.
+  ///
+  /// @param startNode  The start node for the path.
+  /// @param targetNode The target node for the path.
+  /// @return The found [Path]
   private static Path retracePath(final AStarNode startNode, final AStarNode targetNode) {
     final List<AStarNode> path = new ArrayList<>();
     AStarNode currentNode = targetNode.getPredecessor();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/DefaultScriptBehaviorController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/DefaultScriptBehaviorController.java
@@ -10,14 +10,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * A default behavior controller that loads and manages entity scripts internally.
- *
- * <p>This controller encapsulates script bindings and delegates execution to an internal
- * {@link EntityScriptController}, allowing entity behavior to be driven dynamically by runtime scripts.
- *
- * @param <T> the type of controlled entity
- */
+/// A default behavior controller that loads and manages entity scripts internally.
+///
+/// This controller encapsulates script bindings and delegates execution to an internal
+/// [EntityScriptController], allowing entity behavior to be driven dynamically by runtime scripts.
+///
+/// @param <T> the type of controlled entity
 public class DefaultScriptBehaviorController<T extends IEntity> implements IBehaviorController {
   private final T entity;
   private final EntityScriptController<T> scriptController;
@@ -48,30 +46,24 @@ public class DefaultScriptBehaviorController<T extends IEntity> implements IBeha
     return this.entity;
   }
 
-  /**
-   * Returns the internal {@link EntityScriptController} managing the script instances.
-   *
-   * @return the script controller
-   */
+  /// Returns the internal [EntityScriptController] managing the script instances.
+  ///
+  /// @return the script controller
   public EntityScriptController<T> getScriptController() {
     return this.scriptController;
   }
 
-  /**
-   * Loads a script by its definition ID with default parameters.
-   *
-   * @param scriptId the script definition ID to load
-   */
+  /// Loads a script by its definition ID with default parameters.
+  ///
+  /// @param scriptId the script definition ID to load
   public void loadScript(final String scriptId) {
     if (scriptId == null || scriptId.isBlank()) return;
     this.loadScript(new ScriptBinding(scriptId));
   }
 
-  /**
-   * Loads a script with specific bindings and configuration parameters.
-   *
-   * @param binding the script binding to load
-   */
+  /// Loads a script with specific bindings and configuration parameters.
+  ///
+  /// @param binding the script binding to load
   public void loadScript(final ScriptBinding binding) {
     if (binding == null || binding.getScript() == null) return;
     this.loadedBindings.removeIf(b -> binding.getScript().equals(b.getScript()));
@@ -79,11 +71,9 @@ public class DefaultScriptBehaviorController<T extends IEntity> implements IBeha
     this.scriptController.setBindings(this.loadedBindings);
   }
 
-  /**
-   * Loads multiple script bindings.
-   *
-   * @param bindings the script bindings to load
-   */
+  /// Loads multiple script bindings.
+  ///
+  /// @param bindings the script bindings to load
   public void loadScripts(final Collection<ScriptBinding> bindings) {
     if (bindings == null) return;
     for (ScriptBinding binding : bindings) {
@@ -95,11 +85,9 @@ public class DefaultScriptBehaviorController<T extends IEntity> implements IBeha
     this.scriptController.setBindings(this.loadedBindings);
   }
 
-  /**
-   * Unloads a script by its definition ID.
-   *
-   * @param scriptId the script definition ID to unload
-   */
+  /// Unloads a script by its definition ID.
+  ///
+  /// @param scriptId the script definition ID to unload
   public void unloadScript(final String scriptId) {
     if (scriptId == null) return;
     if (this.loadedBindings.removeIf(b -> scriptId.equals(b.getScript()))) {
@@ -107,19 +95,15 @@ public class DefaultScriptBehaviorController<T extends IEntity> implements IBeha
     }
   }
 
-  /**
-   * Unloads all scripts currently loaded by this behavior controller.
-   */
+  /// Unloads all scripts currently loaded by this behavior controller.
   public void unloadAllScripts() {
     this.loadedBindings.clear();
     this.scriptController.setBindings(this.loadedBindings);
   }
 
-  /**
-   * Returns an unmodifiable list of script bindings currently loaded by this controller.
-   *
-   * @return the loaded script bindings
-   */
+  /// Returns an unmodifiable list of script bindings currently loaded by this controller.
+  ///
+  /// @return the loaded script bindings
   public List<ScriptBinding> getLoadedScripts() {
     return List.copyOf(this.loadedBindings);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/EntityNavigator.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/EntityNavigator.java
@@ -14,9 +14,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 
-/**
- * The EntityNavigator class is responsible for navigating an entity along a path. It implements the IUpdateable and IRenderable interfaces.
- */
+/// The EntityNavigator class is responsible for navigating an entity along a path. It implements the IUpdateable and IRenderable interfaces.
 public class EntityNavigator implements IUpdateable, IRenderable {
 
   private static final float DEFAULT_ACCEPTABLE_ERROR = 0.3f;
@@ -31,12 +29,10 @@ public class EntityNavigator implements IUpdateable, IRenderable {
   private Path path;
   private float acceptableError;
 
-  /**
-   * Constructs an EntityNavigator with a specified entity and path finder.
-   *
-   * @param entity     the entity that will be navigated by this instance
-   * @param pathFinder the path finder used to find paths for navigation
-   */
+  /// Constructs an EntityNavigator with a specified entity and path finder.
+  ///
+  /// @param entity     the entity that will be navigated by this instance
+  /// @param pathFinder the path finder used to find paths for navigation
   public EntityNavigator(final IMobileEntity entity, final PathFinder pathFinder) {
     this.cancelNavigationConditions = new CopyOnWriteArrayList<>();
     this.listeners = new CopyOnWriteArrayList<>();
@@ -46,106 +42,84 @@ public class EntityNavigator implements IUpdateable, IRenderable {
     Game.loop().attach(this);
   }
 
-  /**
-   * Instantiates a new entity navigator without a pre-initialized PathFinder.
-   *
-   * @param entity The entity that will be navigated by this instance
-   */
+  /// Instantiates a new entity navigator without a pre-initialized PathFinder.
+  ///
+  /// @param entity The entity that will be navigated by this instance
   public EntityNavigator(final IMobileEntity entity) {
     this(entity, null);
   }
 
-  /**
-   * Adds a navigation listener to this EntityNavigator.
-   *
-   * @param listener the NavigationListener to be added
-   */
+  /// Adds a navigation listener to this EntityNavigator.
+  ///
+  /// @param listener the NavigationListener to be added
   public void addNavigationListener(NavigationListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes a navigation listener from this EntityNavigator.
-   *
-   * @param listener the NavigationListener to be removed
-   */
+  /// Removes a navigation listener from this EntityNavigator.
+  ///
+  /// @param listener the NavigationListener to be removed
   public void removeNavigationListener(NavigationListener listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Adds a condition to cancel the navigation if the specified predicate evaluates to true.
-   *
-   * @param predicate the condition to evaluate for canceling the navigation
-   */
+  /// Adds a condition to cancel the navigation if the specified predicate evaluates to true.
+  ///
+  /// @param predicate the condition to evaluate for canceling the navigation
   public void cancelNavigation(final Predicate<IMobileEntity> predicate) {
     if (!this.cancelNavigationConditions.contains(predicate)) {
       this.cancelNavigationConditions.add(predicate);
     }
   }
 
-  /**
-   * Gets the entity being navigated.
-   *
-   * @return the entity being navigated
-   */
+  /// Gets the entity being navigated.
+  ///
+  /// @return the entity being navigated
   public IMobileEntity getEntity() {
     return entity;
   }
 
-  /**
-   * Gets the current path for navigation.
-   *
-   * @return the current path, or null if no path is set
-   */
+  /// Gets the current path for navigation.
+  ///
+  /// @return the current path, or null if no path is set
   public Path getPath() {
     return this.path;
   }
 
-  /**
-   * Gets the path finder used for navigation.
-   *
-   * @return the path finder, or null if no path finder is set
-   */
+  /// Gets the path finder used for navigation.
+  ///
+  /// @return the path finder, or null if no path finder is set
   public PathFinder getPathFinder() {
     return this.pathFinder;
   }
 
-  /**
-   * Gets the acceptable error for navigation.
-   *
-   * @return the acceptable error
-   */
+  /// Gets the acceptable error for navigation.
+  ///
+  /// @return the acceptable error
   public float getAcceptableError() {
     return this.acceptableError;
   }
 
-  /**
-   * Checks if the entity is currently navigating.
-   *
-   * @return true if the entity is navigating, false otherwise
-   */
+  /// Checks if the entity is currently navigating.
+  ///
+  /// @return true if the entity is navigating, false otherwise
   public boolean isNavigating() {
     return getPath() != null;
   }
 
-  /**
-   * Sets the current path for navigation.
-   *
-   * @param path the path to be navigated
-   * @return true if the path is set successfully, false otherwise
-   */
+  /// Sets the current path for navigation.
+  ///
+  /// @param path the path to be navigated
+  /// @return true if the path is set successfully, false otherwise
   public boolean navigate(final Path2D path) {
     this.path = new Path(path);
     return getPath() != null;
   }
 
-  /**
-   * Finds and sets a path to the specified target point.
-   *
-   * @param target the target point to navigate to
-   * @return true if the path is found and set successfully, false otherwise
-   */
+  /// Finds and sets a path to the specified target point.
+  ///
+  /// @param target the target point to navigate to
+  /// @return true if the path is found and set successfully, false otherwise
   public boolean navigate(final Point2D target) {
     if (this.getPathFinder() != null) {
       this.path = getPathFinder().findPath(getEntity(), target);
@@ -164,11 +138,9 @@ public class EntityNavigator implements IUpdateable, IRenderable {
     Game.graphics().renderOutline(g, getPath().getPath());
   }
 
-  /**
-   * Rotates the entity towards the specified target point.
-   *
-   * @param target the target point to rotate towards
-   */
+  /// Rotates the entity towards the specified target point.
+  ///
+  /// @param target the target point to rotate towards
   public void rotateTowards(final Point2D target) {
     final double angle =
       GeometricUtilities.calcRotationAngleInDegrees(
@@ -179,18 +151,14 @@ public class EntityNavigator implements IUpdateable, IRenderable {
     getEntity().setAngle((float) angle);
   }
 
-  /**
-   * Sets the acceptable error for navigation.
-   *
-   * @param acceptableError the acceptable error to set
-   */
+  /// Sets the acceptable error for navigation.
+  ///
+  /// @param acceptableError the acceptable error to set
   public void setAcceptableError(float acceptableError) {
     this.acceptableError = acceptableError;
   }
 
-  /**
-   * Stops the navigation and resets the current segment and path.
-   */
+  /// Stops the navigation and resets the current segment and path.
   public void stop() {
     this.currentSegment = 0;
     this.path = null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/EntityTransition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/EntityTransition.java
@@ -2,43 +2,35 @@ package de.gurkenlabs.litiengine.entities.behavior;
 
 import de.gurkenlabs.litiengine.entities.IEntity;
 
-/**
- * Represents a transition for an entity.
- *
- * @param <T> the type of entity
- */
+/// Represents a transition for an entity.
+///
+/// @param <T> the type of entity
 public abstract class EntityTransition<T extends IEntity> extends Transition {
 
   private final T entity;
 
-  /**
-   * Initializes a new instance of the EntityTransition class with the specified entity, priority, and state.
-   *
-   * @param entity   the entity associated with this transition
-   * @param priority the priority of the transition
-   * @param state    the state of the transition
-   */
+  /// Initializes a new instance of the EntityTransition class with the specified entity, priority, and state.
+  ///
+  /// @param entity   the entity associated with this transition
+  /// @param priority the priority of the transition
+  /// @param state    the state of the transition
   protected EntityTransition(final T entity, final int priority, final State state) {
     super(priority, state);
     this.entity = entity;
   }
 
-  /**
-   * Initializes a new instance of the EntityTransition class with the specified entity and priority.
-   *
-   * @param entity   the entity associated with this transition
-   * @param priority the priority of the transition
-   */
+  /// Initializes a new instance of the EntityTransition class with the specified entity and priority.
+  ///
+  /// @param entity   the entity associated with this transition
+  /// @param priority the priority of the transition
   protected EntityTransition(final T entity, final int priority) {
     super(priority);
     this.entity = entity;
   }
 
-  /**
-   * Gets the entity associated with this transition.
-   *
-   * @return the entity associated with this transition
-   */
+  /// Gets the entity associated with this transition.
+  ///
+  /// @return the entity associated with this transition
   public T getEntity() {
     return this.entity;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/Path.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/Path.java
@@ -5,9 +5,7 @@ import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.util.List;
 
-/**
- * Represents a path consisting of a series of points.
- */
+/// Represents a path consisting of a series of points.
 public class Path {
   private final Path2D path2D;
 
@@ -16,11 +14,9 @@ public class Path {
 
   private final Point2D target;
 
-  /**
-   * Constructs a Path object from a given Path2D object.
-   *
-   * @param path the Path2D object representing the path.
-   */
+  /// Constructs a Path object from a given Path2D object.
+  ///
+  /// @param path the Path2D object representing the path.
   public Path(final Path2D path) {
     this.path2D = path;
     this.points = GeometricUtilities.getPoints(this.path2D);
@@ -33,14 +29,12 @@ public class Path {
     }
   }
 
-  /**
-   * Constructs a Path object with specified start and target points, Path2D object, and list of points.
-   *
-   * @param start  the starting point of the path.
-   * @param target the target point of the path.
-   * @param path   the Path2D object representing the path.
-   * @param points the list of points that make up the path.
-   */
+  /// Constructs a Path object with specified start and target points, Path2D object, and list of points.
+  ///
+  /// @param start  the starting point of the path.
+  /// @param target the target point of the path.
+  /// @param path   the Path2D object representing the path.
+  /// @param points the list of points that make up the path.
   public Path(final Point2D start, final Point2D target, final Path2D path, final List<Point2D> points) {
     this.start = start;
     this.target = target;
@@ -48,38 +42,30 @@ public class Path {
     this.points = points;
   }
 
-  /**
-   * Gets the Path2D object representing the path.
-   *
-   * @return the Path2D object.
-   */
+  /// Gets the Path2D object representing the path.
+  ///
+  /// @return the Path2D object.
   public Path2D getPath() {
     return path2D;
   }
 
-  /**
-   * Gets the list of points that make up the path.
-   *
-   * @return the list of points.
-   */
+  /// Gets the list of points that make up the path.
+  ///
+  /// @return the list of points.
   public List<Point2D> getPoints() {
     return points;
   }
 
-  /**
-   * Gets the starting point of the path.
-   *
-   * @return the starting point.
-   */
+  /// Gets the starting point of the path.
+  ///
+  /// @return the starting point.
   public Point2D getStart() {
     return start;
   }
 
-  /**
-   * Gets the target point of the path.
-   *
-   * @return the target point.
-   */
+  /// Gets the target point of the path.
+  ///
+  /// @return the target point.
   public Point2D getTarget() {
     return target;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/PathFinder.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/PathFinder.java
@@ -13,29 +13,23 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * Abstract class representing a path finder. This class provides the basic structure for implementing pathfinding algorithms for mobile entities.
- * Subclasses are expected to implement the {@link #findPath(IMobileEntity, Point2D)} method.
- */
+/// Abstract class representing a path finder. This class provides the basic structure for implementing pathfinding algorithms for mobile entities.
+/// Subclasses are expected to implement the [Point2D)][#findPath(IMobileEntity,] method.
 public abstract class PathFinder {
   private static final float PATH_MARGIN = 2.0f;
 
-  /**
-   * Gets the path for a mobile entity from the start to the target.
-   *
-   * @param start  the mobile entity from which the pathfinding originates
-   * @param target the target point to which the entity should move
-   * @return the path to the target
-   */
+  /// Gets the path for a mobile entity from the start to the target.
+  ///
+  /// @param start  the mobile entity from which the pathfinding originates
+  /// @param target the target point to which the entity should move
+  /// @return the path to the target
   public abstract Path findPath(IMobileEntity start, Point2D target);
 
-  /**
-   * Finds a direct path from the starting point to the target point. This path is simply a straight line between the two points.
-   *
-   * @param start  the starting point of the path
-   * @param target the target point of the path
-   * @return a direct path from the start to the target, represented as a {@link Path}
-   */
+  /// Finds a direct path from the starting point to the target point. This path is simply a straight line between the two points.
+  ///
+  /// @param start  the starting point of the path
+  /// @param target the target point of the path
+  /// @return a direct path from the start to the target, represented as a [Path]
   protected Path findDirectPath(final Point2D start, final Point2D target) {
     final Path2D path2D = new GeneralPath(Path2D.WIND_NON_ZERO);
     path2D.moveTo(start.getX(), start.getY());
@@ -47,14 +41,12 @@ public abstract class PathFinder {
     return new Path(start, target, path2D, points);
   }
 
-  /**
-   * Applies a margin to a collision entity's bounding box. This margin is used to prevent collisions when calculating paths, ensuring that entities
-   * have enough space to move around obstacles.
-   *
-   * @param entity    the entity whose path margin should be applied
-   * @param rectangle the bounding box of the entity
-   * @return a new {@link Rectangle2D} with a margin applied around the original bounding box
-   */
+  /// Applies a margin to a collision entity's bounding box. This margin is used to prevent collisions when calculating paths, ensuring that entities
+  /// have enough space to move around obstacles.
+  ///
+  /// @param entity    the entity whose path margin should be applied
+  /// @param rectangle the bounding box of the entity
+  /// @return a new [Rectangle2D] with a margin applied around the original bounding box
   protected Rectangle2D applyPathMargin(final ICollisionEntity entity, final Rectangle2D rectangle) {
     // calculate offset in order to prevent collision
     final double newX = rectangle.getX() - (entity.getCollisionBox().getWidth() * 0.5 + PATH_MARGIN);
@@ -64,15 +56,13 @@ public abstract class PathFinder {
     return new Rectangle2D.Double(newX, newY, newWidth, newHeight);
   }
 
-  /**
-   * Checks whether the direct path between two points intersects with any collision boxes in the game world. This method is used to ensure that
-   * entities do not pass through obstacles.
-   *
-   * @param entity the entity for which the path is being calculated
-   * @param start  the starting point of the path
-   * @param target the target point of the path
-   * @return true if the path intersects with any collision box, false otherwise
-   */
+  /// Checks whether the direct path between two points intersects with any collision boxes in the game world. This method is used to ensure that
+  /// entities do not pass through obstacles.
+  ///
+  /// @param entity the entity for which the path is being calculated
+  /// @param start  the starting point of the path
+  /// @param target the target point of the path
+  /// @return true if the path intersects with any collision box, false otherwise
   protected boolean intersectsWithAnyCollisionBox(final ICollisionEntity entity, final Point2D start, final Point2D target) {
     final Collection<Rectangle2D> allCollisionBoxes = Game.physics().getCollisionBoxes();
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/State.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/State.java
@@ -5,79 +5,61 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * Represents an abstract state in a state machine.
- */
+/// Represents an abstract state in a state machine.
 public abstract class State {
 
   private final String name;
   private final List<Transition> transitions;
   private final Collection<StateListener> listeners = ConcurrentHashMap.newKeySet();
 
-  /**
-   * Initializes a new instance of the State class with the specified name.
-   *
-   * @param name the name of the state
-   */
+  /// Initializes a new instance of the State class with the specified name.
+  ///
+  /// @param name the name of the state
   protected State(final String name) {
     this.transitions = new CopyOnWriteArrayList<>();
     this.name = name;
   }
 
-  /**
-   * Called when the state is entered. Notifies all registered listeners about the state entry.
-   */
+  /// Called when the state is entered. Notifies all registered listeners about the state entry.
   public void enter() {
     StateEvent event = new StateEvent(this);
     listeners.forEach(listener -> listener.onEnter(event));
   }
 
-  /**
-   * Called when the state is exited. Notifies all registered listeners about the state exit.
-   */
+  /// Called when the state is exited. Notifies all registered listeners about the state exit.
   public void exit() {
     StateEvent event = new StateEvent(this);
     listeners.forEach(listener -> listener.onExit(event));
   }
 
-  /**
-   * Gets the name of the state.
-   *
-   * @return the name of the state
-   */
+  /// Gets the name of the state.
+  ///
+  /// @return the name of the state
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Gets the list of transitions associated with this state.
-   *
-   * @return the list of transitions
-   */
+  /// Gets the list of transitions associated with this state.
+  ///
+  /// @return the list of transitions
   public List<Transition> getTransitions() {
     return this.transitions;
   }
 
-  /**
-   * Adds a listener to be notified of state events.
-   *
-   * @param listener the listener to be added
-   */
+  /// Adds a listener to be notified of state events.
+  ///
+  /// @param listener the listener to be added
   public void addStateListener(final StateListener listener) {
     listeners.add(listener);
   }
 
-  /**
-   * Removes a listener from being notified of state events.
-   *
-   * @param listener the listener to be removed
-   */
+  /// Removes a listener from being notified of state events.
+  ///
+  /// @param listener the listener to be removed
   public void removeStateListener(final StateListener listener) {
     listeners.remove(listener);
   }
 
-  /**
-   * Performs the actions associated with this state.
-   */
+  /// Performs the actions associated with this state.
   protected abstract void perform();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/StateController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/StateController.java
@@ -2,30 +2,24 @@ package de.gurkenlabs.litiengine.entities.behavior;
 
 import de.gurkenlabs.litiengine.entities.IEntity;
 
-/**
- * Controls the state of an entity.
- *
- * @param <T> the type of entity
- */
+/// Controls the state of an entity.
+///
+/// @param <T> the type of entity
 public class StateController<T extends IEntity> extends StateMachine
   implements IBehaviorController {
   private final T entity;
 
-  /**
-   * Initializes a new instance of the StateController class with the specified entity.
-   *
-   * @param entity the entity associated with this state controller
-   */
+  /// Initializes a new instance of the StateController class with the specified entity.
+  ///
+  /// @param entity the entity associated with this state controller
   protected StateController(final T entity) {
     super();
     this.entity = entity;
   }
 
-  /**
-   * Gets the entity associated with this state controller.
-   *
-   * @return the entity associated with this state controller
-   */
+  /// Gets the entity associated with this state controller.
+  ///
+  /// @return the entity associated with this state controller
   @Override
   public T getEntity() {
     return this.entity;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/StateMachine.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/StateMachine.java
@@ -5,27 +5,21 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * Represents a state machine that manages the states and transitions of an entity.
- */
+/// Represents a state machine that manages the states and transitions of an entity.
 public class StateMachine implements IUpdateable {
 
   private State currentState;
 
-  /**
-   * Gets the current state of the state machine.
-   *
-   * @return the current state
-   */
+  /// Gets the current state of the state machine.
+  ///
+  /// @return the current state
   public State getCurrentState() {
     return currentState;
   }
 
-  /**
-   * Sets a new state for the state machine.
-   *
-   * @param newState the new state to be set
-   */
+  /// Sets a new state for the state machine.
+  ///
+  /// @param newState the new state to be set
   public void setState(State newState) {
     if (currentState != null) {
       currentState.exit();
@@ -35,9 +29,7 @@ public class StateMachine implements IUpdateable {
     currentState.enter();
   }
 
-  /**
-   * Updates the state machine, performing the current state's actions and handling transitions.
-   */
+  /// Updates the state machine, performing the current state's actions and handling transitions.
   @Override
   public void update() {
     if (currentState == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/Transition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/behavior/Transition.java
@@ -1,66 +1,52 @@
 package de.gurkenlabs.litiengine.entities.behavior;
 
-/**
- * Represents a transition with a priority and a target state.
- */
+/// Represents a transition with a priority and a target state.
 public abstract class Transition implements Comparable<Transition> {
   private final int priority;
   private State targetState;
 
-  /**
-   * Initializes a new instance of the Transition class with the specified priority.
-   *
-   * @param priority the priority of the transition
-   */
+  /// Initializes a new instance of the Transition class with the specified priority.
+  ///
+  /// @param priority the priority of the transition
   protected Transition(final int priority) {
     this.priority = priority;
   }
 
-  /**
-   * Initializes a new instance of the Transition class with the specified priority and target state.
-   *
-   * @param priority    the priority of the transition
-   * @param targetState the target state of the transition
-   */
+  /// Initializes a new instance of the Transition class with the specified priority and target state.
+  ///
+  /// @param priority    the priority of the transition
+  /// @param targetState the target state of the transition
   protected Transition(final int priority, final State targetState) {
     this(priority);
     this.targetState = targetState;
   }
 
-  /**
-   * Compares this transition with another transition based on their priorities.
-   *
-   * @param other the other transition to compare with
-   * @return a negative integer, zero, or a positive integer as this transition's priority is less than, equal to, or greater than the specified
-   * transition's priority
-   */
+  /// Compares this transition with another transition based on their priorities.
+  ///
+  /// @param other the other transition to compare with
+  /// @return a negative integer, zero, or a positive integer as this transition's priority is less than, equal to, or greater than the specified
+  /// transition's priority
   @Override
   public int compareTo(final Transition other) {
     return Integer.compare(this.getPriority(), other.getPriority());
   }
 
-  /**
-   * Gets the next state of the transition.
-   *
-   * @return the next state of the transition
-   */
+  /// Gets the next state of the transition.
+  ///
+  /// @return the next state of the transition
   public State getNextState() {
     return this.targetState;
   }
 
-  /**
-   * Gets the priority of the transition.
-   *
-   * @return the priority of the transition
-   */
+  /// Gets the priority of the transition.
+  ///
+  /// @return the priority of the transition
   public int getPriority() {
     return this.priority;
   }
 
-  /**
-   * Checks if the conditions for the transition are fulfilled.
-   *
-   * @return true if the conditions are fulfilled, false otherwise
-   */
+  /// Checks if the conditions for the transition are fulfilled.
+  ///
+  /// @return true if the conditions are fulfilled, false otherwise
   protected abstract boolean conditionsFullfilled();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/entities/package-info.java
@@ -1,0 +1,6 @@
+/// Objects that occupy an environment and participate in rendering, collision, or gameplay.
+///
+/// [de.gurkenlabs.litiengine.entities.IEntity] defines the common contract and
+/// [de.gurkenlabs.litiengine.entities.Entity] supplies the standard implementation. Use
+/// [de.gurkenlabs.litiengine.entities.EntityQuery] for fluent selection.
+package de.gurkenlabs.litiengine.entities;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/CreatureMapObjectLoader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/CreatureMapObjectLoader.java
@@ -32,31 +32,22 @@ public class CreatureMapObjectLoader extends MapObjectLoader {
     super(MapObjectType.CREATURE);
   }
 
-  /**
-   * <p>
-   * Registers a custom {@link Creature} implementation that can be automatically provided by this
-   * {@link MapObjectLoader}.
-   * </p>
-   *
-   * <p>
-   * <b>This should only be used if the particular implementation doesn't require any additional map object properties to
-   * be initialized.</b>
-   * </p>
-   * <p>
-   * Make sure that the implementation has the following present:
-   * <ol>
-   * <li>An {@link AnimationInfo} annotation with one or more sprite prefixes defined</li>
-   * <li>Either an empty constructor or a constructor that takes in the sprite prefix from the loader.</li>
-   * </ol>
-   *
-   * <p>
-   * The latter is particularly useful for classes that can have different sprite sheets, i.e. share the same logic but
-   * might have a different appearance.
-   * </p>
-   *
-   * @param <T>          The type of the custom creature implementation.
-   * @param creatureType The class of the custom {@link Creature} implementation.
-   */
+  /// Registers a custom [Creature] implementation that can be automatically provided by this
+  /// [MapObjectLoader].
+  ///
+  /// **This should only be used if the particular implementation doesn't require any additional map object properties to
+  /// be initialized.**
+  ///
+  /// Make sure that the implementation has the following present:
+  ///
+  /// 1. An [AnimationInfo] annotation with one or more sprite prefixes defined
+  /// 2. Either an empty constructor or a constructor that takes in the sprite prefix from the loader.
+  ///
+  /// The latter is particularly useful for classes that can have different sprite sheets, i.e. share the same logic but
+  /// might have a different appearance.
+  ///
+  /// @param <T>          The type of the custom creature implementation.
+  /// @param creatureType The class of the custom [Creature] implementation.
   public static <T extends Creature> void registerCustomCreatureType(Class<T> creatureType) {
     customCreatureType.add(creatureType);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/CustomMapObjectLoader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/CustomMapObjectLoader.java
@@ -9,65 +9,56 @@ import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The {@code CustomMapObjectLoader} class extends the {@link MapObjectLoader} class to provide custom functionality for loading map objects into
- * entities.
- *
- * <p>This class uses a functional interface {@code ConstructorInvocation} to dynamically
- * invoke constructors of entity classes based on the provided {@link IMapObject} and {@link Environment}. It supports various constructor signatures
- * and prioritizes them based on their parameter types.
- *
- * <p>It also overrides the {@code load} method to handle the creation and initialization
- * of entities from map objects.
- */
+/// The `CustomMapObjectLoader` class extends the [MapObjectLoader] class to provide custom functionality for loading map objects into
+/// entities.
+///
+/// This class uses a functional interface `ConstructorInvocation` to dynamically
+/// invoke constructors of entity classes based on the provided [IMapObject] and [Environment]. It supports various constructor signatures
+/// and prioritizes them based on their parameter types.
+///
+/// It also overrides the `load` method to handle the creation and initialization
+/// of entities from map objects.
 public final class CustomMapObjectLoader extends MapObjectLoader {
   private static final Logger log = Logger.getLogger(CustomMapObjectLoader.class.getName());
   private final ConstructorInvocation invoke;
 
-  /**
-   * A functional interface for invoking constructors of entity classes.
-   *
-   * <p>This interface defines a single method {@code invoke}, which dynamically
-   * creates an instance of an {@link IEntity} using the provided {@link Environment} and {@link IMapObject}.
-   */
+  /// A functional interface for invoking constructors of entity classes.
+  ///
+  /// This interface defines a single method `invoke`, which dynamically
+  /// creates an instance of an [IEntity] using the provided [Environment] and [IMapObject].
   @FunctionalInterface
   interface ConstructorInvocation {
     IEntity invoke(Environment environment, IMapObject mapObject) throws InvocationTargetException, IllegalAccessException, InstantiationException;
   }
 
-  /**
-   * Constructs a new {@code CustomMapObjectLoader} instance with the specified map object type and constructor invocation logic.
-   *
-   * <p>This constructor initializes the loader with a specific map object type and a functional
-   * interface for dynamically invoking constructors of entity classes.
-   *
-   * @param mapObjectType the type of the map object to be handled by this loader
-   * @param invocation    the {@link ConstructorInvocation} functional interface used to create entities
-   */
+  /// Constructs a new `CustomMapObjectLoader` instance with the specified map object type and constructor invocation logic.
+  ///
+  /// This constructor initializes the loader with a specific map object type and a functional
+  /// interface for dynamically invoking constructors of entity classes.
+  ///
+  /// @param mapObjectType the type of the map object to be handled by this loader
+  /// @param invocation    the [ConstructorInvocation] functional interface used to create entities
   CustomMapObjectLoader(String mapObjectType, ConstructorInvocation invocation) {
     super(mapObjectType);
     this.invoke = invocation;
   }
 
-  /**
-   * Finds the most suitable constructor for the specified entity type.
-   *
-   * <p>This method iterates through all constructors of the given entity class and determines
-   * the best match based on the parameter types. It prioritizes constructors in the following order:
-   * <ol>
-   *   <li>Constructor with parameters {@link Environment} and {@link IMapObject}</li>
-   *   <li>Constructor with parameters {@link IMapObject} and {@link Environment}</li>
-   *   <li>Constructor with a single {@link IMapObject} parameter</li>
-   *   <li>Constructor with a single {@link Environment} parameter</li>
-   *   <li>Default (no-argument) constructor</li>
-   * </ol>
-   *
-   * <p>If multiple constructors match, the one with the highest priority is selected.
-   *
-   * @param entityType the class of the entity for which a constructor is to be found
-   * @return a {@link ConstructorInvocation} functional interface for invoking the selected constructor, or {@code null} if no suitable constructor is
-   * uctor is found
-   */
+  /// Finds the most suitable constructor for the specified entity type.
+  ///
+  /// This method iterates through all constructors of the given entity class and determines
+  /// the best match based on the parameter types. It prioritizes constructors in the following order:
+  ///
+  /// 1. Constructor with parameters [Environment] and [IMapObject]
+  /// 2. Constructor with parameters [IMapObject] and [Environment]
+  /// 3. Constructor with a single [IMapObject] parameter
+  /// 4. Constructor with a single [Environment] parameter
+  /// 5. Default (no-argument) constructor
+  ///
+  /// If multiple constructors match, the one with the highest priority is selected.
+  ///
+  /// @param entityType the class of the entity for which a constructor is to be found
+  /// @return a [ConstructorInvocation] functional interface for invoking the selected constructor, or `null` if no suitable constructor is
+  /// uctor is found
   static ConstructorInvocation findConstructor(Class<? extends IEntity> entityType) {
     ConstructorInvocation inv = null;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EntitySpawner.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EntitySpawner.java
@@ -11,11 +11,9 @@ import java.util.function.Function;
 // TODO: Implement spawn event/listener
 // TODO: Implement additional constructors to enhance the API
 
-/**
- * Represents an abstract entity spawner. This class implements the {@link IEntitySpawner} interface.
- *
- * @param <T> The type of entity to be spawned, which must extend {@link IEntity}.
- */
+/// Represents an abstract entity spawner. This class implements the [IEntitySpawner] interface.
+///
+/// @param <T> The type of entity to be spawned, which must extend [IEntity].
 public abstract class EntitySpawner<T extends IEntity> implements IEntitySpawner<T> {
   private int amount;
   private int interval;
@@ -43,14 +41,12 @@ public abstract class EntitySpawner<T extends IEntity> implements IEntitySpawner
     this.spawnMode = spawnMode;
   }
 
-  /**
-   * Initializes a new instance of the {@code EntitySpawner} class.
-   *
-   * @param spawnpoints The spawnpoints from which this instance will choose from when spawning entities.
-   * @param interval    The interval in which entities will be spawned.
-   * @param amount      The amount of entities to spawn on every spawn event.
-   * @param spawnMode   the spawning behaviour
-   */
+  /// Initializes a new instance of the `EntitySpawner` class.
+  ///
+  /// @param spawnpoints The spawnpoints from which this instance will choose from when spawning entities.
+  /// @param interval    The interval in which entities will be spawned.
+  /// @param amount      The amount of entities to spawn on every spawn event.
+  /// @param spawnMode   the spawning behaviour
   protected EntitySpawner(final List<Spawnpoint> spawnpoints, final int interval, final int amount, SpawnMode spawnMode) {
     this.interval = interval;
     this.spawnDelay = 1000;
@@ -138,11 +134,9 @@ public abstract class EntitySpawner<T extends IEntity> implements IEntitySpawner
     return new ArrayList<>();
   }
 
-  /**
-   * Spawn new entities, depending on the {@code SpawnMode}, spawnAmount, spawnDelay, and spawnInterval of an {@code EntitySpawner}.
-   *
-   * @see SpawnMode
-   */
+  /// Spawn new entities, depending on the `SpawnMode`, spawnAmount, spawnDelay, and spawnInterval of an `EntitySpawner`.
+  ///
+  /// @see SpawnMode
   protected void spawnNewEntities() {
     if (this.getSpawnMode() != SpawnMode.CUSTOMSPAWNPOINTS && this.getSpawnPoints().isEmpty()) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/Environment.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/Environment.java
@@ -133,11 +133,9 @@ public final class Environment implements IRenderable {
     registerMapObjectLoader(new SoundSourceMapObjectLoader());
   }
 
-  /**
-   * Instantiates a new {@code Environment} for the specified map.
-   *
-   * @param map The map that defines this environment.
-   */
+  /// Instantiates a new `Environment` for the specified map.
+  ///
+  /// @param map The map that defines this environment.
   public Environment(final IMap map) {
     this.map = map;
     if (this.getMap() != null) {
@@ -151,51 +149,41 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Instantiates a new {@code Environment} for the specified map.
-   *
-   * @param mapPath The path to the map resource that defines this environment.
-   */
+  /// Instantiates a new `Environment` for the specified map.
+  ///
+  /// @param mapPath The path to the map resource that defines this environment.
   public Environment(final String mapPath) {
     this(Resources.maps().get(mapPath));
   }
 
-  /**
-   * Registers a custom loader instance that is responsible for loading and initializing entities of the defined MapObjectType. <br>
-   * <br>
-   * There can only be one loader for a particular type. Calling this method again for the same type will overwrite the previously registered loader.
-   *
-   * @param mapObjectLoader The MapObjectLoader instance to be registered.
-   * @see IMapObjectLoader#getMapObjectType()
-   */
+  /// Registers a custom loader instance that is responsible for loading and initializing entities of the defined MapObjectType.
+  ///
+  /// There can only be one loader for a particular type. Calling this method again for the same type will overwrite the previously registered loader.
+  ///
+  /// @param mapObjectLoader The MapObjectLoader instance to be registered.
+  /// @see IMapObjectLoader#getMapObjectType()
   public static void registerMapObjectLoader(IMapObjectLoader mapObjectLoader) {
     mapObjectLoaders.put(mapObjectLoader.getMapObjectType(), mapObjectLoader);
   }
 
-  /**
-   * Registers a custom {@code IEntity} implementation to support being loaded from an {@code IMap} instance. Note that the specified class needs to
-   * be accessible in a static manner. Inner classes that aren't declared statically are not supported.
-   * <p>
-   * This is an overload of the {@link #registerCustomEntityType(Class)} method that allows to explicitly specify the {@code MapObjectType} without
-   * having to provide an {@code EntityInfo} annotation containing this information.
-   *
-   * <p>
-   * Custom entity types need to provide at least one constructor that matches the following criteria:
-   * </p>
-   *
-   * <ul>
-   * <li>has 2 parameters: {@code Environment, IMapObject}</li>
-   * <li>has 2 parameters: {@code IMapObject, Environment}</li>
-   * <li>has 1 parameter: {@code IMapObject}</li>
-   * <li>has 1 parameter: {@code Environment}</li>
-   * <li>is empty constructor</li>
-   * </ul>
-   *
-   * @param mapObjectType The custom mapobjectType that is used by {@code IMapObjects} to determine the target entity implementation.
-   * @param entityType    The class type of the custom entity implementation.
-   * @see IMapObject#getType()
-   * @see EntityInfo#customMapObjectType()
-   */
+  /// Registers a custom `IEntity` implementation to support being loaded from an `IMap` instance. Note that the specified class needs to
+  /// be accessible in a static manner. Inner classes that aren't declared statically are not supported.
+  ///
+  /// This is an overload of the [#registerCustomEntityType(Class)] method that allows to explicitly specify the `MapObjectType` without
+  /// having to provide an `EntityInfo` annotation containing this information.
+  ///
+  /// Custom entity types need to provide at least one constructor that matches the following criteria:
+  ///
+  /// - has 2 parameters: `Environment, IMapObject`
+  /// - has 2 parameters: `IMapObject, Environment`
+  /// - has 1 parameter: `IMapObject`
+  /// - has 1 parameter: `Environment`
+  /// - is empty constructor
+  ///
+  /// @param mapObjectType The custom mapobjectType that is used by `IMapObjects` to determine the target entity implementation.
+  /// @param entityType    The class type of the custom entity implementation.
+  /// @see IMapObject#getType()
+  /// @see EntityInfo#customMapObjectType()
   public static void registerCustomEntityType(String mapObjectType,
     Class<? extends IEntity> entityType) {
     if (entityType.isInterface() || Modifier.isAbstract(entityType.getModifiers())) {
@@ -218,17 +206,15 @@ public final class Environment implements IRenderable {
     registerMapObjectLoader(mapObjectLoader);
   }
 
-  /**
-   * Registers a custom {@code IEntity} implementation to support being loaded from an {@code IMap} instance. Note that the specified class needs to
-   * be accessible in a static manner. Inner classes that aren't declared statically are not supported.
-   * <p>
-   * This implementation uses the provided {@code EntityInfo.customMapObjectType()} to determine for which type the specified class should be used.
-   *
-   * @param entityType The class type of the custom entity implementation.
-   * @see Environment#registerCustomEntityType(String, Class)
-   * @see IMapObject#getType()
-   * @see EntityInfo#customMapObjectType()
-   */
+  /// Registers a custom `IEntity` implementation to support being loaded from an `IMap` instance. Note that the specified class needs to
+  /// be accessible in a static manner. Inner classes that aren't declared statically are not supported.
+  ///
+  /// This implementation uses the provided `EntityInfo.customMapObjectType()` to determine for which type the specified class should be used.
+  ///
+  /// @param entityType The class type of the custom entity implementation.
+  /// @see Environment#registerCustomEntityType(String, Class)
+  /// @see IMapObject#getType()
+  /// @see EntityInfo#customMapObjectType()
   public static void registerCustomEntityType(Class<? extends IEntity> entityType) {
     EntityInfo info = entityType.getAnnotation(EntityInfo.class);
     if (info == null || info.customMapObjectType().isEmpty()) {
@@ -241,11 +227,9 @@ public final class Environment implements IRenderable {
     registerCustomEntityType(info.customMapObjectType(), entityType);
   }
 
-  /**
-   * Registers an entity type declared for map editing with {@link MapObjectDefinition}.
-   *
-   * @param entityType the annotated entity implementation
-   */
+  /// Registers an entity type declared for map editing with [MapObjectDefinition].
+  ///
+  /// @param entityType the annotated entity implementation
   public static void registerMapObjectDefinition(Class<? extends IEntity> entityType) {
     MapObjectDefinition definition = entityType.getAnnotation(MapObjectDefinition.class);
     if (definition == null || definition.id().isBlank()) {
@@ -262,72 +246,58 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Adds the specified environment rendered listener to receive events when this instance renders the specified renderType.
-   *
-   * @param renderType The type that defines to which render process this listener should be attached.
-   * @param listener   The listener to add.
-   */
+  /// Adds the specified environment rendered listener to receive events when this instance renders the specified renderType.
+  ///
+  /// @param renderType The type that defines to which render process this listener should be attached.
+  /// @param listener   The listener to add.
   public void onRendered(RenderType renderType, EnvironmentRenderedListener listener) {
     this.renderListeners.get(renderType).add(listener);
   }
 
-  /**
-   * Removes the specified environment rendered listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment rendered listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeListener(EnvironmentRenderedListener listener) {
     for (Collection<EnvironmentRenderedListener> rends : this.renderListeners.values()) {
       rends.remove(listener);
     }
   }
 
-  /**
-   * Adds the specified environment listener to receive events about the basic environment life-cycle.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment listener to receive events about the basic environment life-cycle.
+  ///
+  /// @param listener The listener to add.
   public void addListener(EnvironmentListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes the environment listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the environment listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeListener(EnvironmentListener listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Adds the specified environment entity listener to receive events about entities on this environment.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment entity listener to receive events about entities on this environment.
+  ///
+  /// @param listener The listener to add.
   public void addEntityListener(EnvironmentEntityListener listener) {
     this.entityListeners.add(listener);
   }
 
-  /**
-   * Removes the environment entity listener listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the environment entity listener listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeEntityListener(EnvironmentEntityListener listener) {
     this.entityListeners.remove(listener);
   }
 
-  /**
-   * Adds the specified entity to the environment container. This also loads the entity (registers entity and controllers for update) if the
-   * environment has already been loaded. The entity will not be bound to a layer.
-   *
-   * @param entity The entity to add to the environment.
-   * @see #isLoaded()
-   * @see IEntity#loaded(Environment)
-   * @see EnvironmentEntityListener#entityAdded(IEntity)
-   */
+  /// Adds the specified entity to the environment container. This also loads the entity (registers entity and controllers for update) if the
+  /// environment has already been loaded. The entity will not be bound to a layer.
+  ///
+  /// @param entity The entity to add to the environment.
+  /// @see #isLoaded()
+  /// @see IEntity#loaded(Environment)
+  /// @see EnvironmentEntityListener#entityAdded(IEntity)
   public void add(IEntity entity) {
     if (entity == null) {
       return;
@@ -337,16 +307,14 @@ public final class Environment implements IRenderable {
     this.fireEntityEvent(l -> l.entityAdded(entity));
   }
 
-  /**
-   * Adds all the specified entities to the environment container.
-   *
-   * @param <T>      The type of the entity.
-   * @param entities The entities to be added to the environment.
-   * @see #add(IEntity)
-   * @see #addAll(IEntity...)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Adds all the specified entities to the environment container.
+  ///
+  /// @param <T>      The type of the entity.
+  /// @param entities The entities to be added to the environment.
+  /// @see #add(IEntity)
+  /// @see #addAll(IEntity...)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public <T extends IEntity> void addAll(Iterable<T> entities) {
     if (entities == null) {
       return;
@@ -357,40 +325,34 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Adds all the specified entities to the environment container.
-   *
-   * @param entities The entities to be added to the environment.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Adds all the specified entities to the environment container.
+  ///
+  /// @param entities The entities to be added to the environment.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public void addAll(IEntity... entities) {
     this.addAll(Arrays.asList(entities));
   }
 
-  /**
-   * Forces an update on the lighting layers for the entire map.
-   *
-   * @see #getStaticShadowLayer()
-   * @see #getAmbientLight()
-   * @see ColorLayer#updateSection(Rectangle2D)
-   */
+  /// Forces an update on the lighting layers for the entire map.
+  ///
+  /// @see #getStaticShadowLayer()
+  /// @see #getAmbientLight()
+  /// @see ColorLayer#updateSection(Rectangle2D)
   public void updateLighting() {
     if (this.getMap() != null) {
       this.updateLighting(this.getMap().getBounds());
     }
   }
 
-  /**
-   * Forces an update on the lighting layers for the specified section on the map.
-   *
-   * @param section The section for which to update the lighting layers.
-   * @see #getStaticShadowLayer()
-   * @see #getAmbientLight()
-   * @see ColorLayer#updateSection(Rectangle2D)
-   */
+  /// Forces an update on the lighting layers for the specified section on the map.
+  ///
+  /// @param section The section for which to update the lighting layers.
+  /// @see #getStaticShadowLayer()
+  /// @see #getAmbientLight()
+  /// @see ColorLayer#updateSection(Rectangle2D)
   public void updateLighting(Rectangle2D section) {
     if (getStaticShadowLayer() != null) {
       getStaticShadowLayer().updateSection(section);
@@ -401,46 +363,36 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Adds the specified instance to be rendered with the defined {@code RenderType} whenever the environment's render pipeline is executed.
-   *
-   * <p>
-   * This method can be used for any custom rendering that is not related to an entity, a GUI component or the map.
-   * </p>
-   *
-   * <p>
-   * Note that you don't need to explicitly add an {@code Entity} if it implements {@code IRenderable}. The render engine will inherently call an
-   * entity's render method.
-   * </p>
-   *
-   * @param renderable The instance that should be rendered.
-   * @param renderType The render type that determines how the instance is processed by the environment's render pipeline.
-   * @see #render(Graphics2D)
-   * @see RenderEngine#renderEntity(Graphics2D, IEntity)
-   */
+  /// Adds the specified instance to be rendered with the defined `RenderType` whenever the environment's render pipeline is executed.
+  ///
+  /// This method can be used for any custom rendering that is not related to an entity, a GUI component or the map.
+  ///
+  /// Note that you don't need to explicitly add an `Entity` if it implements `IRenderable`. The render engine will inherently call an
+  /// entity's render method.
+  ///
+  /// @param renderable The instance that should be rendered.
+  /// @param renderType The render type that determines how the instance is processed by the environment's render pipeline.
+  /// @see #render(Graphics2D)
+  /// @see RenderEngine#renderEntity(Graphics2D, IEntity)
   public void add(IRenderable renderable, RenderType renderType) {
     this.renderables.get(renderType).add(renderable);
   }
 
-  /**
-   * Adds entities by the specified blueprint to this environment at the defined location.
-   *
-   * @param blueprint The blueprint, defining the map object to load the entities from.
-   * @param x         The x-coordinate of the location at which to spawn the entities.
-   * @param y         The y-coordinate of the location at which to spawn the entities.
-   * @return A collection with all added entities.
-   */
+  /// Adds entities by the specified blueprint to this environment at the defined location.
+  ///
+  /// @param blueprint The blueprint, defining the map object to load the entities from.
+  /// @param x         The x-coordinate of the location at which to spawn the entities.
+  /// @param y         The y-coordinate of the location at which to spawn the entities.
+  /// @return A collection with all added entities.
   public Collection<IEntity> build(Blueprint blueprint, double x, double y) {
     return this.build(blueprint, new Point2D.Double(x, y));
   }
 
-  /**
-   * Adds entities by the specified blueprint to this environment at the defined location.
-   *
-   * @param blueprint The blueprint, defining the map object to load the entities from.
-   * @param location  The location at which to spawn the entities.
-   * @return A collection with all added entities.
-   */
+  /// Adds entities by the specified blueprint to this environment at the defined location.
+  ///
+  /// @param blueprint The blueprint, defining the map object to load the entities from.
+  /// @param location  The location at which to spawn the entities.
+  /// @return A collection with all added entities.
   public Collection<IEntity> build(Blueprint blueprint, Point2D location) {
     Collection<IMapObject> mapObjects = blueprint.build(location);
     Collection<IEntity> loadedEntities = new ArrayList<>();
@@ -451,9 +403,7 @@ public final class Environment implements IRenderable {
     return loadedEntities;
   }
 
-  /**
-   * Clears all loaded entities and renderable instances from this environment.
-   */
+  /// Clears all loaded entities and renderable instances from this environment.
   public void clear() {
     Game.physics().clear();
 
@@ -497,43 +447,35 @@ public final class Environment implements IRenderable {
     this.fireEvent(l -> l.cleared(this));
   }
 
-  /**
-   * Determines whether the environment contains the specified entity.
-   *
-   * @param entity The entity to check for.
-   * @return True if the environment contains the specified entity; otherwise false.
-   */
+  /// Determines whether the environment contains the specified entity.
+  ///
+  /// @param entity The entity to check for.
+  /// @return True if the environment contains the specified entity; otherwise false.
   public boolean contains(IEntity entity) {
     return this.contains(entity.getMapId());
   }
 
-  /**
-   * Determines whether the environment contains any entity with the specified map ID.
-   *
-   * @param mapId The map ID of the entity to check for.
-   * @return True if the environment contains an entity with the specified map ID; otherwise false.
-   */
+  /// Determines whether the environment contains any entity with the specified map ID.
+  ///
+  /// @param mapId The map ID of the entity to check for.
+  /// @return True if the environment contains an entity with the specified map ID; otherwise false.
   public boolean contains(int mapId) {
     return this.allEntities.containsKey(mapId);
   }
 
-  /**
-   * Attempts to find all combat entities whose hitBox intersects with the specified shape.
-   *
-   * @param shape The shape to check intersection for.
-   * @return A collection of all combat entities that intersect the specified {@link Shape}.
-   */
+  /// Attempts to find all combat entities whose hitBox intersects with the specified shape.
+  ///
+  /// @param shape The shape to check intersection for.
+  /// @return A collection of all combat entities that intersect the specified [Shape].
   public Collection<ICombatEntity> findCombatEntities(final Shape shape) {
     return this.findCombatEntities(shape, entity -> true);
   }
 
-  /**
-   * Attempts to find all combat entities whose hitBox intersects with the specified shape.
-   *
-   * @param shape     The shape to check intersection for.
-   * @param condition An additional condition that allows to specify a condition which determines if a {@link ICombatEntity} should be considered.
-   * @return A collection of all combat entities that intersect the specified {@link Shape}.
-   */
+  /// Attempts to find all combat entities whose hitBox intersects with the specified shape.
+  ///
+  /// @param shape     The shape to check intersection for.
+  /// @param condition An additional condition that allows to specify a condition which determines if a [ICombatEntity] should be considered.
+  /// @return A collection of all combat entities that intersect the specified [Shape].
   public Collection<ICombatEntity> findCombatEntities(final Shape shape,
     final Predicate<ICombatEntity> condition) {
     final Collection<ICombatEntity> foundCombatEntities = new ArrayList<>();
@@ -566,12 +508,10 @@ public final class Environment implements IRenderable {
     return foundCombatEntities;
   }
 
-  /**
-   * Attempts to find all entities whose bounding box intersects with the specified shape.
-   *
-   * @param shape The shape to check intersection for.
-   * @return A collection of all entities that intersect the specified {@link Shape}.
-   */
+  /// Attempts to find all entities whose bounding box intersects with the specified shape.
+  ///
+  /// @param shape The shape to check intersection for.
+  /// @return A collection of all entities that intersect the specified [Shape].
   public Collection<IEntity> findEntities(final Shape shape) {
     final Collection<IEntity> foundEntities = new ArrayList<>();
     if (shape == null) {
@@ -597,22 +537,18 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Gets the entity with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The entity with the specified map ID or null if no entity could be found.
-   */
+  /// Gets the entity with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The entity with the specified map ID or null if no entity could be found.
   public IEntity get(final int mapId) {
     return this.allEntities.get(mapId);
   }
 
-  /**
-   * Gets all entities with the specified map IDs from this environment.
-   *
-   * @param mapIds The map IDs to search for.
-   * @return A {@code List} of entities found, in the order given by the parameters.
-   */
+  /// Gets all entities with the specified map IDs from this environment.
+  ///
+  /// @param mapIds The map IDs to search for.
+  /// @return A `List` of entities found, in the order given by the parameters.
   public List<IEntity> get(final int... mapIds) {
     final List<IEntity> foundEntities = new ArrayList<>();
     if (mapIds == null) {
@@ -629,14 +565,12 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Gets the strongly typed entity with the specified map ID from this environment.
-   *
-   * @param <T>   The type of the entity.
-   * @param clss  The class instance defining the type of the entity.
-   * @param mapId The map ID of the entity.
-   * @return The strongly typed entity with the specified map ID or null if no entity could be found or if the defined type doesn't match.
-   */
+  /// Gets the strongly typed entity with the specified map ID from this environment.
+  ///
+  /// @param <T>   The type of the entity.
+  /// @param clss  The class instance defining the type of the entity.
+  /// @param mapId The map ID of the entity.
+  /// @return The strongly typed entity with the specified map ID or null if no entity could be found or if the defined type doesn't match.
   public <T extends IEntity> T get(Class<T> clss, int mapId) {
     IEntity ent = this.get(mapId);
     if (!clss.isInstance(ent)) {
@@ -646,12 +580,10 @@ public final class Environment implements IRenderable {
     return clss.cast(ent);
   }
 
-  /**
-   * Gets the entity with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The entity with the specified name or null if no entity could be found or if the defined type doesn't match.
-   */
+  /// Gets the entity with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The entity with the specified name or null if no entity could be found or if the defined type doesn't match.
   public IEntity get(final String name) {
     if (name == null || name.isEmpty()) {
       return null;
@@ -666,14 +598,12 @@ public final class Environment implements IRenderable {
     return null;
   }
 
-  /**
-   * Gets the strongly typed entity with the specified name from this environment.
-   *
-   * @param <T>  The type of the entity.
-   * @param clss The class instance defining the type of the entity.
-   * @param name The name of the entity.
-   * @return The strongly typed entity with the specified name or null if no entity could be found or if the defined type doesn't match.
-   */
+  /// Gets the strongly typed entity with the specified name from this environment.
+  ///
+  /// @param <T>  The type of the entity.
+  /// @param clss The class instance defining the type of the entity.
+  /// @param name The name of the entity.
+  /// @return The strongly typed entity with the specified name or null if no entity could be found or if the defined type doesn't match.
   public <T extends IEntity> T get(Class<T> clss, String name) {
     IEntity ent = this.get(name);
     if (!clss.isInstance(ent)) {
@@ -683,12 +613,10 @@ public final class Environment implements IRenderable {
     return clss.cast(ent);
   }
 
-  /**
-   * Gets a distinct collection of all entities with any of the specified tags.
-   *
-   * @param tags The tags to search for.
-   * @return All entities with any of the specified tags.
-   */
+  /// Gets a distinct collection of all entities with any of the specified tags.
+  ///
+  /// @param tags The tags to search for.
+  /// @return All entities with any of the specified tags.
   public Collection<IEntity> getByTag(String... tags) {
     Collection<IEntity> foundEntities = new ArrayList<>();
     for (String rawTag : tags) {
@@ -703,14 +631,12 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Gets a distinct and strongly named collection of all entities with any of the specified tags.
-   *
-   * @param <T>  The type of the entity.
-   * @param clss The class instance defining the type of the entity.
-   * @param tags The tags to search for.
-   * @return All entities with any of the specified tags.
-   */
+  /// Gets a distinct and strongly named collection of all entities with any of the specified tags.
+  ///
+  /// @param <T>  The type of the entity.
+  /// @param clss The class instance defining the type of the entity.
+  /// @param tags The tags to search for.
+  /// @return All entities with any of the specified tags.
   public <T extends IEntity> Collection<T> getByTag(Class<? extends T> clss, String... tags) {
     Collection<T> foundEntities = new ArrayList<>();
     for (String rawTag : tags) {
@@ -727,67 +653,53 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Gets the ambient light instance of this environment.
-   *
-   * @return The ambient light instance of this environment.
-   * @see #getStaticShadowLayer()
-   */
+  /// Gets the ambient light instance of this environment.
+  ///
+  /// @return The ambient light instance of this environment.
+  /// @see #getStaticShadowLayer()
   public AmbientLight getAmbientLight() {
     return this.ambientLight;
   }
 
-  /**
-   * Gets the static shadow lighting layer of this environment.
-   *
-   * @return The static shadow lighting layer of this environment.
-   * @see #getAmbientLight()
-   */
+  /// Gets the static shadow lighting layer of this environment.
+  ///
+  /// @return The static shadow lighting layer of this environment.
+  /// @see #getAmbientLight()
   public StaticShadowLayer getStaticShadowLayer() {
     return this.staticShadowLayer;
   }
 
-  /**
-   * Gets an immutable collection with all assigned map IDs on this environment.
-   *
-   * @return An immutable collection with all map IDs.
-   */
+  /// Gets an immutable collection with all assigned map IDs on this environment.
+  ///
+  /// @return An immutable collection with all map IDs.
   public Collection<Integer> getAllMapIDs() {
     return Collections.unmodifiableCollection(this.allEntities.keySet());
   }
 
-  /**
-   * Gets an immutable collection containing all {@link MapArea} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link MapArea} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [MapArea] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [MapArea] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<MapArea> getAreas() {
     return Collections.unmodifiableCollection(this.mapAreas);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link MapArea} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link MapArea} entities have to provide to be returned.
-   * @return An immutable collection with all {@link MapArea} entities with the specified tag.
-   * @see #getAreas()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [MapArea] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [MapArea] entities have to provide to be returned.
+  /// @return An immutable collection with all [MapArea] entities with the specified tag.
+  /// @see #getAreas()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<MapArea> getAreas(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getAreas();
@@ -796,62 +708,50 @@ public final class Environment implements IRenderable {
     return this.mapAreas.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link MapArea} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link MapArea} with the specified map ID or null if no entity is found.
-   * @see #getArea(String)
-   * @see #getAreas()
-   */
+  /// Gets the [MapArea] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [MapArea] with the specified map ID or null if no entity is found.
+  /// @see #getArea(String)
+  /// @see #getAreas()
   public MapArea getArea(final int mapId) {
     return getById(this.mapAreas, mapId);
   }
 
-  /**
-   * Gets the {@link MapArea} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link MapArea} with the specified name or null if no entity is found.
-   * @see #getArea(int)
-   * @see #getAreas()
-   */
+  /// Gets the [MapArea] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [MapArea] with the specified name or null if no entity is found.
+  /// @see #getArea(int)
+  /// @see #getAreas()
   public MapArea getArea(final String name) {
     return getByName(this.mapAreas, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Emitter} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link Emitter} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Emitter] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [Emitter] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Emitter> getEmitters() {
     return Collections.unmodifiableCollection(this.emitters);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Emitter} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link Emitter} entities have to provide to be returned.
-   * @return An immutable collection with all {@link Emitter} entities with the specified tag.
-   * @see #getEmitters()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Emitter] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [Emitter] entities have to provide to be returned.
+  /// @return An immutable collection with all [Emitter] entities with the specified tag.
+  /// @see #getEmitters()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Emitter> getEmitters(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getEmitters();
@@ -860,62 +760,50 @@ public final class Environment implements IRenderable {
     return this.emitters.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link Emitter} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link Emitter} with the specified map ID or null if no entity is found.
-   * @see #getEmitter(String)
-   * @see #getEmitters()
-   */
+  /// Gets the [Emitter] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [Emitter] with the specified map ID or null if no entity is found.
+  /// @see #getEmitter(String)
+  /// @see #getEmitters()
   public Emitter getEmitter(int mapId) {
     return getById(this.emitters, mapId);
   }
 
-  /**
-   * Gets the {@link Emitter} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link Emitter} with the specified name or null if no entity is found.
-   * @see #getEmitter(int)
-   * @see #getEmitters()
-   */
+  /// Gets the [Emitter] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [Emitter] with the specified name or null if no entity is found.
+  /// @see #getEmitter(int)
+  /// @see #getEmitters()
   public Emitter getEmitter(String name) {
     return getByName(this.emitters, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link CollisionBox} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link CollisionBox} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [CollisionBox] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [CollisionBox] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<CollisionBox> getCollisionBoxes() {
     return Collections.unmodifiableCollection(this.colliders);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link CollisionBox} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link CollisionBox} entities have to provide to be returned.
-   * @return An immutable collection with all {@link CollisionBox} entities with the specified tag.
-   * @see #getCollisionBoxes()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [CollisionBox] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [CollisionBox] entities have to provide to be returned.
+  /// @return An immutable collection with all [CollisionBox] entities with the specified tag.
+  /// @see #getCollisionBoxes()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<CollisionBox> getCollisionBoxes(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getCollisionBoxes();
@@ -924,62 +812,50 @@ public final class Environment implements IRenderable {
     return this.colliders.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link CollisionBox} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link CollisionBox} with the specified map ID or null if no entity is found.
-   * @see #getCollisionBox(String)
-   * @see #getCollisionBoxes()
-   */
+  /// Gets the [CollisionBox] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [CollisionBox] with the specified map ID or null if no entity is found.
+  /// @see #getCollisionBox(String)
+  /// @see #getCollisionBoxes()
   public CollisionBox getCollisionBox(int mapId) {
     return getById(this.colliders, mapId);
   }
 
-  /**
-   * Gets the {@link CollisionBox} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link CollisionBox} with the specified name or null if no entity is found.
-   * @see #getCollisionBox(int)
-   * @see #getCollisionBoxes()
-   */
+  /// Gets the [CollisionBox] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [CollisionBox] with the specified name or null if no entity is found.
+  /// @see #getCollisionBox(int)
+  /// @see #getCollisionBoxes()
   public CollisionBox getCollisionBox(String name) {
     return getByName(this.colliders, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link ICombatEntity} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link ICombatEntity} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [ICombatEntity] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [ICombatEntity] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<ICombatEntity> getCombatEntities() {
     return Collections.unmodifiableCollection(this.combatEntities.values());
   }
 
-  /**
-   * Gets an immutable collection containing all {@link ICombatEntity} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link ICombatEntity} entities have to provide to be returned.
-   * @return An immutable collection with all {@link ICombatEntity} entities with the specified tag.
-   * @see #getMobileEntities()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [ICombatEntity] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [ICombatEntity] entities have to provide to be returned.
+  /// @return An immutable collection with all [ICombatEntity] entities with the specified tag.
+  /// @see #getMobileEntities()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<ICombatEntity> getCombatEntities(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getCombatEntities();
@@ -988,54 +864,44 @@ public final class Environment implements IRenderable {
     return this.combatEntities.values().stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link ICombatEntity} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link ICombatEntity} with the specified map ID or null if no entity is found.
-   * @see #getCombatEntity(String)
-   * @see #getCombatEntities()
-   */
+  /// Gets the [ICombatEntity] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [ICombatEntity] with the specified map ID or null if no entity is found.
+  /// @see #getCombatEntity(String)
+  /// @see #getCombatEntities()
   public ICombatEntity getCombatEntity(final int mapId) {
     return getById(this.combatEntities.values(), mapId);
   }
 
-  /**
-   * Gets the {@link ICombatEntity} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link ICombatEntity} with the specified name or null if no entity is found.
-   * @see #getCombatEntity(int)
-   * @see #getCombatEntities()
-   */
+  /// Gets the [ICombatEntity] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [ICombatEntity] with the specified name or null if no entity is found.
+  /// @see #getCombatEntity(int)
+  /// @see #getCombatEntities()
   public ICombatEntity getCombatEntity(String name) {
     return getByName(this.combatEntities.values(), name);
   }
 
-  /**
-   * Gets an immutable collection containing all entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<IEntity> getEntities() {
     return Collections.unmodifiableCollection(this.allEntities.values());
   }
 
-  /**
-   * Gets all entities of the specified type on this environment.
-   *
-   * @param <T> The type of the entity.
-   * @param cls The class instance defining the type of the entity.
-   * @return All entities of the specified type.
-   */
+  /// Gets all entities of the specified type on this environment.
+  ///
+  /// @param <T> The type of the entity.
+  /// @param cls The class instance defining the type of the entity.
+  /// @return All entities of the specified type.
   public <T> Collection<T> getEntities(Class<? extends T> cls) {
     Collection<T> foundEntities = new ArrayList<>();
     for (IEntity ent : this.allEntities.values()) {
@@ -1047,25 +913,21 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Starts a fluent query for entities of the specified type in this environment.
-   *
-   * @param type The requested entity type.
-   * @param <T> The requested type.
-   * @return A reusable query over the current entity snapshot.
-   */
+  /// Starts a fluent query for entities of the specified type in this environment.
+  ///
+  /// @param type The requested entity type.
+  /// @param <T> The requested type.
+  /// @return A reusable query over the current entity snapshot.
   public <T> EntityQuery<T> query(Class<? extends T> type) {
     return new EntityQuery<>(this.getEntities(type));
   }
 
-  /**
-   * Gets all entities of the specified type on this environment.
-   *
-   * @param <T> The type of the entity.
-   * @param cls The class instance defining the type of the entity.
-   * @param tag A tag that decides whether the defined entity should be included in the result.
-   * @return All entities of the specified type.
-   */
+  /// Gets all entities of the specified type on this environment.
+  ///
+  /// @param <T> The type of the entity.
+  /// @param cls The class instance defining the type of the entity.
+  /// @param tag A tag that decides whether the defined entity should be included in the result.
+  /// @return All entities of the specified type.
   public <T> Collection<T> getEntities(Class<? extends T> cls, String tag) {
     Collection<T> foundEntities = new ArrayList<>();
     for (IEntity ent : this.allEntities.values()) {
@@ -1077,14 +939,12 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Gets all entities of the specified type on this environment.
-   *
-   * @param <T>  The type of the entity.
-   * @param cls  The class instance defining the type of the entity.
-   * @param pred A predicate that decides whether the defined entity should be included in the result.
-   * @return All entities of the specified type.
-   */
+  /// Gets all entities of the specified type on this environment.
+  ///
+  /// @param <T>  The type of the entity.
+  /// @param cls  The class instance defining the type of the entity.
+  /// @param pred A predicate that decides whether the defined entity should be included in the result.
+  /// @return All entities of the specified type.
   public <T> Collection<T> getEntities(Class<? extends T> cls, Predicate<T> pred) {
     Collection<T> foundEntities = new ArrayList<>();
     for (IEntity ent : this.allEntities.values()) {
@@ -1100,32 +960,26 @@ public final class Environment implements IRenderable {
     return foundEntities;
   }
 
-  /**
-   * Gets the entities with the specified render type that are not bound to layers.
-   * <p>
-   * Entities are unbound from there originating {@code MapObjectLayer} if their {@code RenderType} differs from the layer's {@code RenderType}.
-   * </p>
-   *
-   * @param renderType The render type
-   * @return The miscellaneous entities with the specified render type
-   * @see IEntity#getRenderType()
-   * @see ILayer#getRenderType()
-   */
+  /// Gets the entities with the specified render type that are not bound to layers.
+  ///
+  /// Entities are unbound from there originating `MapObjectLayer` if their `RenderType` differs from the layer's `RenderType`.
+  ///
+  /// @param renderType The render type
+  /// @return The miscellaneous entities with the specified render type
+  /// @see IEntity#getRenderType()
+  /// @see ILayer#getRenderType()
   public Collection<IEntity> getEntities(final RenderType renderType) {
     return Collections.unmodifiableCollection(this.miscEntities.get(renderType).values());
   }
 
-  /**
-   * Gets the entities that are bound to the specified layer.
-   * <p>
-   * Entities are bound to a layer if their {@code RenderType} matches the layer's {@code RenderType}
-   * </p>
-   *
-   * @param layer The layer that the entities are bound to.
-   * @return The entities that are bound to the specified layer.
-   * @see IEntity#getRenderType()
-   * @see ILayer#getRenderType()
-   */
+  /// Gets the entities that are bound to the specified layer.
+  ///
+  /// Entities are bound to a layer if their `RenderType` matches the layer's `RenderType`
+  ///
+  /// @param layer The layer that the entities are bound to.
+  /// @return The entities that are bound to the specified layer.
+  /// @see IEntity#getRenderType()
+  /// @see ILayer#getRenderType()
   public Collection<IEntity> getEntities(final IMapObjectLayer layer) {
     if (layer == null || !this.layerEntities.containsKey(layer)) {
       return Collections.emptySet();
@@ -1134,18 +988,15 @@ public final class Environment implements IRenderable {
     return Collections.unmodifiableCollection(this.layerEntities.get(layer));
   }
 
-  /**
-   * Gets the entities that are bound to layer with the specified name.
-   * <p>
-   * Entities are bound to a layer if their {@code RenderType} matches the layer's {@code RenderType}
-   * </p>
-   *
-   * @param name The name of the layer
-   * @return The entities that are bound to the specified layer.
-   * @see IEntity#getRenderType()
-   * @see ILayer#getRenderType()
-   * @see ILayer#getName()
-   */
+  /// Gets the entities that are bound to layer with the specified name.
+  ///
+  /// Entities are bound to a layer if their `RenderType` matches the layer's `RenderType`
+  ///
+  /// @param name The name of the layer
+  /// @return The entities that are bound to the specified layer.
+  /// @see IEntity#getRenderType()
+  /// @see ILayer#getRenderType()
+  /// @see ILayer#getName()
   public Collection<IEntity> getEntitiesByLayer(final String name) {
     if (name == null || name.isEmpty()) {
       return Collections.emptySet();
@@ -1160,18 +1011,15 @@ public final class Environment implements IRenderable {
     return Collections.emptySet();
   }
 
-  /**
-   * Gets the entities that are bound to layer with the specified layer ID.
-   * <p>
-   * Entities are bound to a layer if their {@code RenderType} matches the layer's {@code RenderType}
-   * </p>
-   *
-   * @param layerId The id of the layer
-   * @return The entities that are bound to the specified layer.
-   * @see IEntity#getRenderType()
-   * @see ILayer#getRenderType()
-   * @see ILayer#getId()
-   */
+  /// Gets the entities that are bound to layer with the specified layer ID.
+  ///
+  /// Entities are bound to a layer if their `RenderType` matches the layer's `RenderType`
+  ///
+  /// @param layerId The id of the layer
+  /// @return The entities that are bound to the specified layer.
+  /// @see IEntity#getRenderType()
+  /// @see ILayer#getRenderType()
+  /// @see ILayer#getId()
   public Collection<IEntity> getEntitiesByLayer(final int layerId) {
     for (Entry<IMapObjectLayer, List<IEntity>> entry : this.layerEntities.entrySet()) {
       if (layerId == entry.getKey().getId()) {
@@ -1182,47 +1030,37 @@ public final class Environment implements IRenderable {
     return Collections.emptySet();
   }
 
-  /**
-   * <b>DON'T USE THIS! THIS IS FOR ENGINE INTERNAL PURPOSES ONLY!</b>.
-   *
-   * @return A map with all entities by tags.
-   */
+  /// **DON'T USE THIS! THIS IS FOR ENGINE INTERNAL PURPOSES ONLY!**.
+  ///
+  /// @return A map with all entities by tags.
   public Map<String, Collection<IEntity>> getEntitiesByTag() {
     return this.entitiesByTag;
   }
 
-  /**
-   * Gets an immutable collection containing all {@link LightSource} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link LightSource} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [LightSource] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [LightSource] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<LightSource> getLightSources() {
     return Collections.unmodifiableCollection(this.lightSources);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link LightSource} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link LightSource} entities have to provide to be returned.
-   * @return An immutable collection with all {@link LightSource} entities with the specified tag.
-   * @see #getLightSources()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [LightSource] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [LightSource] entities have to provide to be returned.
+  /// @return An immutable collection with all [LightSource] entities with the specified tag.
+  /// @see #getLightSources()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<LightSource> getLightSources(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getLightSources();
@@ -1231,80 +1069,64 @@ public final class Environment implements IRenderable {
     return this.lightSources.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link LightSource} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link LightSource} with the specified map ID or null if no entity is found.
-   * @see #getLightSource(String)
-   * @see #getLightSources()
-   */
+  /// Gets the [LightSource] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [LightSource] with the specified map ID or null if no entity is found.
+  /// @see #getLightSource(String)
+  /// @see #getLightSources()
   public LightSource getLightSource(final int mapId) {
     return getById(this.lightSources, mapId);
   }
 
-  /**
-   * Gets the {@link LightSource} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link LightSource} with the specified name or null if no entity is found.
-   * @see #getLightSource(int)
-   * @see #getLightSources()
-   */
+  /// Gets the [LightSource] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [LightSource] with the specified name or null if no entity is found.
+  /// @see #getLightSource(int)
+  /// @see #getLightSources()
   public LightSource getLightSource(String name) {
     return getByName(this.lightSources, name);
   }
 
-  /**
-   * Gets the next unique local map id. (All local map ids are negative).
-   *
-   * @return The next unique local map id.
-   */
+  /// Gets the next unique local map id. (All local map ids are negative).
+  ///
+  /// @return The next unique local map id.
   public static synchronized int getLocalMapId() {
     return --localIdSequence;
   }
 
-  /**
-   * Gets the map on which this environment is based upon.
-   *
-   * @return The map of this environment.
-   */
+  /// Gets the map on which this environment is based upon.
+  ///
+  /// @return The map of this environment.
   public IMap getMap() {
     return this.map;
   }
 
-  /**
-   * Gets an immutable collection containing all {@link IMobileEntity} instances on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link IMobileEntity} instances.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [IMobileEntity] instances on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [IMobileEntity] instances.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<IMobileEntity> getMobileEntities() {
     return Collections.unmodifiableCollection(this.mobileEntities.values());
   }
 
-  /**
-   * Gets an immutable collection containing all {@link IMobileEntity} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link IMobileEntity} entities have to provide to be returned.
-   * @return An immutable collection with all {@link IMobileEntity} entities with the specified tag.
-   * @see #getMobileEntities()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [IMobileEntity] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [IMobileEntity] entities have to provide to be returned.
+  /// @return An immutable collection with all [IMobileEntity] entities with the specified tag.
+  /// @see #getMobileEntities()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<IMobileEntity> getMobileEntities(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getMobileEntities();
@@ -1313,88 +1135,70 @@ public final class Environment implements IRenderable {
     return this.mobileEntities.values().stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link IMobileEntity} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link IMobileEntity} with the specified map ID or null if no entity is found.
-   * @see #getMobileEntity(String)
-   * @see #getMobileEntities()
-   */
+  /// Gets the [IMobileEntity] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [IMobileEntity] with the specified map ID or null if no entity is found.
+  /// @see #getMobileEntity(String)
+  /// @see #getMobileEntities()
   public IMobileEntity getMobileEntity(final int mapId) {
     return getById(this.mobileEntities.values(), mapId);
   }
 
-  /**
-   * Gets the {@link IMobileEntity} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link IMobileEntity} with the specified name or null if no entity is found.
-   * @see #getMobileEntity(int)
-   * @see #getMobileEntities()
-   */
+  /// Gets the [IMobileEntity] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [IMobileEntity] with the specified name or null if no entity is found.
+  /// @see #getMobileEntity(int)
+  /// @see #getMobileEntities()
   public IMobileEntity getMobileEntity(String name) {
     return getByName(this.mobileEntities.values(), name);
   }
 
-  /**
-   * Gets the next unique global map id.
-   *
-   * @return The next unique global map id.
-   */
+  /// Gets the next unique global map id.
+  ///
+  /// @return The next unique global map id.
   public synchronized int getNextMapId() {
     int maxMapID = MapUtilities.getMaxMapId(this.getMap());
     return ++maxMapID;
   }
 
-  /**
-   * Gets an immutable collection containing all {@link IRenderable} instances for the specified render type on this environment.
-   *
-   * <p>
-   * To add or remove instances, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param renderType The render type of the renderable instances.
-   * @return An immutable collection with all {@link IRenderable} instances.
-   * @see #add(IRenderable, RenderType)
-   * @see #removeRenderable(IRenderable)
-   */
+  /// Gets an immutable collection containing all [IRenderable] instances for the specified render type on this environment.
+  ///
+  /// To add or remove instances, use the corresponding methods on this environment.
+  ///
+  /// @param renderType The render type of the renderable instances.
+  /// @return An immutable collection with all [IRenderable] instances.
+  /// @see #add(IRenderable, RenderType)
+  /// @see #removeRenderable(IRenderable)
   public Collection<IRenderable> getRenderables(RenderType renderType) {
     return Collections.unmodifiableCollection(this.renderables.get(renderType));
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Prop} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link Prop} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Prop] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [Prop] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Prop> getProps() {
     return Collections.unmodifiableCollection(this.props);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Prop} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link Prop} entities have to provide to be returned.
-   * @return An immutable collection with all {@link Prop} entities with the specified tag.
-   * @see #getProps()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Prop] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [Prop] entities have to provide to be returned.
+  /// @return An immutable collection with all [Prop] entities with the specified tag.
+  /// @see #getProps()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Prop> getProps(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getProps();
@@ -1403,62 +1207,50 @@ public final class Environment implements IRenderable {
     return this.props.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link Prop} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link Prop} with the specified map ID or null if no entity is found.
-   * @see #getProp(String)
-   * @see #getProps()
-   */
+  /// Gets the [Prop] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [Prop] with the specified map ID or null if no entity is found.
+  /// @see #getProp(String)
+  /// @see #getProps()
   public Prop getProp(int mapId) {
     return getById(this.props, mapId);
   }
 
-  /**
-   * Gets the {@link Prop} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link Prop} with the specified name or null if no entity is found.
-   * @see #getProp(int)
-   * @see #getProps()
-   */
+  /// Gets the [Prop] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [Prop] with the specified name or null if no entity is found.
+  /// @see #getProp(int)
+  /// @see #getProps()
   public Prop getProp(String name) {
     return getByName(this.props, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Creature} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link Creature} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Creature] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [Creature] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Creature> getCreatures() {
     return Collections.unmodifiableCollection(this.creatures);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Creature} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link Creature} entities have to provide to be returned.
-   * @return An immutable collection with all {@link Creature} entities with the specified tag.
-   * @see #getCreatures()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Creature] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [Creature] entities have to provide to be returned.
+  /// @return An immutable collection with all [Creature] entities with the specified tag.
+  /// @see #getCreatures()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Creature> getCreatures(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getCreatures();
@@ -1467,62 +1259,50 @@ public final class Environment implements IRenderable {
     return this.creatures.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link Creature} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link Creature} with the specified map ID or null if no entity is found.
-   * @see #getCreature(String)
-   * @see #getCreatures()
-   */
+  /// Gets the [Creature] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [Creature] with the specified map ID or null if no entity is found.
+  /// @see #getCreature(String)
+  /// @see #getCreatures()
   public Creature getCreature(int mapId) {
     return getById(this.creatures, mapId);
   }
 
-  /**
-   * Gets the {@link Creature} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link Creature} with the specified name or null if no entity is found.
-   * @see #getCreature(int)
-   * @see #getCreatures()
-   */
+  /// Gets the [Creature] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [Creature] with the specified name or null if no entity is found.
+  /// @see #getCreature(int)
+  /// @see #getCreatures()
   public Creature getCreature(String name) {
     return getByName(this.creatures, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Spawnpoint} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link Spawnpoint} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Spawnpoint] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [Spawnpoint] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Spawnpoint> getSpawnpoints() {
     return Collections.unmodifiableCollection(this.spawnPoints);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Spawnpoint} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link Spawnpoint} entities have to provide to be returned.
-   * @return An immutable collection with all {@link Spawnpoint} entities with the specified tag.
-   * @see #getSpawnpoints()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Spawnpoint] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [Spawnpoint] entities have to provide to be returned.
+  /// @return An immutable collection with all [Spawnpoint] entities with the specified tag.
+  /// @see #getSpawnpoints()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Spawnpoint> getSpawnpoints(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getSpawnpoints();
@@ -1531,62 +1311,50 @@ public final class Environment implements IRenderable {
     return this.spawnPoints.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link Spawnpoint} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link Spawnpoint} with the specified map ID or null if no entity is found.
-   * @see #getSpawnpoint(String)
-   * @see #getSpawnpoints()
-   */
+  /// Gets the [Spawnpoint] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [Spawnpoint] with the specified map ID or null if no entity is found.
+  /// @see #getSpawnpoint(String)
+  /// @see #getSpawnpoints()
   public Spawnpoint getSpawnpoint(final int mapId) {
     return getById(this.spawnPoints, mapId);
   }
 
-  /**
-   * Gets the {@link Spawnpoint} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link Spawnpoint} with the specified name or null if no entity is found.
-   * @see #getSpawnpoint(int)
-   * @see #getSpawnpoints()
-   */
+  /// Gets the [Spawnpoint] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [Spawnpoint] with the specified name or null if no entity is found.
+  /// @see #getSpawnpoint(int)
+  /// @see #getSpawnpoints()
   public Spawnpoint getSpawnpoint(final String name) {
     return getByName(this.spawnPoints, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link SoundSource} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link SoundSource} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [SoundSource] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [SoundSource] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<SoundSource> getSoundSources() {
     return Collections.unmodifiableCollection(this.soundSources);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link SoundSource} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link SoundSource} entities have to provide to be returned.
-   * @return An immutable collection with all {@link SoundSource} entities with the specified tag.
-   * @see #getSoundSources()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [SoundSource] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [SoundSource] entities have to provide to be returned.
+  /// @return An immutable collection with all [SoundSource] entities with the specified tag.
+  /// @see #getSoundSources()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<SoundSource> getSoundSources(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getSoundSources();
@@ -1595,62 +1363,50 @@ public final class Environment implements IRenderable {
     return this.soundSources.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link SoundSource} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link SoundSource} with the specified map ID or null if no entity is found.
-   * @see #getSpawnpoint(String)
-   * @see #getSpawnpoints()
-   */
+  /// Gets the [SoundSource] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [SoundSource] with the specified map ID or null if no entity is found.
+  /// @see #getSpawnpoint(String)
+  /// @see #getSpawnpoints()
   public SoundSource getSoundSource(final int mapId) {
     return getById(this.soundSources, mapId);
   }
 
-  /**
-   * Gets the {@link SoundSource} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link SoundSource} with the specified name or null if no entity is found.
-   * @see #getSpawnpoint(int)
-   * @see #getSpawnpoints()
-   */
+  /// Gets the [SoundSource] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [SoundSource] with the specified name or null if no entity is found.
+  /// @see #getSpawnpoint(int)
+  /// @see #getSpawnpoints()
   public SoundSource getSoundSource(final String name) {
     return getByName(this.soundSources, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link StaticShadow} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link StaticShadow} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [StaticShadow] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [StaticShadow] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<StaticShadow> getStaticShadows() {
     return Collections.unmodifiableCollection(this.staticShadows);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link StaticShadow} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link StaticShadow} entities have to provide to be returned.
-   * @return An immutable collection with all {@link StaticShadow} entities with the specified tag.
-   * @see #getStaticShadows()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [StaticShadow] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [StaticShadow] entities have to provide to be returned.
+  /// @return An immutable collection with all [StaticShadow] entities with the specified tag.
+  /// @see #getStaticShadows()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<StaticShadow> getStaticShadows(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getStaticShadows();
@@ -1659,62 +1415,50 @@ public final class Environment implements IRenderable {
     return this.staticShadows.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link StaticShadow} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link StaticShadow} with the specified map ID or null if no entity is found.
-   * @see #getStaticShadow(String)
-   * @see #getStaticShadows()
-   */
+  /// Gets the [StaticShadow] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [StaticShadow] with the specified map ID or null if no entity is found.
+  /// @see #getStaticShadow(String)
+  /// @see #getStaticShadows()
   public StaticShadow getStaticShadow(int mapId) {
     return getById(this.staticShadows, mapId);
   }
 
-  /**
-   * Gets the {@link StaticShadow} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link StaticShadow} with the specified name or null if no entity is found.
-   * @see #getStaticShadow(int)
-   * @see #getStaticShadows()
-   */
+  /// Gets the [StaticShadow] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [StaticShadow] with the specified name or null if no entity is found.
+  /// @see #getStaticShadow(int)
+  /// @see #getStaticShadows()
   public StaticShadow getStaticShadow(String name) {
     return getByName(this.staticShadows, name);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Trigger} entities on this environment.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @return An immutable collection with all {@link Trigger} entities.
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Trigger] entities on this environment.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @return An immutable collection with all [Trigger] entities.
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Trigger> getTriggers() {
     return Collections.unmodifiableCollection(this.triggers);
   }
 
-  /**
-   * Gets an immutable collection containing all {@link Trigger} entities with the specified tag.
-   *
-   * <p>
-   * To add or remove entities, use the corresponding methods on this environment.
-   * </p>
-   *
-   * @param tag The tag that the {@link Trigger} entities have to provide to be returned.
-   * @return An immutable collection with all {@link Trigger} entities with the specified tag.
-   * @see #getTriggers()
-   * @see #add(IEntity)
-   * @see #addAll(Iterable)
-   * @see #remove(IEntity)
-   * @see #removeAll(Iterable)
-   */
+  /// Gets an immutable collection containing all [Trigger] entities with the specified tag.
+  ///
+  /// To add or remove entities, use the corresponding methods on this environment.
+  ///
+  /// @param tag The tag that the [Trigger] entities have to provide to be returned.
+  /// @return An immutable collection with all [Trigger] entities with the specified tag.
+  /// @see #getTriggers()
+  /// @see #add(IEntity)
+  /// @see #addAll(Iterable)
+  /// @see #remove(IEntity)
+  /// @see #removeAll(Iterable)
   public Collection<Trigger> getTriggers(String tag) {
     if (tag == null || tag.isEmpty()) {
       return this.getTriggers();
@@ -1723,55 +1467,45 @@ public final class Environment implements IRenderable {
     return this.triggers.stream().filter(p -> p.hasTag(tag)).toList();
   }
 
-  /**
-   * Gets the {@link Trigger} with the specified map ID from this environment.
-   *
-   * @param mapId The map ID of the entity.
-   * @return The {@link Trigger} with the specified map ID or null if no entity is found.
-   * @see #getTrigger(String)
-   * @see #getTriggers()
-   */
+  /// Gets the [Trigger] with the specified map ID from this environment.
+  ///
+  /// @param mapId The map ID of the entity.
+  /// @return The [Trigger] with the specified map ID or null if no entity is found.
+  /// @see #getTrigger(String)
+  /// @see #getTriggers()
   public Trigger getTrigger(final int mapId) {
     return getById(this.triggers, mapId);
   }
 
-  /**
-   * Gets the {@link Trigger} with the specified name from this environment.
-   *
-   * @param name The name of the entity.
-   * @return The {@link Trigger} with the specified name or null if no entity is found.
-   * @see #getTrigger(int)
-   * @see #getTriggers()
-   */
+  /// Gets the [Trigger] with the specified name from this environment.
+  ///
+  /// @param name The name of the entity.
+  /// @return The [Trigger] with the specified name or null if no entity is found.
+  /// @see #getTrigger(int)
+  /// @see #getTriggers()
   public Trigger getTrigger(final String name) {
     return getByName(this.triggers, name);
   }
 
-  /**
-   * Gets all tags that are assigned to entities on this environment.
-   *
-   * @return All assigned tags of this environment.
-   */
+  /// Gets all tags that are assigned to entities on this environment.
+  ///
+  /// @return All assigned tags of this environment.
   public Collection<String> getUsedTags() {
     return Collections.unmodifiableCollection(this.getEntitiesByTag().keySet());
   }
 
-  /**
-   * Gets the center location of the boundaries defined by the map of this environment.
-   *
-   * @return The center of this environment.
-   * @see #getMap()
-   */
+  /// Gets the center location of the boundaries defined by the map of this environment.
+  ///
+  /// @return The center of this environment.
+  /// @see #getMap()
   public Point2D getCenter() {
     return new Point2D.Double(this.getMap().getSizeInPixels().getWidth() / 2.0,
       this.getMap().getSizeInPixels().getHeight() / 2.0);
   }
 
-  /**
-   * Initializes all entities and lighting layers of this environment.
-   *
-   * @see EnvironmentListener#initialized(Environment)
-   */
+  /// Initializes all entities and lighting layers of this environment.
+  ///
+  /// @see EnvironmentListener#initialized(Environment)
   public void init() {
     if (this.initialized) {
       return;
@@ -1788,24 +1522,20 @@ public final class Environment implements IRenderable {
     this.initialized = true;
   }
 
-  /**
-   * Determines whether this environment has been loaded.
-   *
-   * @return True if this environment has been loaded; otherwise false.
-   * @see #load()
-   * @see #unload()
-   */
+  /// Determines whether this environment has been loaded.
+  ///
+  /// @return True if this environment has been loaded; otherwise false.
+  /// @see #load()
+  /// @see #unload()
   public boolean isLoaded() {
     return this.loaded;
   }
 
-  /**
-   * Initializes and loads this environment and all its entities.
-   *
-   * @see #init()
-   * @see EnvironmentListener#loaded(Environment)
-   * @see #isLoaded()
-   */
+  /// Initializes and loads this environment and all its entities.
+  ///
+  /// @see #init()
+  /// @see EnvironmentListener#loaded(Environment)
+  /// @see #isLoaded()
   public void load() {
     this.init();
     if (this.loaded) {
@@ -1824,12 +1554,10 @@ public final class Environment implements IRenderable {
     this.fireEvent(l -> l.loaded(this));
   }
 
-  /**
-   * Loads the entities from the map object with the specified map ID from the map of this environment.
-   *
-   * @param mapId The map ID of the map object.
-   * @return True if any entity could be loaded; otherwise false.
-   */
+  /// Loads the entities from the map object with the specified map ID from the map of this environment.
+  ///
+  /// @param mapId The map ID of the map object.
+  /// @return True if any entity could be loaded; otherwise false.
   public boolean loadFromMap(final int mapId) {
     for (final IMapObjectLayer layer : this.getMap().getMapObjectLayers()) {
       Optional<IMapObject> opt = layer.getMapObjects().stream().filter(
@@ -1843,26 +1571,22 @@ public final class Environment implements IRenderable {
     return false;
   }
 
-  /**
-   * Reloads the map object with the specified map ID from the map by first removing any previously loaded entity and then loading it freshly from its
-   * map definition.
-   *
-   * @param mapId The map ID of the map object.
-   * @see #remove(int)
-   * @see Environment#loadFromMap(int)
-   */
+  /// Reloads the map object with the specified map ID from the map by first removing any previously loaded entity and then loading it freshly from its
+  /// map definition.
+  ///
+  /// @param mapId The map ID of the map object.
+  /// @see #remove(int)
+  /// @see Environment#loadFromMap(int)
   public void reloadFromMap(final int mapId) {
     this.remove(mapId);
     this.loadFromMap(mapId);
   }
 
-  /**
-   * Loads all entities for the specified map object.
-   *
-   * @param mapObject The mapObject to load the entities from.
-   * @return A collection of all loaded entities.
-   * @see MapObjectLoader#load(Environment, IMapObject)
-   */
+  /// Loads all entities for the specified map object.
+  ///
+  /// @param mapObject The mapObject to load the entities from.
+  /// @return A collection of all loaded entities.
+  /// @see MapObjectLoader#load(Environment, IMapObject)
   public Collection<IEntity> load(final IMapObject mapObject) {
     if (mapObject == null) {
       return Collections.emptySet();
@@ -1906,24 +1630,20 @@ public final class Environment implements IRenderable {
     return Collections.emptySet();
   }
 
-  /**
-   * Attempts to interact with triggers on this environment.
-   *
-   * @param source The entity that attempts to interacts with triggers.
-   * @return The trigger that the source entity was able to interact with or null.
-   */
+  /// Attempts to interact with triggers on this environment.
+  ///
+  /// @param source The entity that attempts to interacts with triggers.
+  /// @return The trigger that the source entity was able to interact with or null.
   public Trigger interact(ICollisionEntity source) {
     return this.interact(source, null);
   }
 
-  /**
-   * Attempts to interact with triggers on this environment.
-   *
-   * @param source    The entity that attempts to interacts with triggers.
-   * @param condition The condition that determines whether a trigger can be interacted with.
-   * @return The trigger that the entity was able to interact with or null.
-   * @see Trigger#canTrigger(ICollisionEntity)
-   */
+  /// Attempts to interact with triggers on this environment.
+  ///
+  /// @param source    The entity that attempts to interacts with triggers.
+  /// @param condition The condition that determines whether a trigger can be interacted with.
+  /// @return The trigger that the entity was able to interact with or null.
+  /// @see Trigger#canTrigger(ICollisionEntity)
   public Trigger interact(ICollisionEntity source, Predicate<Trigger> condition) {
     for (final Trigger trigger : this.triggers) {
       if (trigger.canTrigger(source) && (condition == null || condition.test(trigger))) {
@@ -1937,18 +1657,16 @@ public final class Environment implements IRenderable {
     return null;
   }
 
-  /**
-   * Removes the specified entity from this environment and unloads is.
-   *
-   * @param entity The entity to be removed.
-   * @see #remove(int)
-   * @see #remove(String)
-   * @see #removeAll(Iterable)
-   * @see #unload(IEntity)
-   * @see EnvironmentEntityListener#entityRemoved(IEntity)
-   * @see IEntity#removed(Environment)
-   * @see EntityListener#removed(IEntity, Environment)
-   */
+  /// Removes the specified entity from this environment and unloads is.
+  ///
+  /// @param entity The entity to be removed.
+  /// @see #remove(int)
+  /// @see #remove(String)
+  /// @see #removeAll(Iterable)
+  /// @see #unload(IEntity)
+  /// @see EnvironmentEntityListener#entityRemoved(IEntity)
+  /// @see IEntity#removed(Environment)
+  /// @see EntityListener#removed(IEntity, Environment)
   public void remove(final IEntity entity) {
     if (entity == null) {
       return;
@@ -2025,18 +1743,16 @@ public final class Environment implements IRenderable {
     this.fireEntityEvent(l -> l.entityRemoved(entity));
   }
 
-  /**
-   * Removes the entity with the specified map ID from this environment and unloads is.
-   *
-   * @param mapId The map ID of the entity to be removed.
-   * @see #remove(int)
-   * @see #remove(String)
-   * @see #removeAll(Iterable)
-   * @see #unload(IEntity)
-   * @see EnvironmentEntityListener#entityRemoved(IEntity)
-   * @see IEntity#removed(Environment)
-   * @see EntityListener#removed(IEntity, Environment)
-   */
+  /// Removes the entity with the specified map ID from this environment and unloads is.
+  ///
+  /// @param mapId The map ID of the entity to be removed.
+  /// @see #remove(int)
+  /// @see #remove(String)
+  /// @see #removeAll(Iterable)
+  /// @see #unload(IEntity)
+  /// @see EnvironmentEntityListener#entityRemoved(IEntity)
+  /// @see IEntity#removed(Environment)
+  /// @see EntityListener#removed(IEntity, Environment)
   public void remove(final int mapId) {
     final IEntity ent = this.get(mapId);
     if (ent == null) {
@@ -2046,18 +1762,16 @@ public final class Environment implements IRenderable {
     this.remove(ent);
   }
 
-  /**
-   * Removes the entity with the specified name from this environment and unloads is.
-   *
-   * @param name The name of the entity to be removed.
-   * @see #remove(int)
-   * @see #remove(String)
-   * @see #removeAll(Iterable)
-   * @see #unload(IEntity)
-   * @see EnvironmentEntityListener#entityRemoved(IEntity)
-   * @see IEntity#removed(Environment)
-   * @see EntityListener#removed(IEntity, Environment)
-   */
+  /// Removes the entity with the specified name from this environment and unloads is.
+  ///
+  /// @param name The name of the entity to be removed.
+  /// @see #remove(int)
+  /// @see #remove(String)
+  /// @see #removeAll(Iterable)
+  /// @see #unload(IEntity)
+  /// @see EnvironmentEntityListener#entityRemoved(IEntity)
+  /// @see IEntity#removed(Environment)
+  /// @see EntityListener#removed(IEntity, Environment)
   public void remove(String name) {
     final IEntity ent = this.get(name);
     if (ent == null) {
@@ -2067,14 +1781,12 @@ public final class Environment implements IRenderable {
     this.remove(ent);
   }
 
-  /**
-   * Removes all specified entities from this environment.
-   *
-   * @param <T>      The type of the specified entities
-   * @param entities The entities to be removed.
-   * @see #remove(int)
-   * @see #remove(String)
-   */
+  /// Removes all specified entities from this environment.
+  ///
+  /// @param <T>      The type of the specified entities
+  /// @param entities The entities to be removed.
+  /// @see #remove(int)
+  /// @see #remove(String)
   public <T extends IEntity> void removeAll(Iterable<T> entities) {
     if (entities == null) {
       return;
@@ -2085,13 +1797,11 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Removes all specified entities from this environment.
-   *
-   * @param entities The entities to be removed.
-   * @see #remove(int)
-   * @see #remove(String)
-   */
+  /// Removes all specified entities from this environment.
+  ///
+  /// @param entities The entities to be removed.
+  /// @see #remove(int)
+  /// @see #remove(String)
   public void removeAll(IEntity... entities) {
     this.removeAll(Arrays.asList(entities));
   }
@@ -2158,30 +1868,24 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Gets the gravity defined for this environment.
-   *
-   * @return The gravity of this environment.
-   * @see GameWorld#gravity()
-   * @see GameWorld#setGravity(int)
-   * @see #setGravity(int)
-   */
+  /// Gets the gravity defined for this environment.
+  ///
+  /// @return The gravity of this environment.
+  /// @see GameWorld#gravity()
+  /// @see GameWorld#setGravity(int)
+  /// @see #setGravity(int)
   public int getGravity() {
     return this.gravity;
   }
 
-  /**
-   * Sets the gravity for this particular environment.
-   *
-   * <p>
-   * This typically only needs to be called explicitly, when the gravity is different than for other environments.
-   * </p>
-   *
-   * @param gravity The new gravity for this environment. If 0, no gravity will be applied.
-   * @see GameWorld#gravity()
-   * @see GameWorld#setGravity(int)
-   * @see #getGravity()
-   */
+  /// Sets the gravity for this particular environment.
+  ///
+  /// This typically only needs to be called explicitly, when the gravity is different than for other environments.
+  ///
+  /// @param gravity The new gravity for this environment. If 0, no gravity will be applied.
+  /// @see GameWorld#gravity()
+  /// @see GameWorld#setGravity(int)
+  /// @see #getGravity()
   public void setGravity(int gravity) {
     this.gravity = gravity;
 
@@ -2200,12 +1904,10 @@ public final class Environment implements IRenderable {
     }
   }
 
-  /**
-   * Unloads all entities of this environment.
-   *
-   * @see #unload(IEntity)
-   * @see EnvironmentListener#unloaded(Environment)
-   */
+  /// Unloads all entities of this environment.
+  ///
+  /// @see #unload(IEntity)
+  /// @see EnvironmentListener#unloaded(Environment)
   public void unload() {
     if (!this.loaded) {
       return;
@@ -2312,18 +2014,15 @@ public final class Environment implements IRenderable {
     this.staticShadowLayer = new StaticShadowLayer(this, color);
   }
 
-  /**
-   * Loads the specified entity by performing the following steps:
-   * <ol>
-   * <li>add to physics engine</li>
-   * <li>register entity for update</li>
-   * <li>register animation controller for update</li>
-   * <li>register movement controller for update</li>
-   * <li>register AI controller for update</li>
-   * </ol>
-   *
-   * @param entity
-   */
+  /// Loads the specified entity by performing the following steps:
+  ///
+  /// 1. add to physics engine
+  /// 2. register entity for update
+  /// 3. register animation controller for update
+  /// 4. register movement controller for update
+  /// 5. register AI controller for update
+  ///
+  /// @param entity
   private void load(final IEntity entity) {
     // an entity can only exist on one environment at a time, so remove it from the current one
     if (entity.getEnvironment() != null) {
@@ -2446,18 +2145,15 @@ public final class Environment implements IRenderable {
     return normalized;
   }
 
-  /**
-   * Unload the specified entity by performing the following steps:
-   * <ol>
-   * <li>remove entities from physics engine</li>
-   * <li>unregister units from update</li>
-   * <li>unregister ai controller from update</li>
-   * <li>unregister animation controller from update</li>
-   * <li>unregister movement controller from update</li>
-   * </ol>
-   *
-   * @param entity
-   */
+  /// Unload the specified entity by performing the following steps:
+  ///
+  /// 1. remove entities from physics engine
+  /// 2. unregister units from update
+  /// 3. unregister ai controller from update
+  /// 4. unregister animation controller from update
+  /// 5. unregister movement controller from update
+  ///
+  /// @param entity
   private void unload(final IEntity entity) {
     // 1. remove from physics engine
     if (entity instanceof ICollisionEntity iCollisionEntity) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/Environment.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/Environment.java
@@ -75,6 +75,18 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/// The live collection of entities, map data, render layers, and physical state for one loaded map.
+///
+/// Environments are normally created and activated through [GameWorld] rather than constructed by
+/// game code directly. Use [Game#world()] to access the current world and [GameWorld#environment()]
+/// to access its active environment. Entity lookup can be expressed with [#query(Class)].
+///
+/// Map object loaders translate objects from an [IMap] into engine entities when the environment is
+/// loaded. Register custom loaders with [#registerMapObjectLoader(IMapObjectLoader)].
+///
+/// @see Game#world()
+/// @see GameWorld
+/// @see EntityQuery
 public final class Environment implements IRenderable {
 
   private static final Map<String, IMapObjectLoader> mapObjectLoaders = new ConcurrentHashMap<>();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentListener.java
@@ -1,30 +1,24 @@
 package de.gurkenlabs.litiengine.environment;
 
-/**
- * This listener provides callbacks for different points over the life cycle of an {@code IEnvironment}
- * (loaded/unloaded/cleared/initialized).
- * 
- * @see Environment#load()
- * @see Environment#unload()
- * @see Environment#clear()
- * @see Environment#init()
- */
+/// This listener provides callbacks for different points over the life cycle of an `IEnvironment`
+/// (loaded/unloaded/cleared/initialized).
+///
+/// @see Environment#load()
+/// @see Environment#unload()
+/// @see Environment#clear()
+/// @see Environment#init()
 public interface EnvironmentListener extends EnvironmentLoadedListener, EnvironmentUnloadedListener {
 
-  /**
-   * This method was called after the environment was cleared.
-   * 
-   * @param environment
-   *          The environment that was cleared.
-   */
+  /// This method was called after the environment was cleared.
+  ///
+  /// @param environment
+  /// The environment that was cleared.
   default void cleared(Environment environment) {}
 
-  /**
-   * This method was called after the environment was initialized.
-   * 
-   * @param environment
-   *          The environment that was initialized.
-   */
+  /// This method was called after the environment was initialized.
+  ///
+  /// @param environment
+  /// The environment that was initialized.
   default void initialized(Environment environment) {}
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentLoadedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentLoadedListener.java
@@ -2,19 +2,15 @@ package de.gurkenlabs.litiengine.environment;
 
 import java.util.EventListener;
 
-/**
- * This listener provides callbacks for when an {@code Environment} was loaded.
- * 
- * @see Environment#load()
- */
+/// This listener provides callbacks for when an `Environment` was loaded.
+///
+/// @see Environment#load()
 @FunctionalInterface
 public interface EnvironmentLoadedListener extends EventListener {
 
-  /**
-   * This method is called after the environment was loaded.
-   * 
-   * @param environment
-   *          The environment that was loaded.
-   */
+  /// This method is called after the environment was loaded.
+  ///
+  /// @param environment
+  /// The environment that was loaded.
   void loaded(Environment environment);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentRenderedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentRenderedListener.java
@@ -5,20 +5,16 @@ import java.util.EventListener;
 
 import de.gurkenlabs.litiengine.graphics.RenderType;
 
-/**
- * This listener provides call backs for different points during rendering an {@code Environment}.
- * 
- * @see Environment#render(Graphics2D)
- */
+/// This listener provides call backs for different points during rendering an `Environment`.
+///
+/// @see Environment#render(Graphics2D)
 @FunctionalInterface
 public interface EnvironmentRenderedListener extends EventListener {
-  /**
-   * This method is called after the {@code Environment} rendered everything of the specified {@code RenderType}.
-   * 
-   * @param g
-   *          The graphics object that is being rendered to.
-   * @param type
-   *          The render type for which all instances were just rendered.
-   */
+  /// This method is called after the `Environment` rendered everything of the specified `RenderType`.
+  ///
+  /// @param g
+  /// The graphics object that is being rendered to.
+  /// @param type
+  /// The render type for which all instances were just rendered.
   void rendered(Graphics2D g, RenderType type);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentUnloadedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/EnvironmentUnloadedListener.java
@@ -2,19 +2,15 @@ package de.gurkenlabs.litiengine.environment;
 
 import java.util.EventListener;
 
-/**
- * This listener provides callbacks for when an {@code Environment} was unloaded.
- * 
- * @see Environment#load()
- */
+/// This listener provides callbacks for when an `Environment` was unloaded.
+///
+/// @see Environment#load()
 @FunctionalInterface
 public interface EnvironmentUnloadedListener extends EventListener {
 
-  /**
-   * This method is called after the environment was unloaded.
-   * 
-   * @param environment
-   *          The environment that was loaded.
-   */
+  /// This method is called after the environment was unloaded.
+  ///
+  /// @param environment
+  /// The environment that was loaded.
   void unloaded(Environment environment);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/GameWorld.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/GameWorld.java
@@ -15,23 +15,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.Lock;
 
-/**
- * The {@code GameWorld} class is a global environment manager that contains all {@code Environments} and provides the currently active
- * {@code Environment} and {@code Camera}.<br>
- * <p>
- * The {@code GameWorld} returns the same instance for a particular map/mapName until the {@code GameWorld.reset(String)} method is called.
- * </p>
- * <p>
- * Moreover, it provides the possibility to attach game logic via {@code EnvironmentListeners} to different events of the {@code Envrionment's} life
- * cycle (e.g. loaded, initialized, ...).<br>
- * <i>This is typically used to provide some per-level logic or to trigger general loading behavior.</i>
- *
- * @see Environment
- * @see Camera
- * @see GameWorld#environment()
- * @see GameWorld#camera()
- * @see GameWorld#reset(String)
- */
+/// The `GameWorld` class is a global environment manager that contains all `Environments` and provides the currently active
+/// `Environment` and `Camera`.
+///
+/// The `GameWorld` returns the same instance for a particular map/mapName until the `GameWorld.reset(String)` method is called.
+///
+/// Moreover, it provides the possibility to attach game logic via `EnvironmentListeners` to different events of the `Envrionment's` life
+/// cycle (e.g. loaded, initialized, ...).
+///
+/// *This is typically used to provide some per-level logic or to trigger general loading behavior.*
+///
+/// @see Environment
+/// @see Camera
+/// @see GameWorld#environment()
+/// @see GameWorld#camera()
+/// @see GameWorld#reset(String)
 public final class GameWorld implements IUpdateable {
   private final List<EnvironmentListener> listeners = new CopyOnWriteArrayList<>();
   private final List<EnvironmentLoadedListener> loadedListeners = new CopyOnWriteArrayList<>();
@@ -48,22 +46,16 @@ public final class GameWorld implements IUpdateable {
   private ICamera camera;
   private int gravity;
 
-  /**
-   * <p>
-   * <b>You should never call this manually! Instead use the {@code Game.world()} instance.</b>
-   * </p>
-   *
-   * @see Game#world()
-   */
+  /// **You should never call this manually! Instead use the `Game.world()` instance.**
+  ///
+  /// @see Game#world()
   public GameWorld() {
     if (Game.world() != null) {
       throw new UnsupportedOperationException("Never initialize a GameWorld manually. Use Game.world() instead.");
     }
   }
 
-  /**
-   * Don't call this manually!
-   */
+  /// Don't call this manually!
   @Override
   public void update() {
     if (this.environment() == null) {
@@ -78,175 +70,139 @@ public final class GameWorld implements IUpdateable {
     }
   }
 
-  /**
-   * Adds the specified environment listener to receive events about the basic life-cycle of environments. This is a global event that gets called for
-   * any map.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment listener to receive events about the basic life-cycle of environments. This is a global event that gets called for
+  /// any map.
+  ///
+  /// @param listener The listener to add.
   public void addListener(EnvironmentListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes the specified environment listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeListener(EnvironmentListener listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Adds the specified environment loaded listener to receive events for when an environment gets loaded. This is a global event that gets called for
-   * any map.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment loaded listener to receive events for when an environment gets loaded. This is a global event that gets called for
+  /// any map.
+  ///
+  /// @param listener The listener to add.
   public void onLoaded(EnvironmentLoadedListener listener) {
     this.loadedListeners.add(listener);
   }
 
-  /**
-   * Removes the specified environment loaded listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment loaded listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeLoadedListener(EnvironmentLoadedListener listener) {
     this.loadedListeners.remove(listener);
   }
 
-  /**
-   * Adds the specified environment unloaded listener to receive events for when an environment gets unloaded. This is a global event that gets called
-   * for any map.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment unloaded listener to receive events for when an environment gets unloaded. This is a global event that gets called
+  /// for any map.
+  ///
+  /// @param listener The listener to add.
   public void onUnloaded(EnvironmentUnloadedListener listener) {
     this.unloadedListeners.add(listener);
   }
 
-  /**
-   * Removes the specified environment unloaded listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment unloaded listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeUnloadedListener(EnvironmentUnloadedListener listener) {
     this.unloadedListeners.remove(listener);
   }
 
-  /**
-   * Adds the specified environment loaded listener to receive events for when an environment with the specified map name gets loaded.
-   *
-   * @param mapName  The name of the map for which to add the listener.
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment loaded listener to receive events for when an environment with the specified map name gets loaded.
+  ///
+  /// @param mapName  The name of the map for which to add the listener.
+  /// @param listener The listener to add.
   public void onLoaded(String mapName, EnvironmentLoadedListener listener) {
     add(this.environmentLoadedListeners, mapName, listener);
   }
 
-  /**
-   * Removes the specified environment loaded listener for the specified map name.
-   *
-   * @param mapName  The name of the map for which to remove the listener.
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment loaded listener for the specified map name.
+  ///
+  /// @param mapName  The name of the map for which to remove the listener.
+  /// @param listener The listener to remove.
   public void removeLoadedListener(String mapName, EnvironmentLoadedListener listener) {
     remove(this.environmentLoadedListeners, mapName, listener);
   }
 
-  /**
-   * Adds the specified environment unloaded listener to receive events for when an environment with the specified map name gets unloaded.
-   *
-   * @param mapName  The name of the map for which to add the listener.
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment unloaded listener to receive events for when an environment with the specified map name gets unloaded.
+  ///
+  /// @param mapName  The name of the map for which to add the listener.
+  /// @param listener The listener to add.
   public void onUnloaded(String mapName, EnvironmentUnloadedListener listener) {
     add(this.environmentUnloadedListeners, mapName, listener);
   }
 
-  /**
-   * Removes the specified environment unloaded listener for the specified map name.
-   *
-   * @param mapName  The name of the map for which to remove the listener.
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment unloaded listener for the specified map name.
+  ///
+  /// @param mapName  The name of the map for which to remove the listener.
+  /// @param listener The listener to remove.
   public void removeUnloadedListener(String mapName, EnvironmentUnloadedListener listener) {
     add(this.environmentUnloadedListeners, mapName, listener);
   }
 
-  /**
-   * Adds the specified environment listener to receive events about the basic life-cycle of environments with the specified map name.
-   *
-   * @param mapName  The name of the map for which to add the listener.
-   * @param listener The listener to add.
-   */
+  /// Adds the specified environment listener to receive events about the basic life-cycle of environments with the specified map name.
+  ///
+  /// @param mapName  The name of the map for which to add the listener.
+  /// @param listener The listener to add.
   public void addListener(String mapName, EnvironmentListener listener) {
     add(this.environmentListeners, mapName, listener);
   }
 
-  /**
-   * Removes the specified environment listener.
-   *
-   * @param mapName  The name of the map for which to remove the listener.
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified environment listener.
+  ///
+  /// @param mapName  The name of the map for which to remove the listener.
+  /// @param listener The listener to remove.
   public void removeListener(String mapName, EnvironmentListener listener) {
     remove(this.environmentListeners, mapName, listener);
   }
 
-  /**
-   * Attaches the specified updatable instance that only gets updated when an environment with the specified map name is currently loaded.
-   *
-   * @param mapName    The name of the map for which to attach the updatable instance.
-   * @param updateable The updatable instance to attach.
-   */
+  /// Attaches the specified updatable instance that only gets updated when an environment with the specified map name is currently loaded.
+  ///
+  /// @param mapName    The name of the map for which to attach the updatable instance.
+  /// @param updateable The updatable instance to attach.
   public void attach(String mapName, IUpdateable updateable) {
     add(this.updatables, mapName, updateable);
   }
 
-  /**
-   * Detaches the specified updatable instance from the updating of environments with the specified map name.
-   *
-   * @param mapName    The name of the map for which to detach the updatable instance.
-   * @param updateable The updatable instance to detach.
-   */
+  /// Detaches the specified updatable instance from the updating of environments with the specified map name.
+  ///
+  /// @param mapName    The name of the map for which to detach the updatable instance.
+  /// @param updateable The updatable instance to detach.
   public void detach(String mapName, IUpdateable updateable) {
     remove(this.updatables, mapName, updateable);
   }
 
-  /**
-   * Gets the game's current {@code Camera}.
-   *
-   * @return The currently active camera.
-   * @see ICamera
-   */
+  /// Gets the game's current `Camera`.
+  ///
+  /// @return The currently active camera.
+  /// @see ICamera
   public ICamera camera() {
     return this.camera;
   }
 
-  /**
-   * Gets the game's current {@code Environment}.
-   *
-   * @return The currently active environment.
-   * @see Environment
-   */
+  /// Gets the game's current `Environment`.
+  ///
+  /// @return The currently active environment.
+  /// @see Environment
   public Environment environment() {
     return this.environment;
   }
 
-  /**
-   * Gets the game worlds gravity that is applied to any environment. This can e.g. be useful for platformers.
-   *
-   * @return The gravity of the game world that gets applied to any environment.
-   */
+  /// Gets the game worlds gravity that is applied to any environment. This can e.g. be useful for platformers.
+  ///
+  /// @return The gravity of the game world that gets applied to any environment.
   public int gravity() {
     return this.gravity;
   }
 
-  /**
-   * Clears the currently active camera and environment, removes all previously loaded environments and clears all listener lists.
-   */
+  /// Clears the currently active camera and environment, removes all previously loaded environments and clears all listener lists.
   public void clear() {
     this.unloadEnvironment();
     this.environments.clear();
@@ -262,21 +218,18 @@ public final class GameWorld implements IUpdateable {
     this.unloadedListeners.clear();
   }
 
-  /**
-   * Gets all environments that are known to the game world.
-   *
-   * @return All known environments.
-   */
+  /// Gets all environments that are known to the game world.
+  ///
+  /// @return All known environments.
   public Collection<Environment> getEnvironments() {
     return this.environments.values();
   }
 
-  /**
-   * Gets the environment that's related to the specified mapName.<br> This method implicitly creates a new {@code Environment} if necessary.
-   *
-   * @param mapName The map name by which the environment is identified.
-   * @return The environment for the map name or null if no such map can be found.
-   */
+  /// Gets the environment that's related to the specified mapName.
+  /// This method implicitly creates a new `Environment` if necessary.
+  ///
+  /// @param mapName The map name by which the environment is identified.
+  /// @return The environment for the map name or null if no such map can be found.
   public Environment getEnvironment(String mapName) {
     if (mapName == null || mapName.isEmpty()) {
       return null;
@@ -286,12 +239,11 @@ public final class GameWorld implements IUpdateable {
     return this.getEnvironment(map);
   }
 
-  /**
-   * Gets the environment that's related to the specified map.<br> This method implicitly creates a new {@code Environment} if necessary.
-   *
-   * @param map The map by which the environment is identified.
-   * @return The environment for the map or null if no such map can be found.
-   */
+  /// Gets the environment that's related to the specified map.
+  /// This method implicitly creates a new `Environment` if necessary.
+  ///
+  /// @param map The map by which the environment is identified.
+  /// @return The environment for the map or null if no such map can be found.
   public Environment getEnvironment(IMap map) {
     if (map == null || map.getName() == null || map.getName().isEmpty()) {
       return null;
@@ -308,27 +260,21 @@ public final class GameWorld implements IUpdateable {
     return env;
   }
 
-  /**
-   * Indicates whether this instance already contains an {@code Environment} for the specified map name.
-   *
-   * @param mapName The map name by which the environment is identified.
-   * @return True if the game world already has an environment for the specified map name; otherwise false.
-   */
+  /// Indicates whether this instance already contains an `Environment` for the specified map name.
+  ///
+  /// @param mapName The map name by which the environment is identified.
+  /// @return True if the game world already has an environment for the specified map name; otherwise false.
   public boolean containsEnvironment(String mapName) {
     return this.environments.containsKey(mapName.toLowerCase());
   }
 
-  /**
-   * Loads the specified {@code Environment} and sets it as current environment of the game. This implicitly unloads the previously loaded environment
-   * (if present).
-   *
-   * <p>
-   * <i>The loaded environment can then be accessed via {@code GameWorld#environment()}.</i>
-   * </p>
-   *
-   * @param env The environment to be loaded.
-   * @see GameWorld#environment()
-   */
+  /// Loads the specified `Environment` and sets it as current environment of the game. This implicitly unloads the previously loaded environment
+  /// (if present).
+  ///
+  /// *The loaded environment can then be accessed via `GameWorld#environment()`.*
+  ///
+  /// @param env The environment to be loaded.
+  /// @see GameWorld#environment()
   public void loadEnvironment(final Environment env) {
     Lock lock = Game.loop().getLock();
     lock.lock();
@@ -366,47 +312,37 @@ public final class GameWorld implements IUpdateable {
     }
   }
 
-  /**
-   * Loads the {@code Environment} that is identified by the specified map name and sets it as current environment of the game. This implicitly
-   * unloads the previously loaded environment (if present).
-   *
-   * <p>
-   * <i>The loaded environment can then be accessed via {@code GameWorld#environment()}.</i>
-   * </p>
-   *
-   * @param mapName The map name by which the environment is identified.
-   * @return The loaded environment.
-   * @see GameWorld#environment()
-   * @see GameWorld#loadEnvironment(Environment)
-   */
+  /// Loads the `Environment` that is identified by the specified map name and sets it as current environment of the game. This implicitly
+  /// unloads the previously loaded environment (if present).
+  ///
+  /// *The loaded environment can then be accessed via `GameWorld#environment()`.*
+  ///
+  /// @param mapName The map name by which the environment is identified.
+  /// @return The loaded environment.
+  /// @see GameWorld#environment()
+  /// @see GameWorld#loadEnvironment(Environment)
   public Environment loadEnvironment(String mapName) {
     Environment env = this.getEnvironment(mapName);
     this.loadEnvironment(env);
     return env;
   }
 
-  /**
-   * Loads the {@code Environment} that is identified by the specified map and sets it as current environment of the game. This implicitly unloads the
-   * previously loaded environment (if present).
-   *
-   * <p>
-   * <i>The loaded environment can then be accessed via {@code GameWorld#environment()}.</i>
-   * </p>
-   *
-   * @param map The map by which the environment is identified.
-   * @return The loaded environment.
-   * @see GameWorld#environment()
-   * @see GameWorld#loadEnvironment(Environment)
-   */
+  /// Loads the `Environment` that is identified by the specified map and sets it as current environment of the game. This implicitly unloads the
+  /// previously loaded environment (if present).
+  ///
+  /// *The loaded environment can then be accessed via `GameWorld#environment()`.*
+  ///
+  /// @param map The map by which the environment is identified.
+  /// @return The loaded environment.
+  /// @see GameWorld#environment()
+  /// @see GameWorld#loadEnvironment(Environment)
   public Environment loadEnvironment(IMap map) {
     Environment env = this.getEnvironment(map);
     this.loadEnvironment(env);
     return env;
   }
 
-  /**
-   * Unloads the current {@code Environment} and sets it to null.
-   */
+  /// Unloads the current `Environment` and sets it to null.
   public void unloadEnvironment() {
     if (this.environment() != null) {
       this.environment().unload();
@@ -427,19 +363,15 @@ public final class GameWorld implements IUpdateable {
     this.environment = null;
   }
 
-  /**
-   * Resets the previously loaded {@code Environment} for the specified map name so that it can be re-initiated upon the next access.
-   *
-   * <p>
-   * <i>This can be used if one wants to completely reset the state of a level to its initial state. It'll just throw away
-   * the current environment instance and reload a new one upon the next access.</i>
-   * </p>
-   *
-   * @param mapName The map name by which the environment is identified.
-   * @return The environment instance that was reset or null if none was previously loaded.
-   * @see GameWorld#getEnvironment(String)
-   * @see GameWorld#reset(IMap)
-   */
+  /// Resets the previously loaded `Environment` for the specified map name so that it can be re-initiated upon the next access.
+  ///
+  /// *This can be used if one wants to completely reset the state of a level to its initial state. It'll just throw away
+  /// the current environment instance and reload a new one upon the next access.*
+  ///
+  /// @param mapName The map name by which the environment is identified.
+  /// @return The environment instance that was reset or null if none was previously loaded.
+  /// @see GameWorld#getEnvironment(String)
+  /// @see GameWorld#reset(IMap)
   public Environment reset(String mapName) {
     if (mapName == null || mapName.isEmpty()) {
       return null;
@@ -448,19 +380,15 @@ public final class GameWorld implements IUpdateable {
     return this.reset(Resources.maps().get(mapName));
   }
 
-  /**
-   * Resets the previously loaded {@code Environment} for the specified map so that it can be re-initiated upon the next access.
-   *
-   * <p>
-   * <i>This can be used if one wants to completely reset the state of a level to its initial state. It'll just throw away
-   * the current environment instance and reload a new one upon the next access.</i>
-   * </p>
-   *
-   * @param map The map by which the environment is identified.
-   * @return The environment instance that was reset or null if none was previously loaded.
-   * @see GameWorld#getEnvironment(String)
-   * @see GameWorld#reset(IMap)
-   */
+  /// Resets the previously loaded `Environment` for the specified map so that it can be re-initiated upon the next access.
+  ///
+  /// *This can be used if one wants to completely reset the state of a level to its initial state. It'll just throw away
+  /// the current environment instance and reload a new one upon the next access.*
+  ///
+  /// @param map The map by which the environment is identified.
+  /// @return The environment instance that was reset or null if none was previously loaded.
+  /// @see GameWorld#getEnvironment(String)
+  /// @see GameWorld#reset(IMap)
   public Environment reset(IMap map) {
     if (map == null) {
       return null;
@@ -488,11 +416,9 @@ public final class GameWorld implements IUpdateable {
     return env;
   }
 
-  /**
-   * Sets the active camera of the game.
-   *
-   * @param cam The new camera to be set.
-   */
+  /// Sets the active camera of the game.
+  ///
+  /// @param cam The new camera to be set.
   public void setCamera(final ICamera cam) {
     if (this.camera() != null) {
       Game.loop().detach(camera);
@@ -506,13 +432,11 @@ public final class GameWorld implements IUpdateable {
     }
   }
 
-  /**
-   * Specify the general gravity that will be used as default value for all environments that are loaded. The value's unit of measure is pixel/second
-   * (similar to the velocity of a {@code IMobileEntity}.)
-   *
-   * @param gravity The default gravity for all environments.
-   * @see IMobileEntity#getVelocity()
-   */
+  /// Specify the general gravity that will be used as default value for all environments that are loaded. The value's unit of measure is pixel/second
+  /// (similar to the velocity of a `IMobileEntity`.)
+  ///
+  /// @param gravity The default gravity for all environments.
+  /// @see IMobileEntity#getVelocity()
   public void setGravity(int gravity) {
     this.gravity = gravity;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/IEntitySpawner.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/IEntitySpawner.java
@@ -8,107 +8,78 @@ import de.gurkenlabs.litiengine.entities.Spawnpoint;
 
 public interface IEntitySpawner<T extends IEntity> extends IUpdateable {
 
-  /**
-   * SpawnMode specifies the behaviour of the EntitySpawner:
-   * <ul>
-   * <li><b>ALLSPAWNPOINTS</b>: the specified spawnAmount is spawned at each of the SpawnPoints individually</li>
-   * <li><b>ONERANDOMSPAWNPOINT</b>: the specified spawnAmount is spawned at one random SpawnPoint</li>
-   * <li><b>RANDOMSPAWNPOINTS</b>: the specified spawnAmount is distributed equally to all of the SpawnPoints</li>
-   * </ul>
-   */
+  /// SpawnMode specifies the behaviour of the EntitySpawner:
+  ///
+  /// - **ALLSPAWNPOINTS**: the specified spawnAmount is spawned at each of the SpawnPoints individually
+  /// - **ONERANDOMSPAWNPOINT**: the specified spawnAmount is spawned at one random SpawnPoint
+  /// - **RANDOMSPAWNPOINTS**: the specified spawnAmount is distributed equally to all of the SpawnPoints
   enum SpawnMode {
 
-    /**
-     * Spawns the amount of mobs for all the spawnpoints available.
-     */
+    /// Spawns the amount of mobs for all the spawnpoints available.
     ALLSPAWNPOINTS,
 
-    /**
-     * Spawns the amount of mobs on one random spawnpoint.
-     */
+    /// Spawns the amount of mobs on one random spawnpoint.
     ONERANDOMSPAWNPOINT,
 
-    /**
-     * Spawns the amount of mobs, distributed to random spawnpoints.
-     */
+    /// Spawns the amount of mobs, distributed to random spawnpoints.
     RANDOMSPAWNPOINTS,
 
     CUSTOMSPAWNPOINTS,
   }
 
-  /**
-   * Creates a new instance of the provided Entity type.
-   *
-   * @return the Entity instance which will be spawned
-   */
+  /// Creates a new instance of the provided Entity type.
+  ///
+  /// @return the Entity instance which will be spawned
   T createNew();
 
-  /**
-   * Gets the amount of Entities that are spawned in each wave.
-   *
-   * @return the spawn amount
-   */
+  /// Gets the amount of Entities that are spawned in each wave.
+  ///
+  /// @return the spawn amount
   int getSpawnAmount();
 
-  /**
-   * Gets the interval between spawn waves.
-   *
-   * @return the spawn interval
-   */
+  /// Gets the interval between spawn waves.
+  ///
+  /// @return the spawn interval
   int getSpawnInterval();
 
-  /**
-   * Gets the delay between spawning individual Entities of one wave.
-   *
-   * @return the spawn delay
-   */
+  /// Gets the delay between spawning individual Entities of one wave.
+  ///
+  /// @return the spawn delay
   int getSpawnDelay();
 
-  /**
-   * Gets the spawn mode for an EntitySpawner.
-   *
-   * @see SpawnMode
-   * @return the spawn mode
-   */
+  /// Gets the spawn mode for an EntitySpawner.
+  ///
+  /// @see SpawnMode
+  /// @return the spawn mode
   SpawnMode getSpawnMode();
 
-  /**
-   * Gets the list of SpawnPoints that a EntitySpawner uses.
-   *
-   * @return the spawn points
-   */
+  /// Gets the list of SpawnPoints that a EntitySpawner uses.
+  ///
+  /// @return the spawn points
   List<Spawnpoint> getSpawnPoints();
 
-  /**
-   * Sets the amount of Entities that spawn in each wave.
-   *
-   * @param amount
-   *          the new amount
-   */
+  /// Sets the amount of Entities that spawn in each wave.
+  ///
+  /// @param amount
+  /// the new amount
   void setSpawnAmount(int amount);
 
-  /**
-   * Sets the interval in milliseconds between each spawn wave.
-   *
-   * @param interval
-   *          the new interval
-   */
+  /// Sets the interval in milliseconds between each spawn wave.
+  ///
+  /// @param interval
+  /// the new interval
   void setSpawnInterval(int interval);
 
-  /**
-   * Gets the delay in milliseconds between spawning individual Entities of one wave.
-   *
-   * @param delay
-   *          the new spawn delay
-   */
+  /// Gets the delay in milliseconds between spawning individual Entities of one wave.
+  ///
+  /// @param delay
+  /// the new spawn delay
   void setSpawnDelay(int delay);
 
-  /**
-   * Sets the spawn mode.
-   * 
-   * @param mode
-   *          the new spawn mode
-   * @see SpawnMode
-   */
+  /// Sets the spawn mode.
+  ///
+  /// @param mode
+  /// the new spawn mode
+  /// @see SpawnMode
   void setSpawnMode(SpawnMode mode);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/IMapObjectLoader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/IMapObjectLoader.java
@@ -4,34 +4,28 @@ import de.gurkenlabs.litiengine.entities.IEntity;
 import de.gurkenlabs.litiengine.environment.tilemap.IMapObject;
 import java.util.Collection;
 
-/**
- * This interface provides methods that are required for loading an {@code IEntity} from an {@code IMapObject}. It separates the actual entity
- * implementation from the loading process and provide a place to implement all the logic to load attributes and initialize logic based on static
- * information from the {@code IMap}. <br>
- * <br>
- * The engine provides default implementations for all predefined {@code Entity} types (e.g. {@code Prop or Creature}). You can inherit/call the
- * abstract {@code MapObjectLoader} implementation to make use of predefined loading logic.
- *
- * @see Environment#registerMapObjectLoader(IMapObjectLoader)
- * @see MapObjectLoader#loadDefaultProperties(IEntity, IMapObject)
- */
+/// This interface provides methods that are required for loading an `IEntity` from an `IMapObject`. It separates the actual entity
+/// implementation from the loading process and provide a place to implement all the logic to load attributes and initialize logic based on static
+/// information from the `IMap`.
+///
+/// The engine provides default implementations for all predefined `Entity` types (e.g. `Prop or Creature`). You can inherit/call the
+/// abstract `MapObjectLoader` implementation to make use of predefined loading logic.
+///
+/// @see Environment#registerMapObjectLoader(IMapObjectLoader)
+/// @see MapObjectLoader#loadDefaultProperties(IEntity, IMapObject)
 public interface IMapObjectLoader {
   String getMapObjectType();
 
-  /**
-   * Loads entities from the specified map object within the given environment.
-   *
-   * @param environment The environment in which the entities are being loaded.
-   * @param mapObject   The map object containing the data for the entities.
-   * @return A collection of {@code IEntity} instances loaded from the map object.
-   */
+  /// Loads entities from the specified map object within the given environment.
+  ///
+  /// @param environment The environment in which the entities are being loaded.
+  /// @param mapObject   The map object containing the data for the entities.
+  /// @return A collection of `IEntity` instances loaded from the map object.
   Collection<IEntity> load(Environment environment, IMapObject mapObject);
 
-  /**
-   * This method is called externally on the loader instance after the entities have been loaded.
-   *
-   * @param entities  The loaded entities.
-   * @param mapObject The map object by which the entities have been loaded.
-   */
+  /// This method is called externally on the loader instance after the entities have been loaded.
+  ///
+  /// @param entities  The loaded entities.
+  /// @param mapObject The map object by which the entities have been loaded.
   void afterLoad(Collection<IEntity> entities, IMapObject mapObject);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/MapObjectLoader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/MapObjectLoader.java
@@ -34,22 +34,20 @@ public abstract class MapObjectLoader implements IMapObjectLoader {
     return this.mapObjectType;
   }
 
-  /**
-   * Loads engine default properties to the specified {@code IEntity} instance:
-   * <ul>
-   * <li>width, height</li>
-   * <li>mapId</li>
-   * <li>name</li>
-   * <li>location</li>
-   * <li>tags</li>
-   * </ul>
-   * Also, this supports predefined {@code CustomMapObjectProperties}. It loads the specified custom properties via
-   * reflection.
-   *
-   * @param entity    The entity instance that will be initialized.
-   * @param mapObject The mapObject that provides the static information for the new entity.
-   * @see TmxProperty
-   */
+  /// Loads engine default properties to the specified `IEntity` instance:
+  ///
+  /// - width, height
+  /// - mapId
+  /// - name
+  /// - location
+  /// - tags
+  ///
+  /// Also, this supports predefined `CustomMapObjectProperties`. It loads the specified custom properties via
+  /// reflection.
+  ///
+  /// @param entity    The entity instance that will be initialized.
+  /// @param mapObject The mapObject that provides the static information for the new entity.
+  /// @see TmxProperty
   public static void loadDefaultProperties(IEntity entity, IMapObject mapObject) {
     entity.setMapId(mapObject.getId());
     entity.setWidth(mapObject.getWidth());
@@ -130,18 +128,14 @@ public abstract class MapObjectLoader implements IMapObjectLoader {
     }
   }
 
-  /**
-   * If present, this method calls the private {@code afterTmxUnmarshal(IMapObject)} method on the specified entity.
-   *
-   * <p>
-   * The {@link MapObjectLoader} implementation provides the possibility to extend the unmarshalling of the IMapObject within the entity
-   * implementation by implementing a private method with the name "afterTmxUnmarshal" accepting a parameter of type {@link IMapObject}. This method
-   * is called, after the loading has been finished and the entities have been instantiated.
-   * </p>
-   *
-   * @param entity    The entity instance to call the "afterTmxUnmarshal" method on.
-   * @param mapObject The map object to pass to the entity instance when invoking the "afterTmxUnmarshal" method.
-   */
+  /// If present, this method calls the private `afterTmxUnmarshal(IMapObject)` method on the specified entity.
+  ///
+  /// The [MapObjectLoader] implementation provides the possibility to extend the unmarshalling of the IMapObject within the entity
+  /// implementation by implementing a private method with the name "afterTmxUnmarshal" accepting a parameter of type [IMapObject]. This method
+  /// is called, after the loading has been finished and the entities have been instantiated.
+  ///
+  /// @param entity    The entity instance to call the "afterTmxUnmarshal" method on.
+  /// @param mapObject The map object to pass to the entity instance when invoking the "afterTmxUnmarshal" method.
   private void callAfterTmxUnmarshal(IEntity entity, IMapObject mapObject) {
     Method afterTmxUnmarshal = ReflectionUtilities.getMethod("afterTmxUnmarshal", entity.getClass(), IMapObject.class);
     if (afterTmxUnmarshal == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/PropMapObjectLoader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/PropMapObjectLoader.java
@@ -33,32 +33,23 @@ public class PropMapObjectLoader extends MapObjectLoader {
     super(MapObjectType.PROP);
   }
 
-  /**
-   * <p>
-   * Registers a custom {@link Prop} implementation that can be automatically provided by this {@link MapObjectLoader}.
-   * </p>
-   *
-   * <p>
-   * <b>This should only be used if the particular implementation doesn't require any additional map object properties to
-   * be initialized.</b>
-   * </p>
-   *
-   * Make sure that the implementation has the following present:
-   * <ol>
-   * <li>An {@link AnimationInfo} annotation with one or more sprite prefixes defined</li>
-   * <li>Either an empty constructor or a constructor that takes in the sprite prefix from the loader.</li>
-   * </ol>
-   *
-   * <p>
-   * The latter is particularly useful for classes that can have different sprite sheets, i.e. share the same logic but
-   * might have a different appearance.
-   * </p>
-   *
-   * @param <T>
-   *          The type of the custom creature implementation.
-   * @param propType
-   *          The class of the custom {@link Prop} implementation.
-   */
+  /// Registers a custom [Prop] implementation that can be automatically provided by this [MapObjectLoader].
+  ///
+  /// **This should only be used if the particular implementation doesn't require any additional map object properties to
+  /// be initialized.**
+  ///
+  /// Make sure that the implementation has the following present:
+  ///
+  /// 1. An [AnimationInfo] annotation with one or more sprite prefixes defined
+  /// 2. Either an empty constructor or a constructor that takes in the sprite prefix from the loader.
+  ///
+  /// The latter is particularly useful for classes that can have different sprite sheets, i.e. share the same logic but
+  /// might have a different appearance.
+  ///
+  /// @param <T>
+  /// The type of the custom creature implementation.
+  /// @param propType
+  /// The class of the custom [Prop] implementation.
   public static <T extends Prop> void registerCustomPropType(Class<T> propType) {
     customPropType.add(propType);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/TriggerMapObjectLoader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/TriggerMapObjectLoader.java
@@ -24,31 +24,23 @@ public class TriggerMapObjectLoader extends MapObjectLoader {
     super(MapObjectType.TRIGGER);
   }
 
-  /**
-   * <p>
-   * Registers a custom {@link Trigger} implementation that can be automatically provided by this
-   * {@link MapObjectLoader}.
-   * </p>
-   *
-   * <p>
-   * Whenever a {@link MapObjectType#TRIGGER TRIGGER} map object with a {@link IMapObject#getName() name} equal to the
-   * specified {@code name} is loaded, an instance of the supplied {@code triggerType} is created instead of the default
-   * {@link Trigger}.
-   * </p>
-   *
-   * <p>
-   * Make sure that the implementation has one of the following constructors present:
-   * <ol>
-   * <li>A constructor that matches the {@link Trigger} default constructor signature
-   * ({@link TriggerActivation}, {@link String}, {@code boolean}, {@code int}).</li>
-   * <li>An empty constructor.</li>
-   * </ol>
-   *
-   * @param <T>         The type of the custom trigger implementation.
-   * @param name        The map object name used to identify trigger instances that should be loaded as the specified
-   *                    {@code triggerType}.
-   * @param triggerType The class of the custom {@link Trigger} implementation.
-   */
+  /// Registers a custom [Trigger] implementation that can be automatically provided by this
+  /// [MapObjectLoader].
+  ///
+  /// Whenever a [TRIGGER][MapObjectType#TRIGGER] map object with a [name][IMapObject#getName()] equal to the
+  /// specified `name` is loaded, an instance of the supplied `triggerType` is created instead of the default
+  /// [Trigger].
+  ///
+  /// Make sure that the implementation has one of the following constructors present:
+  ///
+  /// 1. A constructor that matches the [Trigger] default constructor signature
+  /// ([TriggerActivation], [String], `boolean`, `int`).
+  /// 2. An empty constructor.
+  ///
+  /// @param <T>         The type of the custom trigger implementation.
+  /// @param name        The map object name used to identify trigger instances that should be loaded as the specified
+  /// `triggerType`.
+  /// @param triggerType The class of the custom [Trigger] implementation.
   public static <T extends Trigger> void registerCustomTriggerType(String name, Class<T> triggerType) {
     if (name == null || name.isEmpty() || triggerType == null) {
       return;
@@ -57,11 +49,9 @@ public class TriggerMapObjectLoader extends MapObjectLoader {
     customTriggerTypes.put(name.toLowerCase(), triggerType);
   }
 
-  /**
-   * Removes all previously registered custom {@link Trigger} types.
-   *
-   * @see #registerCustomTriggerType(String, Class)
-   */
+  /// Removes all previously registered custom [Trigger] types.
+  ///
+  /// @see #registerCustomTriggerType(String, Class)
   public static void clearCustomTriggerTypes() {
     customTriggerTypes.clear();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/package-info.java
@@ -1,0 +1,6 @@
+/// Loading, owning, and updating maps and their live entity collections.
+///
+/// [de.gurkenlabs.litiengine.environment.GameWorld] manages the active
+/// [de.gurkenlabs.litiengine.environment.Environment]. Map object loaders translate TMX objects
+/// into engine entities as an environment loads.
+package de.gurkenlabs.litiengine.environment;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ICustomProperty.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ICustomProperty.java
@@ -3,188 +3,136 @@ package de.gurkenlabs.litiengine.environment.tilemap;
 import java.awt.Color;
 import java.net.URL;
 
-/**
- * The {@code ICustomProperty} interface defines methods for managing custom properties with various data types. It provides functionality to set and
- * retrieve property values in different formats, as well as methods for type and equality handling.
- */
+/// The `ICustomProperty` interface defines methods for managing custom properties with various data types. It provides functionality to set and
+/// retrieve property values in different formats, as well as methods for type and equality handling.
 public interface ICustomProperty {
 
-  /**
-   * Sets the value of the property as a {@link URL}.
-   *
-   * @param value the {@link URL} value to set
-   */
+  /// Sets the value of the property as a [URL].
+  ///
+  /// @param value the [URL] value to set
   void setValue(URL value);
 
-  /**
-   * Sets the value of the property as a {@link String}.
-   *
-   * @param value the {@link String} value to set
-   */
+  /// Sets the value of the property as a [String].
+  ///
+  /// @param value the [String] value to set
   void setValue(String value);
 
-  /**
-   * Sets the value of the property as a {@code char}.
-   *
-   * @param value the {@code char} value to set
-   */
+  /// Sets the value of the property as a `char`.
+  ///
+  /// @param value the `char` value to set
   void setValue(char value);
 
-  /**
-   * Sets the value of the property as an {@link Enum}.
-   *
-   * @param value the {@link Enum} value to set
-   */
+  /// Sets the value of the property as an [Enum].
+  ///
+  /// @param value the [Enum] value to set
   void setValue(Enum<?> value);
 
-  /**
-   * Sets the value of the property as a {@code long}.
-   *
-   * @param value the {@code long} value to set
-   */
+  /// Sets the value of the property as a `long`.
+  ///
+  /// @param value the `long` value to set
   void setValue(long value);
 
-  /**
-   * Sets the value of the property as a {@code double}.
-   *
-   * @param value the {@code double} value to set
-   */
+  /// Sets the value of the property as a `double`.
+  ///
+  /// @param value the `double` value to set
   void setValue(double value);
 
-  /**
-   * Sets the value of the property as a {@code boolean}.
-   *
-   * @param value the {@code boolean} value to set
-   */
+  /// Sets the value of the property as a `boolean`.
+  ///
+  /// @param value the `boolean` value to set
   void setValue(boolean value);
 
-  /**
-   * Sets the value of the property as a {@link Color}.
-   *
-   * @param value the {@link Color} value to set
-   */
+  /// Sets the value of the property as a [Color].
+  ///
+  /// @param value the [Color] value to set
   void setValue(Color value);
 
-  /**
-   * Retrieves the value of the property as a {@link String}.
-   *
-   * @return the property value as a {@link String}
-   */
+  /// Retrieves the value of the property as a [String].
+  ///
+  /// @return the property value as a [String]
   String getAsString();
 
-  /**
-   * Retrieves the value of the property as a {@code char}.
-   *
-   * @return the property value as a {@code char}
-   */
+  /// Retrieves the value of the property as a `char`.
+  ///
+  /// @return the property value as a `char`
   char getAsChar();
 
-  /**
-   * Retrieves the value of the property as a {@code boolean}.
-   *
-   * @return the property value as a {@code boolean}
-   */
+  /// Retrieves the value of the property as a `boolean`.
+  ///
+  /// @return the property value as a `boolean`
   boolean getAsBool();
 
-  /**
-   * Retrieves the value of the property as a {@link Color}.
-   *
-   * @return the property value as a {@link Color}
-   */
+  /// Retrieves the value of the property as a [Color].
+  ///
+  /// @return the property value as a [Color]
   Color getAsColor();
 
-  /**
-   * Retrieves the value of the property as a {@code float}.
-   *
-   * @return the property value as a {@code float}
-   */
+  /// Retrieves the value of the property as a `float`.
+  ///
+  /// @return the property value as a `float`
   float getAsFloat();
 
-  /**
-   * Retrieves the value of the property as a {@code double}.
-   *
-   * @return the property value as a {@code double}
-   */
+  /// Retrieves the value of the property as a `double`.
+  ///
+  /// @return the property value as a `double`
   double getAsDouble();
 
-  /**
-   * Retrieves the value of the property as a {@code byte}.
-   *
-   * @return the property value as a {@code byte}
-   */
+  /// Retrieves the value of the property as a `byte`.
+  ///
+  /// @return the property value as a `byte`
   byte getAsByte();
 
-  /**
-   * Retrieves the value of the property as a {@code short}.
-   *
-   * @return the property value as a {@code short}
-   */
+  /// Retrieves the value of the property as a `short`.
+  ///
+  /// @return the property value as a `short`
   short getAsShort();
 
-  /**
-   * Retrieves the value of the property as an {@code int}.
-   *
-   * @return the property value as an {@code int}
-   */
+  /// Retrieves the value of the property as an `int`.
+  ///
+  /// @return the property value as an `int`
   int getAsInt();
 
-  /**
-   * Retrieves the value of the property as a {@code long}.
-   *
-   * @return the property value as a {@code long}
-   */
+  /// Retrieves the value of the property as a `long`.
+  ///
+  /// @return the property value as a `long`
   long getAsLong();
 
-  /**
-   * Retrieves the value of the property as an {@link Enum}.
-   *
-   * @param <T>      the type of the {@link Enum}
-   * @param enumType the {@link Class} of the {@link Enum} type
-   * @return the property value as an {@link Enum}
-   */
+  /// Retrieves the value of the property as an [Enum].
+  ///
+  /// @param <T>      the type of the [Enum]
+  /// @param enumType the [Class] of the [Enum] type
+  /// @return the property value as an [Enum]
   <T extends Enum<T>> T getAsEnum(Class<T> enumType);
 
-  /**
-   * Retrieves the value of the property as a {@link URL}.
-   *
-   * @return the property value as a {@link URL}
-   */
+  /// Retrieves the value of the property as a [URL].
+  ///
+  /// @return the property value as a [URL]
   URL getAsFile();
 
-  /**
-   * Retrieves the map object ID associated with this property.
-   *
-   * @return the map object ID
-   */
+  /// Retrieves the map object ID associated with this property.
+  ///
+  /// @return the map object ID
   int getMapObjectId();
 
-  /**
-   * Retrieves the type of the property.
-   *
-   * @return the property type as a {@link String}
-   */
+  /// Retrieves the type of the property.
+  ///
+  /// @return the property type as a [String]
   String getType();
 
-  /**
-   * Sets the type of the property.
-   *
-   * @param type the property type as a {@link String}
-   */
+  /// Sets the type of the property.
+  ///
+  /// @param type the property type as a [String]
   void setType(String type);
 
-  /**
-   * Tests for equality between two custom properties. Two custom properties are <i>equal</i> if they both have the same type and string value.
-   *
-   * @param anObject the custom property to test equality for
-   * @return {@code true} if the two custom properties are equal, or {@code false} otherwise
-   */
+  /// Tests for equality between two custom properties. Two custom properties are *equal* if they both have the same type and string value.
+  ///
+  /// @param anObject the custom property to test equality for
+  /// @return `true` if the two custom properties are equal, or `false` otherwise
   boolean equals(Object anObject);
 
-  /**
-   * Returns the hash code for this custom property. The hash code for a custom property is equal to its type's hash code times 31 plus its value's
-   * hash code.
-   *
-   * @return the hash code for this custom property
-   */
+  /// Returns the hash code for this custom property. The hash code for a custom property is equal to its type's hash code times 31 plus its value's
+  /// hash code.
+  ///
+  /// @return the hash code for this custom property
   int hashCode();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ICustomPropertyProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ICustomPropertyProvider.java
@@ -6,396 +6,306 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-/**
- * The Interface ICustomPropertyProvider is providing methods to get and set custom properties.
- */
+/// The Interface ICustomPropertyProvider is providing methods to get and set custom properties.
 public interface ICustomPropertyProvider {
-  /**
-   * Checks if a custom property with the given name is present.
-   *
-   * @param propertyName the name of the custom property
-   * @return true if a custom property with the given name is present. False otherwise.
-   */
+  /// Checks if a custom property with the given name is present.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return true if a custom property with the given name is present. False otherwise.
   boolean hasCustomProperty(String propertyName);
 
-  /**
-   * Retrieves the custom property with the specified name.
-   *
-   * @param propertyName the name of the custom property to retrieve
-   * @return the custom property associated with the given name, or {@code null} if no such property exists
-   */
+  /// Retrieves the custom property with the specified name.
+  ///
+  /// @param propertyName the name of the custom property to retrieve
+  /// @return the custom property associated with the given name, or `null` if no such property exists
   ICustomProperty getProperty(String propertyName);
 
-  /**
-   * Sets the value for the custom property with the given name.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value to set for the custom property
-   */
+  /// Sets the value for the custom property with the given name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value to set for the custom property
   void setValue(String propertyName, ICustomProperty value);
 
-  /**
-   * Removes the custom property with the given name.
-   *
-   * @param propertyName the name of the custom property to remove
-   */
+  /// Removes the custom property with the given name.
+  ///
+  /// @param propertyName the name of the custom property to remove
   void removeProperty(String propertyName);
 
-  /**
-   * Gets the string value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the string value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   */
+  /// Gets the string value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the string value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
   String getStringValue(String propertyName);
 
-  /**
-   * Gets the string value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the string value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the string value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the string value of the custom property, if present. Otherwise, the provided default value is returned.
   String getStringValue(String propertyName, String defaultValue);
 
-  /**
-   * Gets a list of strings stored in a single comma-separated property.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the list of comma-separated strings in the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets a list of strings stored in a single comma-separated property.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the list of comma-separated strings in the custom property, if present. Otherwise, the provided default value is returned.
   List<String> getCommaSeparatedStringValues(String propertyName, String defaultValue);
 
-  /**
-   * Gets the char value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the char value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not a char or is not in range for a {@code char}
-   */
+  /// Gets the char value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the char value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not a char or is not in range for a `char`
   char getCharValue(String propertyName);
 
-  /**
-   * Gets the char value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the char value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the char value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the char value of the custom property, if present. Otherwise, the provided default value is returned.
   char getCharValue(String propertyName, char defaultValue);
 
-  /**
-   * Gets the int value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the int value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not an integer or is not in range for an {@code int}
-   */
+  /// Gets the int value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the int value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not an integer or is not in range for an `int`
   int getIntValue(String propertyName);
 
-  /**
-   * Gets the int value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the int value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the int value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the int value of the custom property, if present. Otherwise, the provided default value is returned.
   int getIntValue(String propertyName, int defaultValue);
 
-  /**
-   * Gets the long value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the long value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not an integer or is not in range for a {@code long}
-   */
+  /// Gets the long value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the long value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not an integer or is not in range for a `long`
   long getLongValue(String propertyName);
 
-  /**
-   * Gets the long value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the long value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the long value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the long value of the custom property, if present. Otherwise, the provided default value is returned.
   long getLongValue(String propertyName, long defaultValue);
 
-  /**
-   * Gets the short value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the short value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not an integer or is out of range for a {@code short}
-   */
+  /// Gets the short value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the short value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not an integer or is out of range for a `short`
   short getShortValue(String propertyName);
 
-  /**
-   * Gets the short value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the short value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the short value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the short value of the custom property, if present. Otherwise, the provided default value is returned.
   short getShortValue(String propertyName, short defaultValue);
 
-  /**
-   * Gets the byte value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the byte value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not an integer or is out of range for a {@code byte}
-   */
+  /// Gets the byte value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the byte value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not an integer or is out of range for a `byte`
   byte getByteValue(String propertyName);
 
-  /**
-   * Gets the byte value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the byte value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the byte value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the byte value of the custom property, if present. Otherwise, the provided default value is returned.
   byte getByteValue(String propertyName, byte defaultValue);
 
-  /**
-   * Gets the boolean value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the boolean value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not a {@code boolean} value
-   */
+  /// Gets the boolean value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the boolean value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not a `boolean` value
   boolean getBoolValue(String propertyName);
 
-  /**
-   * Gets the boolean value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the boolean value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the boolean value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the boolean value of the custom property, if present. Otherwise, the provided default value is returned.
   boolean getBoolValue(String propertyName, boolean defaultValue);
 
-  /**
-   * Gets the float value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the float value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not a number
-   */
+  /// Gets the float value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the float value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not a number
   float getFloatValue(String propertyName);
 
-  /**
-   * Gets the float value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the float value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the float value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the float value of the custom property, if present. Otherwise, the provided default value is returned.
   float getFloatValue(String propertyName, float defaultValue);
 
-  /**
-   * Gets the double value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the double value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   * @throws NumberFormatException  if the custom property is not a number
-   */
+  /// Gets the double value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the double value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
+  /// @throws NumberFormatException  if the custom property is not a number
   double getDoubleValue(String propertyName);
 
-  /**
-   * Gets the double value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the double value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the double value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the double value of the custom property, if present. Otherwise, the provided default value is returned.
   double getDoubleValue(String propertyName, double defaultValue);
 
-  /**
-   * Gets the color value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @return the color value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   */
+  /// Gets the color value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the color value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
   Color getColorValue(String propertyName);
 
-  /**
-   * Gets the color value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the color value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the color value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the color value of the custom property, if present. Otherwise, the provided default value is returned.
   Color getColorValue(String propertyName, Color defaultValue);
 
-  /**
-   * Gets the enum value of the custom property with the provided name.
-   *
-   * @param propertyName the name of the custom property
-   * @param enumType     a {@code Class} object for {@code <T>}
-   * @param <T>          the enum type to use
-   * @return the enum value of the custom property
-   * @throws NoSuchElementException if the custom property does not exist
-   */
+  /// Gets the enum value of the custom property with the provided name.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param enumType     a `Class` object for `<T>`
+  /// @param <T>          the enum type to use
+  /// @return the enum value of the custom property
+  /// @throws NoSuchElementException if the custom property does not exist
   <T extends Enum<T>> T getEnumValue(String propertyName, Class<T> enumType);
 
-  /**
-   * Gets the enum value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @param enumType     a {@code Class} object for {@code <T>}
-   * @param <T>          the enum type to use
-   * @return the enum value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the enum value of the custom property with the provided name. If the value is null, the provided default value is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @param enumType     a `Class` object for `<T>`
+  /// @param <T>          the enum type to use
+  /// @return the enum value of the custom property, if present. Otherwise, the provided default value is returned.
   <T extends Enum<T>> T getEnumValue(String propertyName, Class<T> enumType, T defaultValue);
 
-  /**
-   * Gets the file value of the custom property with the provided name. If the property is not a file, {@code null} is returned instead.
-   *
-   * @param propertyName the name of the custom property
-   * @return the file value of the custom property, if present.
-   */
+  /// Gets the file value of the custom property with the provided name. If the property is not a file, `null` is returned instead.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @return the file value of the custom property, if present.
   URL getFileValue(String propertyName);
 
-  /**
-   * Gets the file value of the custom property with the provided name. If the value is null or the property is not a file, the provided default value
-   * is used as a fallback.
-   *
-   * @param propertyName the name of the custom property
-   * @param defaultValue the fallback value in case the property value is null.
-   * @return the file value of the custom property, if present. Otherwise, the provided default value is returned.
-   */
+  /// Gets the file value of the custom property with the provided name. If the value is null or the property is not a file, the provided default value
+  /// is used as a fallback.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param defaultValue the fallback value in case the property value is null.
+  /// @return the file value of the custom property, if present. Otherwise, the provided default value is returned.
   URL getFileValue(String propertyName, URL defaultValue);
 
   int getMapObjectId(String propertyName);
 
-  /**
-   * Sets the value for the custom property with the given name to the given file.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given file.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, URL value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given string.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given string.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, String value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given boolean.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given boolean.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, boolean value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given byte.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given byte.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, byte value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given short.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given short.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, short value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given char.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given char.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, char value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given int.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given int.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, int value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given long.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given long.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, long value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given float.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given float.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, float value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given double.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given double.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, double value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given color.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given color.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, Color value);
 
-  /**
-   * Sets the value for the custom property with the given name to the given enum.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the given name to the given enum.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, Enum<?> value);
 
-  /**
-   * Sets the value for the custom property with the ID of the given map object.
-   *
-   * @param propertyName the name of the custom property
-   * @param value        the new value
-   */
+  /// Sets the value for the custom property with the ID of the given map object.
+  ///
+  /// @param propertyName the name of the custom property
+  /// @param value        the new value
   void setValue(String propertyName, IMapObject value);
 
-  /**
-   * Returns a {@code Map} view of the custom properties for this {@code ICustomPropertyProvider}.
-   *
-   * @return a {@code Map} view of the custom properties for this {@code ICustomPropertyProvider}
-   */
+  /// Returns a `Map` view of the custom properties for this `ICustomPropertyProvider`.
+  ///
+  /// @return a `Map` view of the custom properties for this `ICustomPropertyProvider`
   Map<String, ICustomProperty> getProperties();
 
-  /**
-   * Sets all the custom properties on this object to the provided values. Properties are added when they only exist in the provided properties, and
-   * deleted when they only exist in the current properties.
-   *
-   * @param props the new list of properties
-   */
+  /// Sets all the custom properties on this object to the provided values. Properties are added when they only exist in the provided properties, and
+  /// deleted when they only exist in the current properties.
+  ///
+  /// @param props the new list of properties
   void setProperties(Map<String, ICustomProperty> props);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IImageLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IImageLayer.java
@@ -4,32 +4,24 @@ import java.awt.Color;
 
 public interface IImageLayer extends ICustomPropertyProvider, ILayer {
 
-  /**
-   * Gets the image.
-   *
-   * @return the image
-   */
+  /// Gets the image.
+  ///
+  /// @return the image
   IMapImage getImage();
 
-  /**
-   * Gets the transparent color.
-   *
-   * @return the transparent color
-   */
+  /// Gets the transparent color.
+  ///
+  /// @return the transparent color
   Color getTransparentColor();
 
-  /**
-   * Gets a value indicating whether the image should be rendered repeatedly horizontally.
-   *
-   * @return True if the image should be repeated horizontally; Otherwise false.
-   */
+  /// Gets a value indicating whether the image should be rendered repeatedly horizontally.
+  ///
+  /// @return True if the image should be repeated horizontally; Otherwise false.
   boolean repeatHorizontally();
 
 
-  /**
-   * Gets a value indicating whether the image should be rendered repeatedly vertically.
-   *
-   * @return True if the image should be repeated vertically; Otherwise false.
-   */
+  /// Gets a value indicating whether the image should be rendered repeatedly vertically.
+  ///
+  /// @return True if the image should be repeated vertically; Otherwise false.
   boolean repeatVertically();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ILayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ILayer.java
@@ -7,157 +7,113 @@ import java.awt.geom.Point2D;
 
 public interface ILayer extends ICustomPropertyProvider {
 
-  /**
-   * Gets the unique id of the layer.
-   *
-   * @return the layer id
-   */
+  /// Gets the unique id of the layer.
+  ///
+  /// @return the layer id
   int getId();
 
-  /**
-   * Gets the name.
-   *
-   * @return the name
-   */
+  /// Gets the name.
+  ///
+  /// @return the name
   String getName();
 
-  /**
-   * Sets the name of the layer.
-   *
-   * @param name the layer name
-   */
+  /// Sets the name of the layer.
+  ///
+  /// @param name the layer name
   void setName(String name);
 
-  /**
-   * Gets the opacity.
-   *
-   * @return the opacity
-   */
+  /// Gets the opacity.
+  ///
+  /// @return the opacity
   float getOpacity();
 
-  /**
-   * Sets the opacity of the layer in the range {@code [0, 1]}.
-   *
-   * @param opacity the opacity to set
-   */
+  /// Sets the opacity of the layer in the range `[0, 1]`.
+  ///
+  /// @param opacity the opacity to set
   void setOpacity(float opacity);
 
-  /**
-   * Gets both the X and the Y offset of the layer.
-   *
-   * @return a {@link Point2D} representing the offset
-   */
+  /// Gets both the X and the Y offset of the layer.
+  ///
+  /// @return a [Point2D] representing the offset
   Point2D getOffset();
 
-  /**
-   * Gets the horizontal offset of the layer.
-   *
-   * @return the x offset
-   */
+  /// Gets the horizontal offset of the layer.
+  ///
+  /// @return the x offset
   double getOffsetX();
 
-  /**
-   * Gets the vertical offset of the layer.
-   *
-   * @return the y offset
-   */
+  /// Gets the vertical offset of the layer.
+  ///
+  /// @return the y offset
   double getOffsetY();
 
-  /**
-   * Gets the horizontal parallax scrolling factor of the layer. Defaults to 1.0.
-   *
-   * @return The horizontal parallax scrolling factor.
-   */
+  /// Gets the horizontal parallax scrolling factor of the layer. Defaults to 1.0.
+  ///
+  /// @return The horizontal parallax scrolling factor.
   double getHorizontalParallaxFactor();
 
-  /**
-   * Gets the vertical parallax scrolling factor of the layer. Defaults to 1.0.
-   *
-   * @return The vertical parallax scrolling factor.
-   */
+  /// Gets the vertical parallax scrolling factor of the layer. Defaults to 1.0.
+  ///
+  /// @return The vertical parallax scrolling factor.
   double getVerticalParallaxFactor();
 
-  /**
-   * Gets a tint color that affects the way contents of this layer are rendered.
-   *
-   * @return A color that is used to tint the visible contents of this layer.
-   */
+  /// Gets a tint color that affects the way contents of this layer are rendered.
+  ///
+  /// @return A color that is used to tint the visible contents of this layer.
   Color getTintColor();
 
-  /**
-   * Sets the tint color of this layer.
-   *
-   * @param tintcolor The tint color of this layer.
-   */
+  /// Sets the tint color of this layer.
+  ///
+  /// @param tintcolor The tint color of this layer.
   void setTintColor(Color tintcolor);
 
-  /**
-   * Gets the size in tiles.
-   *
-   * @return the size in tiles
-   */
+  /// Gets the size in tiles.
+  ///
+  /// @return the size in tiles
   Dimension getSizeInTiles();
 
-  /**
-   * Gets the map that owns this layer.
-   *
-   * @return the owning map
-   */
+  /// Gets the map that owns this layer.
+  ///
+  /// @return the owning map
   IMap getMap();
 
-  /**
-   * Checks if is visible.
-   *
-   * @return true, if is visible
-   */
+  /// Checks if is visible.
+  ///
+  /// @return true, if is visible
   boolean isVisible();
 
-  /**
-   * Sets whether the layer is visible.
-   *
-   * @param visible {@code true} to make the layer visible
-   */
+  /// Sets whether the layer is visible.
+  ///
+  /// @param visible `true` to make the layer visible
   void setVisible(boolean visible);
 
-  /**
-   * Gets the render type used when drawing this layer.
-   *
-   * @return the render type
-   */
+  /// Gets the render type used when drawing this layer.
+  ///
+  /// @return the render type
   RenderType getRenderType();
 
-  /**
-   * Sets the render type used when drawing this layer.
-   *
-   * @param renderType the render type
-   */
+  /// Sets the render type used when drawing this layer.
+  ///
+  /// @param renderType the render type
   void setRenderType(RenderType renderType);
 
-  /**
-   * Gets the width of the layer, in tiles.
-   *
-   * @return the width in tiles
-   */
+  /// Gets the width of the layer, in tiles.
+  ///
+  /// @return the width in tiles
   int getWidth();
 
-  /**
-   * Sets the width of the layer, in tiles.
-   *
-   * @param newWidth the new width in tiles
-   */
+  /// Sets the width of the layer, in tiles.
+  ///
+  /// @param newWidth the new width in tiles
   void setWidth(int newWidth);
 
-  /**
-   * Gets the height of the layer, in tiles.
-   *
-   * @return the height in tiles
-   */
+  /// Gets the height of the layer, in tiles.
+  ///
+  /// @return the height in tiles
   int getHeight();
 
-  /**
-   * Sets the height of the layer, in tiles.
-   *
-   * @param newWidth the new height in tiles
-   */
+  /// Sets the height of the layer, in tiles.
+  ///
+  /// @param newWidth the new height in tiles
   void setHeight(int newWidth);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ILayerList.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ILayerList.java
@@ -10,53 +10,41 @@ import de.gurkenlabs.litiengine.environment.Environment;
 
 public interface ILayerList extends ICustomPropertyProvider {
 
-  /**
-   * Gets all render layers in the Layer list.
-   *
-   * @return a List of ILayers
-   */
+  /// Gets all render layers in the Layer list.
+  ///
+  /// @return a List of ILayers
   List<ILayer> getRenderLayers();
 
-  /**
-   * Gets all MapObjectLayers in the Layer list.
-   *
-   * @return a List of IMapObjectLayers
-   */
+  /// Gets all MapObjectLayers in the Layer list.
+  ///
+  /// @return a List of IMapObjectLayers
   List<IMapObjectLayer> getMapObjectLayers();
 
-  /**
-   * Adds an {@code ILayer} to the Layer list.
-   *
-   * @param layer
-   *          the layer to be added
-   */
+  /// Adds an `ILayer` to the Layer list.
+  ///
+  /// @param layer
+  /// the layer to be added
   void addLayer(ILayer layer);
 
-  /**
-   * Adds an {@code ILayer} to the Layer list at the given index.
-   *
-   * @param index
-   *          the index
-   * @param layer
-   *          the layer to be added
-   */
+  /// Adds an `ILayer` to the Layer list at the given index.
+  ///
+  /// @param index
+  /// the index
+  /// @param layer
+  /// the layer to be added
   void addLayer(int index, ILayer layer);
 
-  /**
-   * Removes an {@code ILayer} from the Layer list.
-   *
-   * @param layer
-   *          the layer to be removed
-   */
+  /// Removes an `ILayer` from the Layer list.
+  ///
+  /// @param layer
+  /// the layer to be removed
   void removeLayer(ILayer layer);
 
-  /**
-   * Gets the {@code IMapObjectLayer} containing a given {@code IMapObject}.
-   *
-   * @param mapObject
-   *          the map object being searched
-   * @return the map object layer containing the map object
-   */
+  /// Gets the `IMapObjectLayer` containing a given `IMapObject`.
+  ///
+  /// @param mapObject
+  /// the map object being searched
+  /// @return the map object layer containing the map object
   default IMapObjectLayer getMapObjectLayer(IMapObject mapObject) {
     for (IMapObjectLayer layer : this.getMapObjectLayers()) {
       Optional<IMapObject> found = layer.getMapObjects().stream().filter(x -> x.getId() == mapObject.getId()).findFirst();
@@ -78,19 +66,15 @@ public interface ILayerList extends ICustomPropertyProvider {
     return layer.orElse(null);
   }
 
-  /**
-   * Removes a layer from the Layer list.
-   *
-   * @param index
-   *          the index of the layer to be removed
-   */
+  /// Removes a layer from the Layer list.
+  ///
+  /// @param index
+  /// the index of the layer to be removed
   void removeLayer(int index);
 
-  /**
-   * Gets all map objects in the layer list.
-   *
-   * @return a Collection of all IMapObjects in the layer list
-   */
+  /// Gets all map objects in the layer list.
+  ///
+  /// @return a Collection of all IMapObjects in the layer list
   default Collection<IMapObject> getMapObjects() {
     List<IMapObject> mapObjects = new ArrayList<>();
     if (this.getMapObjectLayers() == null) {
@@ -112,13 +96,11 @@ public interface ILayerList extends ICustomPropertyProvider {
     return Collections.unmodifiableCollection(mapObjects);
   }
 
-  /**
-   * Gets all map objects in the layer list that belong to the types passed as a parameter.
-   *
-   * @param types
-   *          an array of types for which the layer list is searched
-   * @return a Collection of IMapObjects matching the given MapObjectTypes
-   */
+  /// Gets all map objects in the layer list that belong to the types passed as a parameter.
+  ///
+  /// @param types
+  /// an array of types for which the layer list is searched
+  /// @return a Collection of IMapObjects matching the given MapObjectTypes
   default Collection<IMapObject> getMapObjects(String... types) {
     List<IMapObject> mapObjects = new ArrayList<>();
     if (this.getMapObjectLayers() == null || this.getMapObjectLayers().isEmpty() || types.length == 0) {
@@ -136,18 +118,15 @@ public interface ILayerList extends ICustomPropertyProvider {
     return mapObjects;
   }
 
-  /**
-   * Gets all map objects in the layer list using the map IDs passed as a parameter. Please note that map IDs are intended
-   * to be unique identifiers for {@code IMapObject}s (and their corresponding {@code Entity}). This method is just a way
-   * of checking for non-unique IDs and re-assigning them before adding entities.
-   *
-   * @param mapIDs
-   *          an array of mapIDs for which the layer list is searched
-   *
-   * @return a Collection of IMapObjects matching the given MapObject IDs
-   * @see Environment#add
-   *
-   */
+  /// Gets all map objects in the layer list using the map IDs passed as a parameter. Please note that map IDs are intended
+  /// to be unique identifiers for `IMapObject`s (and their corresponding `Entity`). This method is just a way
+  /// of checking for non-unique IDs and re-assigning them before adding entities.
+  ///
+  /// @param mapIDs
+  /// an array of mapIDs for which the layer list is searched
+  ///
+  /// @return a Collection of IMapObjects matching the given MapObject IDs
+  /// @see Environment#add
   default Collection<IMapObject> getMapObjects(int... mapIDs) {
     List<IMapObject> mapObjects = new ArrayList<>();
     if (this.getMapObjectLayers() == null || this.getMapObjectLayers().isEmpty() || mapIDs.length == 0) {
@@ -165,13 +144,11 @@ public interface ILayerList extends ICustomPropertyProvider {
     return mapObjects;
   }
 
-  /**
-   * Gets the first {@code IMapObject} with the given ID from a layer list.
-   *
-   * @param mapId
-   *          the map id of the desired {@code IMapObject}
-   * @return the {@code IMapObject} with the given ID
-   */
+  /// Gets the first `IMapObject` with the given ID from a layer list.
+  ///
+  /// @param mapId
+  /// the map id of the desired `IMapObject`
+  /// @return the `IMapObject` with the given ID
   default IMapObject getMapObject(int mapId) {
     if (this.getMapObjectLayers() == null) {
       return null;
@@ -192,12 +169,10 @@ public interface ILayerList extends ICustomPropertyProvider {
     return null;
   }
 
-  /**
-   * Removes the first {@code IMapObject} with the given ID.
-   *
-   * @param mapId
-   *          the map id of the {@code IMapObject} we want to remove
-   */
+  /// Removes the first `IMapObject` with the given ID.
+  ///
+  /// @param mapId
+  /// the map id of the `IMapObject` we want to remove
   default void removeMapObject(int mapId) {
     for (IMapObjectLayer layer : this.getMapObjectLayers()) {
       IMapObject remove = null;
@@ -215,25 +190,19 @@ public interface ILayerList extends ICustomPropertyProvider {
     }
   }
 
-  /**
-   * Gets the {@code ITileLayer}s contained in a Layer list.
-   *
-   * @return a {@code List} of all {@code ITileLayer}s
-   */
+  /// Gets the `ITileLayer`s contained in a Layer list.
+  ///
+  /// @return a `List` of all `ITileLayer`s
   List<ITileLayer> getTileLayers();
 
-  /**
-   * Gets the {@code IImageLayer}s contained in a Layer list.
-   *
-   * @return a {@code List} of all {@code IImageLayer}s
-   */
+  /// Gets the `IImageLayer`s contained in a Layer list.
+  ///
+  /// @return a `List` of all `IImageLayer`s
   List<IImageLayer> getImageLayers();
 
-  /**
-   * Gets the {@code IGroupLayer}s contained in a Layer list.
-   *
-   * @return a {@code List} of all {@code IGroupLayer}s
-   */
+  /// Gets the `IGroupLayer`s contained in a Layer list.
+  ///
+  /// @return a `List` of all `IGroupLayer`s
   List<IGroupLayer> getGroupLayers();
 
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
@@ -10,180 +10,130 @@ import java.util.List;
 
 public interface IMap extends ILayerList, Comparable<IMap> {
 
-  /**
-   * Gets the tilesets.
-   *
-   * @return the tilesets
-   */
+  /// Gets the tilesets.
+  ///
+  /// @return the tilesets
   List<ITileset> getTilesets();
 
-  /**
-   * Gets the tileset entry referenced by the supplied global tile id.
-   *
-   * @param gid the global tile id
-   * @return the matching tileset entry, or {@code null} if no tileset contains the id
-   */
+  /// Gets the tileset entry referenced by the supplied global tile id.
+  ///
+  /// @param gid the global tile id
+  /// @return the matching tileset entry, or `null` if no tileset contains the id
   ITilesetEntry getTilesetEntry(int gid);
 
-  /**
-   * Gets the orientation.
-   *
-   * @return the orientation
-   */
+  /// Gets the orientation.
+  ///
+  /// @return the orientation
   IMapOrientation getOrientation();
 
-  /**
-   * Gets the source URL the map was loaded from.
-   *
-   * @return the source URL
-   */
+  /// Gets the source URL the map was loaded from.
+  ///
+  /// @return the source URL
   URL getPath();
 
-  /**
-   * Gets the renderorder.
-   *
-   * @return the renderorder
-   */
+  /// Gets the renderorder.
+  ///
+  /// @return the renderorder
   RenderOrder getRenderOrder();
 
-  /**
-   * Gets the size in pixels.
-   *
-   * @return the size in pixels
-   */
+  /// Gets the size in pixels.
+  ///
+  /// @return the size in pixels
   Dimension getSizeInPixels();
 
-  /**
-   * Gets the map width in tiles.
-   *
-   * @return the width in tiles
-   */
+  /// Gets the map width in tiles.
+  ///
+  /// @return the width in tiles
   int getWidth();
 
-  /**
-   * Gets the map height in tiles.
-   *
-   * @return the height in tiles
-   */
+  /// Gets the map height in tiles.
+  ///
+  /// @return the height in tiles
   int getHeight();
 
-  /**
-   * Gets the sizein tiles.
-   *
-   * @return the sizein tiles
-   */
+  /// Gets the sizein tiles.
+  ///
+  /// @return the sizein tiles
   Dimension getSizeInTiles();
 
-  /**
-   * Gets the bounding rectangle of the map in pixels.
-   *
-   * @return the bounding rectangle
-   */
+  /// Gets the bounding rectangle of the map in pixels.
+  ///
+  /// @return the bounding rectangle
   Rectangle2D getBounds();
 
-  /**
-   * Gets the tile size.
-   *
-   * @return the tile size
-   */
+  /// Gets the tile size.
+  ///
+  /// @return the tile size
   Dimension getTileSize();
 
-  /**
-   * Gets the coordinates of the parallax origin in pixels.
-   *
-   * @return The parallax origin.
-   */
+  /// Gets the coordinates of the parallax origin in pixels.
+  ///
+  /// @return The parallax origin.
   Point2D getParallaxOrigin();
 
-  /**
-   * Gets the horizontal tile size.
-   *
-   * @return the horizontal tile size
-   */
+  /// Gets the horizontal tile size.
+  ///
+  /// @return the horizontal tile size
   int getTileWidth();
 
-  /**
-   * Gets the vertical tile size.
-   *
-   * @return the vertical tile size
-   */
+  /// Gets the vertical tile size.
+  ///
+  /// @return the vertical tile size
   int getTileHeight();
 
-  /**
-   * Gets the straight edges' length for hexagonal maps.
-   *
-   * @return the hex side length
-   */
+  /// Gets the straight edges' length for hexagonal maps.
+  ///
+  /// @return the hex side length
   int getHexSideLength();
 
-  /**
-   * Gets the staggering axis
-   *
-   * @return the tile size
-   */
+  /// Gets the staggering axis
+  ///
+  /// @return the tile size
   StaggerAxis getStaggerAxis();
 
-  /**
-   * Gets the tile size.
-   *
-   * @return the tile size
-   */
+  /// Gets the tile size.
+  ///
+  /// @return the tile size
   StaggerIndex getStaggerIndex();
 
-  /**
-   * Gets the version.
-   *
-   * @return the version
-   */
+  /// Gets the version.
+  ///
+  /// @return the version
   double getVersion();
 
-  /**
-   * Gets the Tiled editor version string the map was saved with.
-   *
-   * @return the Tiled version string
-   */
+  /// Gets the Tiled editor version string the map was saved with.
+  ///
+  /// @return the Tiled version string
   String getTiledVersion();
 
-  /**
-   * Gets the display name of this map.
-   *
-   * @return the map name
-   */
+  /// Gets the display name of this map.
+  ///
+  /// @return the map name
   String getName();
 
-  /**
-   * Sets the name.
-   *
-   * @param name the new name
-   */
+  /// Sets the name.
+  ///
+  /// @param name the new name
   void setName(String name);
 
-  /**
-   * Gets the next available object id, used to assign unique ids to newly created map objects.
-   *
-   * @return the next object id
-   */
+  /// Gets the next available object id, used to assign unique ids to newly created map objects.
+  ///
+  /// @return the next object id
   int getNextObjectId();
 
-  /**
-   * Gets the next available layer id, used to assign unique ids to newly created layers.
-   *
-   * @return the next layer id
-   */
+  /// Gets the next available layer id, used to assign unique ids to newly created layers.
+  ///
+  /// @return the next layer id
   int getNextLayerId();
 
-  /**
-   * Gets the background color of the map.
-   *
-   * @return the background color
-   */
+  /// Gets the background color of the map.
+  ///
+  /// @return the background color
   Color getBackgroundColor();
 
-  /**
-   * Returns whether this is an infinite map (i.e. composed of chunks rather than a fixed-size grid).
-   *
-   * @return {@code true} if the map is infinite
-   */
+  /// Returns whether this is an infinite map (i.e. composed of chunks rather than a fixed-size grid).
+  ///
+  /// @return `true` if the map is infinite
   boolean isInfinite();
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMap.java
@@ -8,6 +8,14 @@ import java.awt.geom.Rectangle2D;
 import java.net.URL;
 import java.util.List;
 
+/// Engine-facing representation of a tile map and its layer hierarchy.
+///
+/// Dimensions returned by [#getWidth()] and [#getHeight()] are measured in tiles; use
+/// [#getSizeInPixels()] or [#getBounds()] for map-coordinate dimensions. Maps loaded from TMX are
+/// represented by [de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap].
+///
+/// @see de.gurkenlabs.litiengine.resources.Maps
+/// @see de.gurkenlabs.litiengine.environment.tilemap.xml.TmxMap
 public interface IMap extends ILayerList, Comparable<IMap> {
 
   /// Gets the tilesets.
@@ -31,9 +39,9 @@ public interface IMap extends ILayerList, Comparable<IMap> {
   /// @return the source URL
   URL getPath();
 
-  /// Gets the renderorder.
+  /// Gets the order in which orthogonal tile coordinates are rendered.
   ///
-  /// @return the renderorder
+  /// @return the render order declared by the map
   RenderOrder getRenderOrder();
 
   /// Gets the size in pixels.
@@ -51,9 +59,9 @@ public interface IMap extends ILayerList, Comparable<IMap> {
   /// @return the height in tiles
   int getHeight();
 
-  /// Gets the sizein tiles.
+  /// Gets the width and height in tiles.
   ///
-  /// @return the sizein tiles
+  /// @return the map size in tiles
   Dimension getSizeInTiles();
 
   /// Gets the bounding rectangle of the map in pixels.
@@ -86,14 +94,14 @@ public interface IMap extends ILayerList, Comparable<IMap> {
   /// @return the hex side length
   int getHexSideLength();
 
-  /// Gets the staggering axis
+  /// Gets the axis along which hexagonal or staggered rows are offset.
   ///
-  /// @return the tile size
+  /// @return the staggering axis
   StaggerAxis getStaggerAxis();
 
-  /// Gets the tile size.
+  /// Gets whether even or odd indexes are staggered.
   ///
-  /// @return the tile size
+  /// @return the staggering index
   StaggerIndex getStaggerIndex();
 
   /// Gets the version.

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapImage.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapImage.java
@@ -8,48 +8,36 @@ public interface IMapImage extends ICustomPropertyProvider {
 
   URL getAbsoluteSourcePath(); // XXX merge with getSource
 
-  /**
-   * Gets the width.
-   *
-   * @return the width
-   */
+  /// Gets the width.
+  ///
+  /// @return the width
   int getWidth();
 
-  /**
-   * Gets the height.
-   *
-   * @return the height
-   */
+  /// Gets the height.
+  ///
+  /// @return the height
   int getHeight();
 
-  /**
-   * Gets the dimension.
-   *
-   * @return the dimension
-   */
+  /// Gets the dimension.
+  ///
+  /// @return the dimension
   Dimension getDimension();
 
-  /**
-   * Gets the source.
-   *
-   * @return the source
-   */
+  /// Gets the source.
+  ///
+  /// @return the source
   String getSource();
 
-  /**
-   * Gets the transparent color.
-   *
-   * @return the transparent color
-   */
+  /// Gets the transparent color.
+  ///
+  /// @return the transparent color
   Color getTransparentColor();
 
-  /**
-   * Tests for equality between two map images. Two map images are <i>equal</i> if they have the same absolute source path and the same transparent
-   * color.
-   *
-   * @param anObject The map image to test for equality with
-   * @return Whether this map image is equal to the provided map image, or {@code false} if {@code anObject} is not a map image
-   */
+  /// Tests for equality between two map images. Two map images are *equal* if they have the same absolute source path and the same transparent
+  /// color.
+  ///
+  /// @param anObject The map image to test for equality with
+  /// @return Whether this map image is equal to the provided map image, or `false` if `anObject` is not a map image
   boolean equals(Object anObject);
 
   void setTransparentColor(Color color);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapObject.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapObject.java
@@ -5,220 +5,158 @@ import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-/**
- * This interface represents an instance on a map that can define various things for an engine. e.g. it can be used to
- * define static collision boxes or other special regions on the map.
- */
+/// This interface represents an instance on a map that can define various things for an engine. e.g. it can be used to
+/// define static collision boxes or other special regions on the map.
 public interface IMapObject extends ICustomPropertyProvider, Resource {
 
-  /**
-   * Gets the grid id.
-   *
-   * @return the grid id
-   */
+  /// Gets the grid id.
+  ///
+  /// @return the grid id
   public int getGridId();
 
-  /**
-   * Gets the tileset entry referenced by this map object's {@linkplain #getGridId() grid id}, if any.
-   *
-   * @return the referenced tileset entry, or {@code null} if this object does not reference a tile
-   */
+  /// Gets the tileset entry referenced by this map object's [grid id][#getGridId()], if any.
+  ///
+  /// @return the referenced tileset entry, or `null` if this object does not reference a tile
   public ITilesetEntry getTile();
 
-  /**
-   * Gets the hit box.
-   *
-   * @return the hit box
-   */
+  /// Gets the hit box.
+  ///
+  /// @return the hit box
   public Rectangle2D getBoundingBox();
 
-  /**
-   * Gets the id.
-   *
-   * @return the id
-   */
+  /// Gets the id.
+  ///
+  /// @return the id
   public int getId();
 
-  /**
-   * Gets the location.
-   *
-   * @return the location
-   */
+  /// Gets the location.
+  ///
+  /// @return the location
   public Point2D getLocation();
 
-  /**
-   * Gets the user-defined type string of this map object.
-   *
-   * @return the type string
-   */
+  /// Gets the user-defined type string of this map object.
+  ///
+  /// @return the type string
   public String getType();
 
-  /**
-   * Gets the polyline shape of this map object, if any.
-   *
-   * @return the polyline, or {@code null} if this object is not a polyline
-   */
+  /// Gets the polyline shape of this map object, if any.
+  ///
+  /// @return the polyline, or `null` if this object is not a polyline
   public IPolyShape getPolyline();
 
-  /**
-   * Gets the polygon shape of this map object, if any.
-   *
-   * @return the polygon, or {@code null} if this object is not a polygon
-   */
+  /// Gets the polygon shape of this map object, if any.
+  ///
+  /// @return the polygon, or `null` if this object is not a polygon
   public IPolyShape getPolygon();
 
-  /**
-   * Gets the ellipse shape of this map object, if any.
-   *
-   * @return the ellipse, or {@code null} if this object is not an ellipse
-   */
+  /// Gets the ellipse shape of this map object, if any.
+  ///
+  /// @return the ellipse, or `null` if this object is not an ellipse
   public Ellipse2D getEllipse();
 
-  /**
-   * Gets the text content of this map object, if it represents a text object.
-   *
-   * @return the text content, or {@code null} if this is not a text object
-   */
+  /// Gets the text content of this map object, if it represents a text object.
+  ///
+  /// @return the text content, or `null` if this is not a text object
   public IMapObjectText getText();
 
-  /**
-   * Gets the layer that contains this map object.
-   *
-   * @return the owning layer
-   */
+  /// Gets the layer that contains this map object.
+  ///
+  /// @return the owning layer
   public IMapObjectLayer getLayer();
 
-  /**
-   * Sets the grid id, i.e. the global tile id this object references.
-   *
-   * @param gid the grid id to set
-   */
+  /// Sets the grid id, i.e. the global tile id this object references.
+  ///
+  /// @param gid the grid id to set
   public void setGridId(int gid);
 
-  /**
-   * Sets the unique id of this map object.
-   *
-   * @param id the id to set
-   */
+  /// Sets the unique id of this map object.
+  ///
+  /// @param id the id to set
   public void setId(int id);
 
-  /**
-   * Sets the user-defined type string of this map object.
-   *
-   * @param type the type to set
-   */
+  /// Sets the user-defined type string of this map object.
+  ///
+  /// @param type the type to set
   public void setType(String type);
 
-  /**
-   * Sets the x coordinate of this map object.
-   *
-   * @param x the x coordinate
-   */
+  /// Sets the x coordinate of this map object.
+  ///
+  /// @param x the x coordinate
   public void setX(float x);
 
-  /**
-   * Sets the y coordinate of this map object.
-   *
-   * @param y the y coordinate
-   */
+  /// Sets the y coordinate of this map object.
+  ///
+  /// @param y the y coordinate
   public void setY(float y);
 
-  /**
-   * Sets the location of this map object.
-   *
-   * @param location the new location
-   */
+  /// Sets the location of this map object.
+  ///
+  /// @param location the new location
   public void setLocation(Point2D location);
 
-  /**
-   * Sets the location of this map object.
-   *
-   * @param x the x coordinate
-   * @param y the y coordinate
-   */
+  /// Sets the location of this map object.
+  ///
+  /// @param x the x coordinate
+  /// @param y the y coordinate
   public void setLocation(float x, float y);
 
-  /**
-   * Sets the width of this map object.
-   *
-   * @param width the width to set
-   */
+  /// Sets the width of this map object.
+  ///
+  /// @param width the width to set
   public void setWidth(float width);
 
-  /**
-   * Sets the height of this map object.
-   *
-   * @param height the height to set
-   */
+  /// Sets the height of this map object.
+  ///
+  /// @param height the height to set
   public void setHeight(float height);
 
-  /**
-   * Gets the x coordinate of this map object.
-   *
-   * @return the x coordinate
-   */
+  /// Gets the x coordinate of this map object.
+  ///
+  /// @return the x coordinate
   public float getX();
 
-  /**
-   * Gets the y coordinate of this map object.
-   *
-   * @return the y coordinate
-   */
+  /// Gets the y coordinate of this map object.
+  ///
+  /// @return the y coordinate
   public float getY();
 
-  /**
-   * Gets the width of this map object.
-   *
-   * @return the width
-   */
+  /// Gets the width of this map object.
+  ///
+  /// @return the width
   public float getWidth();
 
-  /**
-   * Gets the height of this map object.
-   *
-   * @return the height
-   */
+  /// Gets the height of this map object.
+  ///
+  /// @return the height
   public float getHeight();
 
-  /**
-   * Returns whether this map object is a polyline.
-   *
-   * @return {@code true} if this object is a polyline
-   */
+  /// Returns whether this map object is a polyline.
+  ///
+  /// @return `true` if this object is a polyline
   public boolean isPolyline();
 
-  /**
-   * Returns whether this map object is a polygon.
-   *
-   * @return {@code true} if this object is a polygon
-   */
+  /// Returns whether this map object is a polygon.
+  ///
+  /// @return `true` if this object is a polygon
   public boolean isPolygon();
 
-  /**
-   * Returns whether this map object is a single point.
-   *
-   * @return {@code true} if this object is a point
-   */
+  /// Returns whether this map object is a single point.
+  ///
+  /// @return `true` if this object is a point
   public boolean isPoint();
 
-  /**
-   * Returns whether this map object is an ellipse.
-   *
-   * @return {@code true} if this object is an ellipse
-   */
+  /// Returns whether this map object is an ellipse.
+  ///
+  /// @return `true` if this object is an ellipse
   public boolean isEllipse();
 
-  /**
-   * Sets the polyline shape of this map object.
-   *
-   * @param polyline the polyline shape to set
-   */
+  /// Sets the polyline shape of this map object.
+  ///
+  /// @param polyline the polyline shape to set
   public void setPolyline(IPolyShape polyline);
 
-  /**
-   * Sets the polygon shape of this map object.
-   *
-   * @param polygon the polygon shape to set
-   */
+  /// Sets the polygon shape of this map object.
+  ///
+  /// @param polygon the polygon shape to set
   public void setPolygon(IPolyShape polygon);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapObjectLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapObjectLayer.java
@@ -6,11 +6,9 @@ import java.util.List;
 
 public interface IMapObjectLayer extends ILayer {
 
-  /**
-   * Gets the shapes.
-   *
-   * @return the shapes
-   */
+  /// Gets the shapes.
+  ///
+  /// @return the shapes
   List<IMapObject> getMapObjects();
 
   void addMapObject(IMapObject mapObject);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapObjectText.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapObjectText.java
@@ -5,84 +5,60 @@ import de.gurkenlabs.litiengine.Valign;
 import java.awt.Color;
 import java.awt.Font;
 
-/**
- * Represents the text content and rendering attributes of a Tiled text map object.
- */
+/// Represents the text content and rendering attributes of a Tiled text map object.
 public interface IMapObjectText {
-  /**
-   * Gets the text string.
-   *
-   * @return the text
-   */
+  /// Gets the text string.
+  ///
+  /// @return the text
   String getText();
 
-  /**
-   * Gets the font used to render the text.
-   *
-   * @return the font
-   */
+  /// Gets the font used to render the text.
+  ///
+  /// @return the font
   Font getFont();
 
-  /**
-   * Returns whether the text wraps within the bounds of its map object.
-   *
-   * @return {@code true} if word wrapping is enabled
-   */
+  /// Returns whether the text wraps within the bounds of its map object.
+  ///
+  /// @return `true` if word wrapping is enabled
   boolean wrap();
 
-  /**
-   * Gets the text color.
-   *
-   * @return the color
-   */
+  /// Gets the text color.
+  ///
+  /// @return the color
   Color getColor();
 
-  /**
-   * Gets the horizontal alignment of the text.
-   *
-   * @return the horizontal alignment
-   */
+  /// Gets the horizontal alignment of the text.
+  ///
+  /// @return the horizontal alignment
   Align getAlign();
 
-  /**
-   * Gets the vertical alignment of the text.
-   *
-   * @return the vertical alignment
-   */
+  /// Gets the vertical alignment of the text.
+  ///
+  /// @return the vertical alignment
   Valign getValign();
 
-  /**
-   * Returns whether the text is rendered bold.
-   *
-   * @return {@code true} if bold
-   */
+  /// Returns whether the text is rendered bold.
+  ///
+  /// @return `true` if bold
   boolean isBold();
 
-  /**
-   * Returns whether the text is rendered italic.
-   *
-   * @return {@code true} if italic
-   */
+  /// Returns whether the text is rendered italic.
+  ///
+  /// @return `true` if italic
   boolean isItalic();
 
-  /**
-   * Returns whether the text is rendered with an underline.
-   *
-   * @return {@code true} if underlined
-   */
+  /// Returns whether the text is rendered with an underline.
+  ///
+  /// @return `true` if underlined
   boolean isUnderlined();
 
-  /**
-   * Returns whether the text is rendered with strike-through.
-   *
-   * @return {@code true} if strike-through is applied
-   */
+  /// Returns whether the text is rendered with strike-through.
+  ///
+  /// @return `true` if strike-through is applied
   boolean isStrikeout();
 
-  /**
-   * Returns whether the text is rendered with kerning enabled.
-   *
-   * @return {@code true} if kerning is applied
-   */
+  /// Returns whether the text is rendered with kerning enabled.
+  ///
+  /// @return `true` if kerning is applied
   boolean useKerning();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapOrientation.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IMapOrientation.java
@@ -7,184 +7,156 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
 public interface IMapOrientation {
-  /**
-   * Gets the name of this {@code IMapOrientation}.
-   * 
-   * @return The name of this orientation
-   */
+  /// Gets the name of this `IMapOrientation`.
+  ///
+  /// @return The name of this orientation
   public String getName();
 
-  /**
-   * Determines the size required for all tiles within the given map to be drawn into an image. Tiles larger than the
-   * map's tile size may not fit within this size.
-   *
-   * @param map
-   *          The {@code IMap} to measure
-   * @return The required image size
-   */
+  /// Determines the size required for all tiles within the given map to be drawn into an image. Tiles larger than the
+  /// map's tile size may not fit within this size.
+  ///
+  /// @param map
+  /// The `IMap` to measure
+  /// @return The required image size
   public Dimension getSize(IMap map);
 
-  /**
-   * Determines the rendered location of a tile within the given {@code IMap}, given the saved coordinates of the tile.
-   * The coordinates of the point returned are those of the bottom-left corner of the tile's image relative to the
-   * top-left corner of the rectangle in which tiles in the given map are drawn. The point returned by this method will
-   * not necessarily be contained inside the shape returned by {@code getShape}.
-   *
-   * @param x
-   *          The saved X coordinate of the tile
-   * @param y
-   *          The saved Y coordinate of the tile
-   * @param map
-   *          The {@code IMap} that the tile is in
-   * @return The location of a tile for the given map and coordinates
-   */
+  /// Determines the rendered location of a tile within the given `IMap`, given the saved coordinates of the tile.
+  /// The coordinates of the point returned are those of the bottom-left corner of the tile's image relative to the
+  /// top-left corner of the rectangle in which tiles in the given map are drawn. The point returned by this method will
+  /// not necessarily be contained inside the shape returned by `getShape`.
+  ///
+  /// @param x
+  /// The saved X coordinate of the tile
+  /// @param y
+  /// The saved Y coordinate of the tile
+  /// @param map
+  /// The `IMap` that the tile is in
+  /// @return The location of a tile for the given map and coordinates
   public Point getLocation(int x, int y, IMap map);
 
-  /**
-   * Determines the rendered location of a tile within the given {@code IMap}, given the saved coordinates of the tile.
-   * The coordinates of the point returned are those of the bottom-left corner of the tile's image relative to the
-   * top-left corner of the rectangle in which tiles in the given map are drawn. The point returned by this method will
-   * not necessarily be contained inside the shape returned by {@code getShape}.
-   *
-   * @param tile
-   *          The saved location of the tile
-   * @param map
-   *          The {@code IMap} that the tile is in
-   * @return The location of a tile for the given map and coordinates
-   */
+  /// Determines the rendered location of a tile within the given `IMap`, given the saved coordinates of the tile.
+  /// The coordinates of the point returned are those of the bottom-left corner of the tile's image relative to the
+  /// top-left corner of the rectangle in which tiles in the given map are drawn. The point returned by this method will
+  /// not necessarily be contained inside the shape returned by `getShape`.
+  ///
+  /// @param tile
+  /// The saved location of the tile
+  /// @param map
+  /// The `IMap` that the tile is in
+  /// @return The location of a tile for the given map and coordinates
   public Point getLocation(Point tile, IMap map);
 
-  /**
-   * Creates a {@code Shape} for the tile at the given coordinates. The shapes returned by this method should reflect the
-   * intended shape of a tile in this orientation, and in general should not overlap.
-   *
-   * @param x
-   *          The X coordinate of the tile
-   * @param y
-   *          The Y coordinate of the tile
-   * @param map
-   *          The {@code IMap} that the tile is in
-   * @return The shape of the tile
-   */
+  /// Creates a `Shape` for the tile at the given coordinates. The shapes returned by this method should reflect the
+  /// intended shape of a tile in this orientation, and in general should not overlap.
+  ///
+  /// @param x
+  /// The X coordinate of the tile
+  /// @param y
+  /// The Y coordinate of the tile
+  /// @param map
+  /// The `IMap` that the tile is in
+  /// @return The shape of the tile
   public Shape getShape(int x, int y, IMap map);
 
-  /**
-   * Creates a {@code Shape} for the tile at the given coordinates. The shapes returned by this method should reflect the
-   * intended shape of a tile in this orientation, and in general should not overlap.
-   *
-   * @param tile
-   *          The location of the tile
-   * @param map
-   *          The {@code IMap} that the tile is in
-   * @return The shape of the tile
-   */
+  /// Creates a `Shape` for the tile at the given coordinates. The shapes returned by this method should reflect the
+  /// intended shape of a tile in this orientation, and in general should not overlap.
+  ///
+  /// @param tile
+  /// The location of the tile
+  /// @param map
+  /// The `IMap` that the tile is in
+  /// @return The shape of the tile
   public Shape getShape(Point tile, IMap map);
 
-  /**
-   * Determines the bounding box for the tile at the given coordinates. A call to this method is equivalent to calling
-   * {@code orientation.getShape(x, y, map).getBounds2D()}.
-   *
-   * @param x
-   *          The X coordinate of the tile
-   * @param y
-   *          The Y coordinate of the tile
-   * @param map
-   *          The {@code IMap} that the tile is in
-   * @return The bounding box of the tile
-   */
+  /// Determines the bounding box for the tile at the given coordinates. A call to this method is equivalent to calling
+  /// `orientation.getShape(x, y, map).getBounds2D()`.
+  ///
+  /// @param x
+  /// The X coordinate of the tile
+  /// @param y
+  /// The Y coordinate of the tile
+  /// @param map
+  /// The `IMap` that the tile is in
+  /// @return The bounding box of the tile
   public Rectangle2D getBounds(int x, int y, IMap map);
 
-  /**
-   * Determines the bounding box for the tile at the given coordinates. A call to this method is equivalent to calling
-   * {@code orientation.getShape(tile, map).getBounds2D()}.
-   *
-   * @param tile
-   *          The location of the tile
-   * @param map
-   *          The {@code IMap} that the tile is in
-   * @return The bounding box of the tile
-   */
+  /// Determines the bounding box for the tile at the given coordinates. A call to this method is equivalent to calling
+  /// `orientation.getShape(tile, map).getBounds2D()`.
+  ///
+  /// @param tile
+  /// The location of the tile
+  /// @param map
+  /// The `IMap` that the tile is in
+  /// @return The bounding box of the tile
   public Rectangle2D getBounds(Point tile, IMap map);
 
-  /**
-   * Returns the shape of the tile containing the given coordinates. A call to this method is equivalent to calling
-   * {@code orientation.getShape(orientation.getTile(x, y, map), map)}.
-   *
-   * @param x
-   *          The X coordinate to contain
-   * @param y
-   *          The Y coordinate to contain
-   * @param map
-   *          The {@code IMap} containing the tile
-   * @return The shape of the tile containing the given point
-   */
+  /// Returns the shape of the tile containing the given coordinates. A call to this method is equivalent to calling
+  /// `orientation.getShape(orientation.getTile(x, y, map), map)`.
+  ///
+  /// @param x
+  /// The X coordinate to contain
+  /// @param y
+  /// The Y coordinate to contain
+  /// @param map
+  /// The `IMap` containing the tile
+  /// @return The shape of the tile containing the given point
   public Shape getEnclosingTileShape(double x, double y, IMap map);
 
-  /**
-   * Returns the shape of the tile containing the given coordinates. A call to this method is equivalent to calling
-   * {@code orientation.getShape(orientation.getTile(location, map), map)}.
-   *
-   * @param location
-   *          The point to contain
-   * @param map
-   *          The {@code IMap} containing the tile
-   * @return The shape of the tile containing the given point
-   */
+  /// Returns the shape of the tile containing the given coordinates. A call to this method is equivalent to calling
+  /// `orientation.getShape(orientation.getTile(location, map), map)`.
+  ///
+  /// @param location
+  /// The point to contain
+  /// @param map
+  /// The `IMap` containing the tile
+  /// @return The shape of the tile containing the given point
   public Shape getEnclosingTileShape(Point2D location, IMap map);
 
-  /**
-   * Returns the bounding box of the tile containing the given coordinates. A call to this method is equivalent to calling
-   * {@code orientation.getShape(orientation.getTile(x, y, map), map).getBounds2D()}.
-   *
-   * @param x
-   *          The X coordinate to contain
-   * @param y
-   *          The Y coordinate to contain
-   * @param map
-   *          The {@code IMap} containing the tile
-   * @return The bounding box of the tile containing the given point
-   */
+  /// Returns the bounding box of the tile containing the given coordinates. A call to this method is equivalent to calling
+  /// `orientation.getShape(orientation.getTile(x, y, map), map).getBounds2D()`.
+  ///
+  /// @param x
+  /// The X coordinate to contain
+  /// @param y
+  /// The Y coordinate to contain
+  /// @param map
+  /// The `IMap` containing the tile
+  /// @return The bounding box of the tile containing the given point
   public Rectangle2D getEnclosingTileBounds(double x, double y, IMap map);
 
-  /**
-   * Returns the bounding box of the tile containing the given coordinates. A call to this method is equivalent to calling
-   * {@code orientation.getShape(orientation.getTile(location, map), map).getBounds2D()}.
-   *
-   * @param location
-   *          The point to contain
-   * @param map
-   *          The {@code IMap} containing the tile
-   * @return The bounding box of the tile containing the given point
-   */
+  /// Returns the bounding box of the tile containing the given coordinates. A call to this method is equivalent to calling
+  /// `orientation.getShape(orientation.getTile(location, map), map).getBounds2D()`.
+  ///
+  /// @param location
+  /// The point to contain
+  /// @param map
+  /// The `IMap` containing the tile
+  /// @return The bounding box of the tile containing the given point
   public Rectangle2D getEnclosingTileBounds(Point2D location, IMap map);
 
-  /**
-   * Determines the coordinates of the tile containing the given point, as determined by
-   * {@link IMapOrientation#getShape(int, int, IMap)}.
-   *
-   * @param x
-   *          The X coordinate to contain
-   * @param y
-   *          The Y coordinate to contain
-   * @param map
-   *          The {@code IMap} containing the tile
-   * @return The tile coordinates of the tile containing the point.
-   * @throws ArithmeticException
-   *           if the tiles are packed too tightly to resolve
-   */
+  /// Determines the coordinates of the tile containing the given point, as determined by
+  /// [int, IMap)][IMapOrientation#getShape(int,].
+  ///
+  /// @param x
+  /// The X coordinate to contain
+  /// @param y
+  /// The Y coordinate to contain
+  /// @param map
+  /// The `IMap` containing the tile
+  /// @return The tile coordinates of the tile containing the point.
+  /// @throws ArithmeticException
+  /// if the tiles are packed too tightly to resolve
   public Point getTile(double x, double y, IMap map);
 
-  /**
-   * Determines the coordinates of the tile containing the given point, as determined by
-   * {@link IMapOrientation#getShape(int, int, IMap)}.
-   *
-   * @param location
-   *          The point to contain
-   * @param map
-   *          The {@code IMap} containing the tile
-   * @return The tile coordinates of the tile containing the point.
-   * @throws ArithmeticException
-   *           if the tiles are packed too tightly to resolve
-   */
+  /// Determines the coordinates of the tile containing the given point, as determined by
+  /// [int, IMap)][IMapOrientation#getShape(int,].
+  ///
+  /// @param location
+  /// The point to contain
+  /// @param map
+  /// The `IMap` containing the tile
+  /// @return The tile coordinates of the tile containing the point.
+  /// @throws ArithmeticException
+  /// if the tiles are packed too tightly to resolve
   public Point getTile(Point2D location, IMap map);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IPolyShape.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/IPolyShape.java
@@ -4,35 +4,26 @@ import java.awt.geom.Point2D;
 import java.util.List;
 
 public interface IPolyShape {
-  /**
-   * Gets all points of a polyline. The points are relative to the x and y coordinate of the parent {@link IMapObject}.
-   * 
-   * <p>
-   * <i>To get a {@code Path2D} object, you should use {@code Map}</i>
-   * </p>
-   * 
-   * @return A list containing all points of the polyline.
-   */
+  /// Gets all points of a polyline. The points are relative to the x and y coordinate of the parent [IMapObject].
+  ///
+  /// *To get a `Path2D` object, you should use `Map`*
+  ///
+  /// @return A list containing all points of the polyline.
   public List<Point2D> getPoints();
 
   public List<Point2D> getAbsolutePoints(double originX, double originY);
 
   public List<Point2D> getAbsolutePoints(Point2D origin);
 
-  /**
-   * Tests for equality between two polylines. Two polylines are <i>equal</i> if they have the same points.
-   * 
-   * @param anObject
-   *          The polyline to test equality for
-   * @return Whether the two polylines are equal, or {@code false} if {@code
-   * anObject} is not a polyline
-   */
+  /// Tests for equality between two polylines. Two polylines are *equal* if they have the same points.
+  ///
+  /// @param anObject
+  /// The polyline to test equality for
+  /// @return Whether the two polylines are equal, or `false` if `anObject` is not a polyline
   public boolean equals(Object anObject);
 
-  /**
-   * Computes a hash code for this polyline. A polyline's hash code is equal to the hash code of its points.
-   * 
-   * @return The hash code for this polyline
-   */
+  /// Computes a hash code for this polyline. A polyline's hash code is equal to the hash code of its points.
+  ///
+  /// @return The hash code for this polyline
   public int hashCode();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITerrain.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITerrain.java
@@ -2,34 +2,26 @@ package de.gurkenlabs.litiengine.environment.tilemap;
 
 import java.awt.*;
 
-/**
- * Interface representing a terrain with specific characteristics. Implementations of this interface define methods
- * to retrieve the name, color, and probability associated with the terrain, which may be used
- * for automatic mapping purposes.
- */
+/// Interface representing a terrain with specific characteristics. Implementations of this interface define methods
+/// to retrieve the name, color, and probability associated with the terrain, which may be used
+/// for automatic mapping purposes.
 public interface ITerrain {
 
-  /**
-   * Gets the name of the terrain.
-   *
-   * @return A {@code String} representing the name of the terrain.
-   */
+  /// Gets the name of the terrain.
+  ///
+  /// @return A `String` representing the name of the terrain.
   String getName();
 
-  /**
-   * Gets the color associated with the terrain.
-   *
-   * @return A {@link Color} object representing the color of the terrain.
-   */
+  /// Gets the color associated with the terrain.
+  ///
+  /// @return A [Color] object representing the color of the terrain.
   Color getColor();
 
-  /**
-   * Gets the probability value associated with the terrain.
-   * <p>
-   * The probability value is used in automatic mapping processes to indicate the likelihood or preference of using
-   * this terrain in specific contexts. Higher probability values may suggest a higher preference for automatic mapping.
-   *
-   * @return A {@code double} representing the probability value of the terrain.
-   */
+  /// Gets the probability value associated with the terrain.
+  ///
+  /// The probability value is used in automatic mapping processes to indicate the likelihood or preference of using
+  /// this terrain in specific contexts. Higher probability values may suggest a higher preference for automatic mapping.
+  ///
+  /// @return A `double` representing the probability value of the terrain.
   double getProbability();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITerrainSet.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITerrainSet.java
@@ -2,50 +2,40 @@ package de.gurkenlabs.litiengine.environment.tilemap;
 
 import java.util.List;
 
-/**
- * A set that contains {@link ITerrain} definitions and allocations to tiles of the related {@link ITileset}.
- */
+/// A set that contains [ITerrain] definitions and allocations to tiles of the related [ITileset].
 public interface ITerrainSet extends ICustomPropertyProvider {
-  /**
-   * Gets the name of this terrain set.
-   *
-   * @return THe name of the terrain set.
-   */
+  /// Gets the name of this terrain set.
+  ///
+  /// @return THe name of the terrain set.
   String getName();
 
-  /**
-   * Gets the type of terrain represented by this instance.
-   * <p>
-   * This method returns the specific type of terrain as an element of the {@link TerrainType} enumeration.
-   * The {@link TerrainType} enum defines different types of terrain, including "corner," "edge," and "mixed."
-   * The return value indicates the classification of the terrain associated with the current instance.
-   *
-   * @return The {@link TerrainType} representing the type of terrain.
-   *
-   * @see TerrainType
-   * @see TerrainType#CORNER
-   * @see TerrainType#EDGE
-   * @see TerrainType#MIXED
-   */
+  /// Gets the type of terrain represented by this instance.
+  ///
+  /// This method returns the specific type of terrain as an element of the [TerrainType] enumeration.
+  /// The [TerrainType] enum defines different types of terrain, including "corner," "edge," and "mixed."
+  /// The return value indicates the classification of the terrain associated with the current instance.
+  ///
+  /// @return The [TerrainType] representing the type of terrain.
+  ///
+  /// @see TerrainType
+  /// @see TerrainType#CORNER
+  /// @see TerrainType#EDGE
+  /// @see TerrainType#MIXED
   TerrainType getType();
 
-  /**
-   * Gets the terrains defined by this terrain set.
-   *
-   * @return The terrains defined by this instance.
-   */
+  /// Gets the terrains defined by this terrain set.
+  ///
+  /// @return The terrains defined by this instance.
   List<ITerrain> getTerrains();
 
-  /**
-   * Gets the terrains object associated with the specified tile ID.
-   * <p>
-   * This method searches through the collection of Wang tiles to find a match for the specified tile ID.
-   * If a match is found, it extracts the Wang IDs associated with the tile and maps them to terrains defined by this {@link ITerrainSet}.
-   * The resulting array contains references to the corresponding terrain objects based on the Wang IDs.
-   * If a Wang ID is 0, the corresponding terrain in the array is set to null.
-   *
-   * @param tileId The tile ID for which terrains are to be retrieved.
-   * @return An array of ITerrain objects representing the terrains associated with the given tile ID.
-   */
+  /// Gets the terrains object associated with the specified tile ID.
+  ///
+  /// This method searches through the collection of Wang tiles to find a match for the specified tile ID.
+  /// If a match is found, it extracts the Wang IDs associated with the tile and maps them to terrains defined by this [ITerrainSet].
+  /// The resulting array contains references to the corresponding terrain objects based on the Wang IDs.
+  /// If a Wang ID is 0, the corresponding terrain in the array is set to null.
+  ///
+  /// @param tileId The tile ID for which terrains are to be retrieved.
+  /// @return An array of ITerrain objects representing the terrains associated with the given tile ID.
   ITerrain[] getTerrains(int tileId);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITile.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITile.java
@@ -5,20 +5,16 @@ import java.awt.image.BufferedImage;
 
 public interface ITile extends ICustomPropertyProvider {
 
-  /**
-   * Gets the grid id.
-   *
-   * @return the grid id
-   */
+  /// Gets the grid id.
+  ///
+  /// @return the grid id
   public int getGridId();
 
   public BufferedImage getImage();
 
-  /**
-   * Gets the tile coordinate.
-   *
-   * @return the tile coordinate
-   */
+  /// Gets the tile coordinate.
+  ///
+  /// @return the tile coordinate
   public Point getTileCoordinate();
 
   public ITilesetEntry getTilesetEntry();
@@ -31,21 +27,17 @@ public interface ITile extends ICustomPropertyProvider {
 
   public boolean isFlipped();
 
-  /**
-   * Tests for equality between two tiles. Two tiles are <i>equal</i> if they have the same grid ID, flipped flags, and
-   * tileset entry.
-   * 
-   * @param anObject
-   *          The tile to test equality for
-   * @return Whether the provided tile is equal to this tile, or {@code false} if {@code anObject} is not a tile
-   */
+  /// Tests for equality between two tiles. Two tiles are *equal* if they have the same grid ID, flipped flags, and
+  /// tileset entry.
+  ///
+  /// @param anObject
+  /// The tile to test equality for
+  /// @return Whether the provided tile is equal to this tile, or `false` if `anObject` is not a tile
   public boolean equals(Object anObject);
 
-  /**
-   * Computes a hash code for this tile. A tile's hash code is equal to its stored grid ID, i.e. the gid bitmask, xor the
-   * tileset entry's hash code.
-   * 
-   * @return The hash code for this tile
-   */
+  /// Computes a hash code for this tile. A tile's hash code is equal to its stored grid ID, i.e. the gid bitmask, xor the
+  /// tileset entry's hash code.
+  ///
+  /// @return The hash code for this tile
   public int hashCode();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITileLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITileLayer.java
@@ -5,65 +5,53 @@ import java.util.List;
 
 public interface ITileLayer extends ILayer {
 
-  /**
-   * Gets the tile by location.
-   *
-   * @param location
-   *          the location
-   * @return the tile by location
-   */
+  /// Gets the tile by location.
+  ///
+  /// @param location
+  /// the location
+  /// @return the tile by location
   ITile getTileByLocation(Point2D location);
 
-  /**
-   * Gets the tile at the specified map grid location.
-   * 
-   * <p>
-   * To retrieve map grid coordinates from a location on the map, use the {@code MapUtilities#getTile(Point2D)} method.
-   * </p>
-   * 
-   * @param x
-   *          The x-coordinate (on the map grid) to retrieve the tile.
-   * @param y
-   *          The y-coordinate (on the map grid) to retrieve the tile.
-   * 
-   * @return The tile at the specified grid location.
-   * 
-   * @see MapUtilities#getTile(Point2D)
-   */
+  /// Gets the tile at the specified map grid location.
+  ///
+  /// To retrieve map grid coordinates from a location on the map, use the `MapUtilities#getTile(Point2D)` method.
+  ///
+  /// @param x
+  /// The x-coordinate (on the map grid) to retrieve the tile.
+  /// @param y
+  /// The y-coordinate (on the map grid) to retrieve the tile.
+  ///
+  /// @return The tile at the specified grid location.
+  ///
+  /// @see MapUtilities#getTile(Point2D)
   ITile getTile(int x, int y);
 
-  /**
-   * Sets the id of the tile at the specified map grid location.
-   * 
-   * @param x
-   *          The x-coordinate (on the map grid).
-   * @param y
-   *          The y-coordinate (on the map grid).
-   * 
-   * @param tile
-   *          The tile that provides the tile id to be set on the tile at the specified location.
-   * 
-   * @see ITile#getGridId()
-   */
+  /// Sets the id of the tile at the specified map grid location.
+  ///
+  /// @param x
+  /// The x-coordinate (on the map grid).
+  /// @param y
+  /// The y-coordinate (on the map grid).
+  ///
+  /// @param tile
+  /// The tile that provides the tile id to be set on the tile at the specified location.
+  ///
+  /// @see ITile#getGridId()
   void setTile(int x, int y, ITile tile);
 
-  /**
-   * Sets the id of the tile at the specified map grid location.
-   * 
-   * @param x
-   *          The x-coordinate (on the map grid).
-   * @param y
-   *          The y-coordinate (on the map grid).
-   * 
-   * @param gid
-   *          The id to be set on the tile at the specified location.
-   */
+  /// Sets the id of the tile at the specified map grid location.
+  ///
+  /// @param x
+  /// The x-coordinate (on the map grid).
+  /// @param y
+  /// The y-coordinate (on the map grid).
+  ///
+  /// @param gid
+  /// The id to be set on the tile at the specified location.
   void setTile(int x, int y, int gid);
 
-  /**
-   * Gets the tiles.
-   *
-   * @return the tiles
-   */
+  /// Gets the tiles.
+  ///
+  /// @return the tiles
   List<ITile> getTiles();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITileset.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITileset.java
@@ -7,119 +7,87 @@ import java.util.List;
 
 public interface ITileset extends ICustomPropertyProvider, Resource {
 
-  /**
-   * Gets the first grid id.
-   *
-   * @return the first grid id
-   */
+  /// Gets the first grid id.
+  ///
+  /// @return the first grid id
   int getFirstGridId();
 
-  /**
-   * Gets the image.
-   *
-   * @return the image
-   */
+  /// Gets the image.
+  ///
+  /// @return the image
   IMapImage getImage();
 
-  /**
-   * Gets the spritesheet that contains the rendered tile images.
-   *
-   * @return the spritesheet
-   */
+  /// Gets the spritesheet that contains the rendered tile images.
+  ///
+  /// @return the spritesheet
   Spritesheet getSpritesheet();
 
-  /**
-   * Gets the margin (in pixels) between the tileset image edge and the first tile.
-   *
-   * @return the margin in pixels
-   */
+  /// Gets the margin (in pixels) between the tileset image edge and the first tile.
+  ///
+  /// @return the margin in pixels
   int getMargin();
 
-  /**
-   * Gets the spacing (in pixels) between adjacent tiles in the tileset image.
-   *
-   * @return the spacing in pixels
-   */
+  /// Gets the spacing (in pixels) between adjacent tiles in the tileset image.
+  ///
+  /// @return the spacing in pixels
   int getSpacing();
 
-  /**
-   * Gets the tile dimension.
-   *
-   * @return the tile dimension
-   */
+  /// Gets the tile dimension.
+  ///
+  /// @return the tile dimension
   Dimension getTileDimension();
 
-  /**
-   * Gets the number of tile columns in the tileset.
-   *
-   * @return the number of columns
-   */
+  /// Gets the number of tile columns in the tileset.
+  ///
+  /// @return the number of columns
   int getColumns();
 
-  /**
-   * Gets the per-tileset rendering offset.
-   *
-   * @return the tile offset
-   */
+  /// Gets the per-tileset rendering offset.
+  ///
+  /// @return the tile offset
   ITileOffset getTileOffset();
 
-  /**
-   * Gets the tile height in pixels.
-   *
-   * @return the tile height
-   */
+  /// Gets the tile height in pixels.
+  ///
+  /// @return the tile height
   int getTileHeight();
 
-  /**
-   * Gets the tile width.
-   *
-   * @return the tile width
-   */
+  /// Gets the tile width.
+  ///
+  /// @return the tile width
   int getTileWidth();
 
-  /**
-   * Gets the total number of tiles defined by this tileset.
-   *
-   * @return the tile count
-   */
+  /// Gets the total number of tiles defined by this tileset.
+  ///
+  /// @return the tile count
   int getTileCount();
 
-  /**
-   * Gets the tileset entry with the given local id.
-   *
-   * @param id the local tile id
-   * @return the tileset entry, or {@code null} if no such entry exists
-   */
+  /// Gets the tileset entry with the given local id.
+  ///
+  /// @param id the local tile id
+  /// @return the tileset entry, or `null` if no such entry exists
   ITilesetEntry getTile(int id);
 
-  /**
-   * Returns whether this tileset contains the supplied tile.
-   *
-   * @param tile the tile to test
-   * @return {@code true} if this tileset contains the tile
-   */
+  /// Returns whether this tileset contains the supplied tile.
+  ///
+  /// @param tile the tile to test
+  /// @return `true` if this tileset contains the tile
   boolean containsTile(ITile tile);
 
-  /**
-   * Returns whether this tileset contains the supplied tileset entry.
-   *
-   * @param entry the entry to test
-   * @return {@code true} if this tileset contains the entry
-   */
+  /// Returns whether this tileset contains the supplied tileset entry.
+  ///
+  /// @param entry the entry to test
+  /// @return `true` if this tileset contains the entry
   boolean containsTile(ITilesetEntry entry);
 
-  /**
-   * Returns whether this tileset contains a tile with the supplied global id.
-   *
-   * @param tileId the global tile id
-   * @return {@code true} if the global id belongs to this tileset
-   */
+  /// Returns whether this tileset contains a tile with the supplied global id.
+  ///
+  /// @param tileId the global tile id
+  /// @return `true` if the global id belongs to this tileset
   boolean containsTile(int tileId);
 
-  /**
-   * Gets the terrain sets defined by this tile set.
-   *
-   * @return The terrain sets of this instance.
-   */
+  /// Gets the terrain sets defined by this tile set.
+  ///
+  /// @return The terrain sets of this instance.
   List<ITerrainSet> getTerrainSets();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITilesetEntry.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/ITilesetEntry.java
@@ -8,25 +8,19 @@ public interface ITilesetEntry extends ICustomPropertyProvider {
 
   ITileAnimation getAnimation();
 
-  /**
-   * Gets the current image for this tileset entry.
-   *
-   * @return The current image for this tileset entry, accounting for animation.
-   */
+  /// Gets the current image for this tileset entry.
+  ///
+  /// @return The current image for this tileset entry, accounting for animation.
   BufferedImage getImage();
 
-  /**
-   * Gets the "standard" image for this tileset entry, without applying any animations.
-   *
-   * @return The standard image for this tileset entry
-   */
+  /// Gets the "standard" image for this tileset entry, without applying any animations.
+  ///
+  /// @return The standard image for this tileset entry
   BufferedImage getBasicImage();
 
-  /**
-   * Gets the tileset that this entry belongs to.
-   *
-   * @return The tileset for this entry
-   */
+  /// Gets the tileset that this entry belongs to.
+  ///
+  /// @return The tileset for this entry
   ITileset getTileset();
 
   String getType();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectDefinition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectDefinition.java
@@ -5,14 +5,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Marks an entity implementation as a map object type that game tooling can discover. */
+/// Marks an entity implementation as a map object type that game tooling can discover.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MapObjectDefinition {
-  /** Stable implementation identifier stored in {@link MapObjectProperty#IMPLEMENTATION}. */
+  /// Stable implementation identifier stored in [MapObjectProperty#IMPLEMENTATION].
   String id();
 
-  /** Built-in map object behavior and editor panels inherited by this type. */
+  /// Built-in map object behavior and editor panels inherited by this type.
   MapObjectType baseType();
 
   String displayName() default "";

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectProperty.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectProperty.java
@@ -7,278 +7,269 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Defines the built-in custom property names that LITIengine recognizes on Tiled {@link IMapObject} instances.
- * <p>
- * These string constants are used as keys for properties attached to map objects in {@code .tmx} files and are referenced by the various
- * {@code MapObjectLoader} implementations to configure entities at load time.
- * </p>
- */
+/// Defines the built-in custom property names that LITIengine recognizes on Tiled [IMapObject] instances.
+///
+/// These string constants are used as keys for properties attached to map objects in `.tmx` files and are referenced by the various
+/// `MapObjectLoader` implementations to configure entities at load time.
 public final class MapObjectProperty {
   private static final Logger log = Logger.getLogger(MapObjectProperty.class.getName());
 
-  /**
-   * Comma-separated list of tags assigned to an entity.
-   */
+  /// Comma-separated list of tags assigned to an entity.
   @TmxPropertyInfo(name = "tags", description = "Comma-separated list of tags assigned to an entity.", category = "General", type = "string")
   public static final String TAGS = "tags";
 
-  /**
-   * Render type used when drawing the entity.
-   */
+  /// Render type used when drawing the entity.
   @TmxPropertyInfo(name = "renderType", description = "Render type used when drawing the entity (BACKGROUND, GROUND, SURFACE, NORMAL, OVERLAY).", category = "Graphics", type = "enum", defaultValue = "NORMAL")
   public static final String RENDERTYPE = "renderType";
 
-  /** Whether the entity should be rendered together with its containing layer. */
+  /// Whether the entity should be rendered together with its containing layer.
   @TmxPropertyInfo(name = "renderWithLayer", description = "Whether the entity should be rendered together with its containing layer.", category = "Graphics", type = "boolean", defaultValue = "false")
   public static final String RENDERWITHLAYER = "renderWithLayer";
 
-  /** Minimum graphics quality required for the entity to be rendered. */
+  /// Minimum graphics quality required for the entity to be rendered.
   @TmxPropertyInfo(name = "requiredQuality", description = "Minimum graphics quality required for the entity to be rendered.", category = "Graphics", type = "enum", defaultValue = "VERYLOW")
   public static final String REQUIRED_QUALITY = "requiredQuality";
 
   // collision entity
-  /** Whether collision is enabled for the entity. */
+  /// Whether collision is enabled for the entity.
   @TmxPropertyInfo(name = "collision", description = "Whether collision is enabled for the entity.", category = "Collision", type = "boolean", defaultValue = "false")
   public static final String COLLISION = "collision";
 
-  /** Horizontal alignment of the entity's collision box. */
+  /// Horizontal alignment of the entity's collision box.
   @TmxPropertyInfo(name = "collisionAlign", description = "Horizontal alignment of the entity's collision box (LEFT, CENTER, RIGHT).", category = "Collision", type = "enum", defaultValue = "CENTER")
   public static final String COLLISION_ALIGN = "collisionAlign";
 
-  /** Vertical alignment of the entity's collision box. */
+  /// Vertical alignment of the entity's collision box.
   @TmxPropertyInfo(name = "collisionValign", description = "Vertical alignment of the entity's collision box (TOP, MIDDLE, DOWN).", category = "Collision", type = "enum", defaultValue = "DOWN")
   public static final String COLLISION_VALIGN = "collisionValign";
 
-  /** Type of collision used by the entity (static, dynamic, etc.). */
+  /// Type of collision used by the entity (static, dynamic, etc.).
   @TmxPropertyInfo(name = "collisionType", description = "Type of collision used by the entity (STATIC, DYNAMIC).", category = "Collision", type = "enum", defaultValue = "STATIC")
   public static final String COLLISION_TYPE = "collisionType";
 
   // collision box
-  /** Height of the entity's collision box, in pixels. */
+  /// Height of the entity's collision box, in pixels.
   @TmxPropertyInfo(name = "collisionboxHeight", description = "Height of the entity's collision box in pixels.", category = "Collision", type = "float")
   public static final String COLLISIONBOX_HEIGHT = "collisionboxHeight";
 
-  /** Width of the entity's collision box, in pixels. */
+  /// Width of the entity's collision box, in pixels.
   @TmxPropertyInfo(name = "collisionboxWidth", description = "Width of the entity's collision box in pixels.", category = "Collision", type = "float")
   public static final String COLLISIONBOX_WIDTH = "collisionboxWidth";
 
-  /** Whether the collision box obstructs light sources. */
+  /// Whether the collision box obstructs light sources.
   @TmxPropertyInfo(name = "isObstructingLight", description = "Whether the collision box obstructs light sources.", category = "Collision", type = "boolean", defaultValue = "false")
   public static final String COLLISIONBOX_OBSTRUCTINGLIGHTS = "isObstructingLight";
 
   // general entity stuff
-  /** Name of the spritesheet associated with the entity. */
+  /// Name of the spritesheet associated with the entity.
   @TmxPropertyInfo(name = "spritesheetName", description = "Name of the spritesheet associated with the entity.", category = "Graphics", type = "string")
   public static final String SPRITESHEETNAME = "spritesheetName";
 
-  /** Whether the entity's sprite should be scaled to fit its bounding box. */
+  /// Whether the entity's sprite should be scaled to fit its bounding box.
   @TmxPropertyInfo(name = "scaling", description = "Whether the entity's sprite should be scaled to fit its bounding box.", category = "Graphics", type = "boolean", defaultValue = "false")
   public static final String SCALE_SPRITE = "scaling";
 
-  /** Project-defined implementation identifier for a built-in map object type. */
+  /// Project-defined implementation identifier for a built-in map object type.
   @TmxPropertyInfo(name = "implementation", description = "Project-defined implementation identifier for a built-in map object type.", category = "General", type = "string")
   public static final String IMPLEMENTATION = "implementation";
 
-  /** Versioned JSON bindings for scripts attached to an entity. */
+  /// Versioned JSON bindings for scripts attached to an entity.
   @TmxPropertyInfo(name = "scriptBindings", description = "Structured Java or runtime script bindings assigned to this entity.", category = "Behavior", type = "scripts")
   public static final String SCRIPT_BINDINGS = "scriptBindings";
 
   // mobile entity
-  /** Acceleration value of a mobile entity, in milliseconds to reach max velocity. */
+  /// Acceleration value of a mobile entity, in milliseconds to reach max velocity.
   @TmxPropertyInfo(name = "acceleration", description = "Acceleration value of a mobile entity in milliseconds to reach max velocity.", category = "Movement", type = "int", defaultValue = "0")
   public static final String MOVEMENT_ACCELERATION = "acceleration";
 
-  /** Deceleration value of a mobile entity, in milliseconds to come to a stop. */
+  /// Deceleration value of a mobile entity, in milliseconds to come to a stop.
   @TmxPropertyInfo(name = "deceleration", description = "Deceleration value of a mobile entity in milliseconds to come to a stop.", category = "Movement", type = "int", defaultValue = "0")
   public static final String MOVEMENT_DECELERATION = "deceleration";
 
-  /** Maximum movement velocity of a mobile entity, in pixels per second. */
+  /// Maximum movement velocity of a mobile entity, in pixels per second.
   @TmxPropertyInfo(name = "velocity", description = "Maximum movement velocity of a mobile entity in pixels per second.", category = "Movement", type = "float", defaultValue = "100")
   public static final String MOVEMENT_VELOCITY = "velocity";
 
-  /** Whether the entity should rotate towards its movement direction. */
+  /// Whether the entity should rotate towards its movement direction.
   @TmxPropertyInfo(name = "turnOnMove", description = "Whether the entity should rotate towards its movement direction.", category = "Movement", type = "boolean", defaultValue = "true")
   public static final String MOVEMENT_TURNONMOVE = "turnOnMove";
 
   // combat entity
-  /** Hit points of a combat entity. */
+  /// Hit points of a combat entity.
   @TmxPropertyInfo(name = "hitpoints", description = "Maximum hit points of a combat entity.", category = "Combat", type = "int", defaultValue = "100")
   public static final String COMBAT_HITPOINTS = "hitpoints";
 
-  /** Initial current hit points of a combat entity. */
+  /// Initial current hit points of a combat entity.
   @TmxPropertyInfo(name = "currentHitpoints", description = "Initial current hit points of a combat entity.", category = "Combat", type = "int", defaultValue = "100")
   public static final String COMBAT_CURRENT_HITPOINTS = "currentHitpoints";
 
-  /** Whether the combat entity is indestructible. */
+  /// Whether the combat entity is indestructible.
   @TmxPropertyInfo(name = "indestructible", description = "Whether the combat entity is indestructible.", category = "Combat", type = "boolean", defaultValue = "false")
   public static final String COMBAT_INDESTRUCTIBLE = "indestructible";
 
-  /** Identifier of the team the combat entity belongs to. */
+  /// Identifier of the team the combat entity belongs to.
   @TmxPropertyInfo(name = "team", description = "Identifier of the team the combat entity belongs to.", category = "Combat", type = "int", defaultValue = "0")
   public static final String COMBAT_TEAM = "team";
 
   // props
-  /** Material of a prop, used to determine sound effects and damage interactions. */
+  /// Material of a prop, used to determine sound effects and damage interactions.
   @TmxPropertyInfo(name = "material", description = "Material of a prop used to determine sound effects and damage interactions.", category = "Prop", type = "string")
   public static final String PROP_MATERIAL = "material";
 
-  /** Whether the prop should cast a shadow. */
+  /// Whether the prop should cast a shadow.
   @TmxPropertyInfo(name = "addShadow", description = "Whether the prop should cast a shadow.", category = "Prop", type = "boolean", defaultValue = "false")
   public static final String PROP_ADDSHADOW = "addShadow";
 
-  /** Sprite rotation of the prop. */
+  /// Sprite rotation of the prop.
   @TmxPropertyInfo(name = "rotationSprite", description = "Sprite rotation angle of the prop.", category = "Prop", type = "int", defaultValue = "0")
   public static final String PROP_ROTATION = "rotationSprite";
 
-  /** Whether the prop's sprite is flipped horizontally. */
+  /// Whether the prop's sprite is flipped horizontally.
   @TmxPropertyInfo(name = "flipHorizontally", description = "Whether the prop's sprite is flipped horizontally.", category = "Prop", type = "boolean", defaultValue = "false")
   public static final String PROP_FLIPHORIZONTALLY = "flipHorizontally";
 
-  /** Whether the prop's sprite is flipped vertically. */
+  /// Whether the prop's sprite is flipped vertically.
   @TmxPropertyInfo(name = "flipVertically", description = "Whether the prop's sprite is flipped vertically.", category = "Prop", type = "boolean", defaultValue = "false")
   public static final String PROP_FLIPVERTICALLY = "flipVertically";
 
   // light source
-  /** Color of the emitted light, encoded as a string. */
+  /// Color of the emitted light, encoded as a string.
   @TmxPropertyInfo(name = "lightColor", description = "Color of the emitted light encoded as a hex string.", category = "Light", type = "color", defaultValue = "#FFFFFF")
   public static final String LIGHT_COLOR = "lightColor";
 
-  /** Intensity of the emitted light. */
+  /// Intensity of the emitted light.
   @TmxPropertyInfo(name = "lightIntensity", description = "Intensity of the emitted light (0 to 255).", category = "Light", type = "int", defaultValue = "100")
   public static final String LIGHT_INTENSITY = "lightIntensity";
 
-  /** Shape of the light source (e.g. rectangle, ellipse). */
+  /// Shape of the light source (e.g. rectangle, ellipse).
   @TmxPropertyInfo(name = "lightShape", description = "Shape of the light source (ELLIPSE, RECTANGLE).", category = "Light", type = "enum", defaultValue = "ELLIPSE")
   public static final String LIGHT_SHAPE = "lightShape";
 
-  /** Whether the light source is initially active. */
+  /// Whether the light source is initially active.
   @TmxPropertyInfo(name = "lightActive", description = "Whether the light source is initially active.", category = "Light", type = "boolean", defaultValue = "true")
   public static final String LIGHT_ACTIVE = "lightActive";
 
   // sound source
-  /** Volume modifier of the sound source. */
+  /// Volume modifier of the sound source.
   @TmxPropertyInfo(name = "soundVolume", description = "Volume modifier of the sound source (0.0 to 1.0).", category = "Sound", type = "float", defaultValue = "1.0")
   public static final String SOUND_VOLUME = "soundVolume";
 
-  /** Whether the sound source loops its playback. */
+  /// Whether the sound source loops its playback.
   @TmxPropertyInfo(name = "soundLoop", description = "Whether the sound source loops its playback.", category = "Sound", type = "boolean", defaultValue = "true")
   public static final String SOUND_LOOP = "soundLoop";
 
-  /** Name of the sound resource played by the source. */
+  /// Name of the sound resource played by the source.
   @TmxPropertyInfo(name = "soundName", description = "Name of the sound resource played by the source.", category = "Sound", type = "string")
   public static final String SOUND_NAME = "soundName";
 
-  /** Range, in pixels, within which the sound is audible. */
+  /// Range, in pixels, within which the sound is audible.
   @TmxPropertyInfo(name = "soundRange", description = "Range in pixels within which the sound is audible.", category = "Sound", type = "float", defaultValue = "100")
   public static final String SOUND_RANGE = "soundRange";
 
   // static shadow
-  /** Type of static shadow cast (e.g. rectangle, ellipse). */
+  /// Type of static shadow cast (e.g. rectangle, ellipse).
   @TmxPropertyInfo(name = "shadowType", description = "Type of static shadow cast (NONE, RECTANGLE, ELLIPSE).", category = "Shadow", type = "enum", defaultValue = "RECTANGLE")
   public static final String SHADOW_TYPE = "shadowType";
 
-  /** Pixel offset applied to the static shadow. */
+  /// Pixel offset applied to the static shadow.
   @TmxPropertyInfo(name = "shadowOffset", description = "Pixel offset applied to the static shadow.", category = "Shadow", type = "float", defaultValue = "0")
   public static final String SHADOW_OFFSET = "shadowOffset";
 
   // spawnpoint
-  /** Free-form spawn information string passed to the spawned entity. */
+  /// Free-form spawn information string passed to the spawned entity.
   @TmxPropertyInfo(name = "spawnInfo", description = "Free-form spawn information string passed to spawned entities.", category = "Spawn", type = "string")
   public static final String SPAWN_INFO = "spawnInfo";
 
-  /** Initial facing direction of the spawned entity. */
+  /// Initial facing direction of the spawned entity.
   @TmxPropertyInfo(name = "spawnDirection", description = "Initial facing direction of the spawned entity (UP, DOWN, LEFT, RIGHT).", category = "Spawn", type = "enum", defaultValue = "DOWN")
   public static final String SPAWN_DIRECTION = "spawnDirection";
 
-  /** Pivot point used when positioning the spawned entity. */
+  /// Pivot point used when positioning the spawned entity.
   @TmxPropertyInfo(name = "spawnPivot", description = "Pivot point used when positioning the spawned entity.", category = "Spawn", type = "enum", defaultValue = "LOCATION")
   public static final String SPAWN_PIVOT = "spawnPivot";
 
-  /** Horizontal offset of the spawn pivot. */
+  /// Horizontal offset of the spawn pivot.
   @TmxPropertyInfo(name = "spawnPivotOffsetX", description = "Horizontal offset of the spawn pivot.", category = "Spawn", type = "float", defaultValue = "0")
   public static final String SPAWN_PIVOT_OFFSETX = "spawnPivotOffsetX";
 
-  /** Vertical offset of the spawn pivot. */
+  /// Vertical offset of the spawn pivot.
   @TmxPropertyInfo(name = "spawnPivotOffsetY", description = "Vertical offset of the spawn pivot.", category = "Spawn", type = "float", defaultValue = "0")
   public static final String SPAWN_PIVOT_OFFSETY = "spawnPivotOffsetY";
 
   // trigger
-  /** Activation mode of a trigger (interact, collision, etc.). */
+  /// Activation mode of a trigger (interact, collision, etc.).
   @TmxPropertyInfo(name = "triggerActivation", description = "Activation mode of a trigger (INTERACT, COLLISION).", category = "Trigger", type = "enum", defaultValue = "INTERACT")
   public static final String TRIGGER_ACTIVATION = "triggerActivation";
 
-  /** Message dispatched when the trigger fires. */
+  /// Message dispatched when the trigger fires.
   @TmxPropertyInfo(name = "triggermessage", description = "Message dispatched when the trigger fires.", category = "Trigger", type = "string")
   public static final String TRIGGER_MESSAGE = "triggermessage";
 
-  /** Whether the trigger can fire only once. */
+  /// Whether the trigger can fire only once.
   @TmxPropertyInfo(name = "triggerOneTime", description = "Whether the trigger can fire only once.", category = "Trigger", type = "boolean", defaultValue = "false")
   public static final String TRIGGER_ONETIME = "triggerOneTime";
 
-  /** Identifiers of entities that may activate the trigger. */
+  /// Identifiers of entities that may activate the trigger.
   @TmxPropertyInfo(name = "triggerActivators", description = "Identifiers or tags of entities that may activate the trigger.", category = "Trigger", type = "string")
   public static final String TRIGGER_ACTIVATORS = "triggerActivators";
 
-  /** Identifiers of entities that receive the trigger message. */
+  /// Identifiers of entities that receive the trigger message.
   @TmxPropertyInfo(name = "triggerTarget", description = "Identifiers or tags of entities that receive the trigger message.", category = "Trigger", type = "string")
   public static final String TRIGGER_TARGETS = "triggerTarget";
 
-  /** Cooldown, in milliseconds, between subsequent activations of the trigger. */
+  /// Cooldown, in milliseconds, between subsequent activations of the trigger.
   @TmxPropertyInfo(name = "triggerCooldown", description = "Cooldown in milliseconds between subsequent activations.", category = "Trigger", type = "int", defaultValue = "0")
   public static final String TRIGGER_COOLDOWN = "triggerCooldown";
 
   private static final List<String> availableProperties = new ArrayList<>();
 
-  /**
-   * Property names specific to particle emitter map objects.
-   */
+  /// Property names specific to particle emitter map objects.
   public static final class Emitter {
-    /** Encoded list of emitter colors. */
+    /// Encoded list of emitter colors.
     @TmxPropertyInfo(name = "emitterColors", description = "Comma-separated or encoded list of emitter colors.", category = "Emitter", type = "string")
     public static final String COLORS = "emitterColors";
 
-    /** Encoded list of probabilities per emitter color. */
+    /// Encoded list of probabilities per emitter color.
     @TmxPropertyInfo(name = "emitterColorProbabilities", description = "Probabilities per emitter color.", category = "Emitter", type = "string")
     public static final String COLORPROBABILITIES = "emitterColorProbabilities";
 
-    /** Spawn rate in milliseconds between spawn ticks. */
+    /// Spawn rate in milliseconds between spawn ticks.
     @TmxPropertyInfo(name = "emitterSpawnRate", description = "Spawn rate in milliseconds between spawn ticks.", category = "Emitter", type = "int", defaultValue = "100")
     public static final String SPAWNRATE = "emitterSpawnRate";
 
-    /** Number of particles spawned per spawn tick. */
+    /// Number of particles spawned per spawn tick.
     @TmxPropertyInfo(name = "emitterSpawnAmount", description = "Number of particles spawned per spawn tick.", category = "Emitter", type = "int", defaultValue = "1")
     public static final String SPAWNAMOUNT = "emitterSpawnAmount";
 
-    /** Update delay of the emitter, in milliseconds. */
+    /// Update delay of the emitter, in milliseconds.
     @TmxPropertyInfo(name = "emitterUpdateDelay", description = "Update delay of the emitter in milliseconds.", category = "Emitter", type = "int", defaultValue = "10")
     public static final String UPDATERATE = "emitterUpdateDelay";
 
-    /** Total duration of the emitter, in milliseconds; {@code 0} means infinite. */
+    /// Total duration of the emitter, in milliseconds; `0` means infinite.
     @TmxPropertyInfo(name = "emitterDuration", description = "Total duration of the emitter in milliseconds (0 = infinite).", category = "Emitter", type = "int", defaultValue = "0")
     public static final String DURATION = "emitterDuration";
 
-    /** Maximum number of concurrently alive particles. */
+    /// Maximum number of concurrently alive particles.
     @TmxPropertyInfo(name = "emitterMaxParticles", description = "Maximum number of concurrently alive particles.", category = "Emitter", type = "int", defaultValue = "100")
     public static final String MAXPARTICLES = "emitterMaxParticles";
 
-    /** Default particle type/shape used by the emitter. */
+    /// Default particle type/shape used by the emitter.
     @TmxPropertyInfo(name = "emitterParticleType", description = "Default particle type or shape used by the emitter (RECTANGLE, CIRCLE, TEXT, SPRITE).", category = "Emitter", type = "enum", defaultValue = "RECTANGLE")
     public static final String PARTICLETYPE = "emitterParticleType";
 
-    /** Per-particle color variance in the range {@code [0, 1]}. */
+    /// Per-particle color variance in the range `[0, 1]`.
     @TmxPropertyInfo(name = "emitterColorVariance", description = "Per-particle color variance ratio [0, 1].", category = "Emitter", type = "float", defaultValue = "0")
     public static final String COLORVARIANCE = "emitterColorVariance";
 
-    /** Per-particle alpha variance in the range {@code [0, 1]}. */
+    /// Per-particle alpha variance in the range `[0, 1]`.
     @TmxPropertyInfo(name = "emitterAlphaVariance", description = "Per-particle alpha variance ratio [0, 1].", category = "Emitter", type = "float", defaultValue = "0")
     public static final String ALPHAVARIANCE = "emitterAlphaVariance";
 
-    /** Horizontal alignment of the emitter origin. */
+    /// Horizontal alignment of the emitter origin.
     @TmxPropertyInfo(name = "emitterOriginAlign", description = "Horizontal alignment of the emitter origin.", category = "Emitter", type = "enum", defaultValue = "CENTER")
     public static final String ORIGIN_ALIGN = "emitterOriginAlign";
 
-    /** Vertical alignment of the emitter origin. */
+    /// Vertical alignment of the emitter origin.
     @TmxPropertyInfo(name = "emitterOriginValign", description = "Vertical alignment of the emitter origin.", category = "Emitter", type = "enum", defaultValue = "MIDDLE")
     public static final String ORIGIN_VALIGN = "emitterOriginValign";
 
@@ -286,147 +277,145 @@ public final class MapObjectProperty {
     }
   }
 
-  /**
-   * Property names specific to particle configuration on emitter map objects.
-   */
+  /// Property names specific to particle configuration on emitter map objects.
   public static final class Particle {
-    /** Minimum horizontal spawn offset, in pixels. */
+    /// Minimum horizontal spawn offset, in pixels.
     @TmxPropertyInfo(name = "particleMinOffsetX", description = "Minimum horizontal spawn offset in pixels.", category = "Particle", type = "float", defaultValue = "0")
     public static final String OFFSET_X_MIN = "particleMinOffsetX";
 
-    /** Maximum horizontal spawn offset, in pixels. */
+    /// Maximum horizontal spawn offset, in pixels.
     @TmxPropertyInfo(name = "particleMaxOffsetX", description = "Maximum horizontal spawn offset in pixels.", category = "Particle", type = "float", defaultValue = "0")
     public static final String OFFSET_X_MAX = "particleMaxOffsetX";
 
-    /** Minimum vertical spawn offset, in pixels. */
+    /// Minimum vertical spawn offset, in pixels.
     @TmxPropertyInfo(name = "particleMinOffsetY", description = "Minimum vertical spawn offset in pixels.", category = "Particle", type = "float", defaultValue = "0")
     public static final String OFFSET_Y_MIN = "particleMinOffsetY";
 
-    /** Maximum vertical spawn offset, in pixels. */
+    /// Maximum vertical spawn offset, in pixels.
     @TmxPropertyInfo(name = "particleMaxOffsetY", description = "Maximum vertical spawn offset in pixels.", category = "Particle", type = "float", defaultValue = "0")
     public static final String OFFSET_Y_MAX = "particleMaxOffsetY";
 
-    /** Minimum horizontal initial velocity. */
+    /// Minimum horizontal initial velocity.
     @TmxPropertyInfo(name = "particleMinVelocityX", description = "Minimum horizontal initial velocity.", category = "Particle", type = "float", defaultValue = "0")
     public static final String VELOCITY_X_MIN = "particleMinVelocityX";
 
-    /** Maximum horizontal initial velocity. */
+    /// Maximum horizontal initial velocity.
     @TmxPropertyInfo(name = "particleMaxVelocityX", description = "Maximum horizontal initial velocity.", category = "Particle", type = "float", defaultValue = "0")
     public static final String VELOCITY_X_MAX = "particleMaxVelocityX";
 
-    /** Minimum vertical initial velocity. */
+    /// Minimum vertical initial velocity.
     @TmxPropertyInfo(name = "particleMinVelocityY", description = "Minimum vertical initial velocity.", category = "Particle", type = "float", defaultValue = "0")
     public static final String VELOCITY_Y_MIN = "particleMinVelocityY";
 
-    /** Maximum vertical initial velocity. */
+    /// Maximum vertical initial velocity.
     @TmxPropertyInfo(name = "particleMaxVelocityY", description = "Maximum vertical initial velocity.", category = "Particle", type = "float", defaultValue = "0")
     public static final String VELOCITY_Y_MAX = "particleMaxVelocityY";
 
-    /** Minimum horizontal acceleration. */
+    /// Minimum horizontal acceleration.
     @TmxPropertyInfo(name = "particleMinAccelerationX", description = "Minimum horizontal acceleration.", category = "Particle", type = "float", defaultValue = "0")
     public static final String ACCELERATION_X_MIN = "particleMinAccelerationX";
 
-    /** Maximum horizontal acceleration. */
+    /// Maximum horizontal acceleration.
     @TmxPropertyInfo(name = "particleMaxAccelerationX", description = "Maximum horizontal acceleration.", category = "Particle", type = "float", defaultValue = "0")
     public static final String ACCELERATION_X_MAX = "particleMaxAccelerationX";
 
-    /** Minimum vertical acceleration. */
+    /// Minimum vertical acceleration.
     @TmxPropertyInfo(name = "particleMinAccelerationY", description = "Minimum vertical acceleration.", category = "Particle", type = "float", defaultValue = "0")
     public static final String ACCELERATION_Y_MIN = "particleMinAccelerationY";
 
-    /** Maximum vertical acceleration. */
+    /// Maximum vertical acceleration.
     @TmxPropertyInfo(name = "particleMaxAccelerationY", description = "Maximum vertical acceleration.", category = "Particle", type = "float", defaultValue = "0")
     public static final String ACCELERATION_Y_MAX = "particleMaxAccelerationY";
 
-    /** Minimum initial particle width, in pixels. */
+    /// Minimum initial particle width, in pixels.
     @TmxPropertyInfo(name = "particleMinStartWidth", description = "Minimum initial particle width in pixels.", category = "Particle", type = "float", defaultValue = "4")
     public static final String STARTWIDTH_MIN = "particleMinStartWidth";
 
-    /** Maximum initial particle width, in pixels. */
+    /// Maximum initial particle width, in pixels.
     @TmxPropertyInfo(name = "particleMaxStartWidth", description = "Maximum initial particle width in pixels.", category = "Particle", type = "float", defaultValue = "4")
     public static final String STARTWIDTH_MAX = "particleMaxStartWidth";
 
-    /** Minimum initial particle height, in pixels. */
+    /// Minimum initial particle height, in pixels.
     @TmxPropertyInfo(name = "particleMinStartHeight", description = "Minimum initial particle height in pixels.", category = "Particle", type = "float", defaultValue = "4")
     public static final String STARTHEIGHT_MIN = "particleMinStartHeight";
 
-    /** Maximum initial particle height, in pixels. */
+    /// Maximum initial particle height, in pixels.
     @TmxPropertyInfo(name = "particleMaxStartHeight", description = "Maximum initial particle height in pixels.", category = "Particle", type = "float", defaultValue = "4")
     public static final String STARTHEIGHT_MAX = "particleMaxStartHeight";
 
-    /** Minimum per-update width delta. */
+    /// Minimum per-update width delta.
     @TmxPropertyInfo(name = "particleMinDeltaWidth", description = "Minimum per-update width delta.", category = "Particle", type = "float", defaultValue = "0")
     public static final String DELTAWIDTH_MIN = "particleMinDeltaWidth";
 
-    /** Maximum per-update width delta. */
+    /// Maximum per-update width delta.
     @TmxPropertyInfo(name = "particleMaxDeltaWidth", description = "Maximum per-update width delta.", category = "Particle", type = "float", defaultValue = "0")
     public static final String DELTAWIDTH_MAX = "particleMaxDeltaWidth";
 
-    /** Minimum per-update height delta. */
+    /// Minimum per-update height delta.
     @TmxPropertyInfo(name = "particleMinDeltaHeight", description = "Minimum per-update height delta.", category = "Particle", type = "float", defaultValue = "0")
     public static final String DELTAHEIGHT_MIN = "particleMinDeltaHeight";
 
-    /** Maximum per-update height delta. */
+    /// Maximum per-update height delta.
     @TmxPropertyInfo(name = "particleMaxDeltaHeight", description = "Maximum per-update height delta.", category = "Particle", type = "float", defaultValue = "0")
     public static final String DELTAHEIGHT_MAX = "particleMaxDeltaHeight";
 
-    /** Minimum initial angle, in degrees. */
+    /// Minimum initial angle, in degrees.
     @TmxPropertyInfo(name = "particleMinAngle", description = "Minimum initial angle in degrees.", category = "Particle", type = "float", defaultValue = "0")
     public static final String ANGLE_MIN = "particleMinAngle";
 
-    /** Maximum initial angle, in degrees. */
+    /// Maximum initial angle, in degrees.
     @TmxPropertyInfo(name = "particleMaxAngle", description = "Maximum initial angle in degrees.", category = "Particle", type = "float", defaultValue = "360")
     public static final String ANGLE_MAX = "particleMaxAngle";
 
-    /** Minimum per-update angle delta, in degrees. */
+    /// Minimum per-update angle delta, in degrees.
     @TmxPropertyInfo(name = "particleMinDeltaAngle", description = "Minimum per-update angle delta in degrees.", category = "Particle", type = "float", defaultValue = "0")
     public static final String DELTA_ANGLE_MIN = "particleMinDeltaAngle";
 
-    /** Maximum per-update angle delta, in degrees. */
+    /// Maximum per-update angle delta, in degrees.
     @TmxPropertyInfo(name = "particleMaxDeltaAngle", description = "Maximum per-update angle delta in degrees.", category = "Particle", type = "float", defaultValue = "0")
     public static final String DELTA_ANGLE_MAX = "particleMaxDeltaAngle";
 
-    /** Minimum particle time-to-live, in milliseconds. */
+    /// Minimum particle time-to-live, in milliseconds.
     @TmxPropertyInfo(name = "particleMinTTL", description = "Minimum particle time-to-live in milliseconds.", category = "Particle", type = "int", defaultValue = "1000")
     public static final String TTL_MIN = "particleMinTTL";
 
-    /** Maximum particle time-to-live, in milliseconds. */
+    /// Maximum particle time-to-live, in milliseconds.
     @TmxPropertyInfo(name = "particleMaxTTL", description = "Maximum particle time-to-live in milliseconds.", category = "Particle", type = "int", defaultValue = "1000")
     public static final String TTL_MAX = "particleMaxTTL";
 
-    /** Whether sprite-based particles are animated. */
+    /// Whether sprite-based particles are animated.
     @TmxPropertyInfo(name = "particleAnimateSprite", description = "Whether sprite-based particles are animated.", category = "Particle", type = "boolean", defaultValue = "false")
     public static final String ANIMATESPRITE = "particleAnimateSprite";
 
-    /** Whether sprite-based particle animations are looped. */
+    /// Whether sprite-based particle animations are looped.
     @TmxPropertyInfo(name = "particleLoopSprite", description = "Whether sprite-based particle animations are looped.", category = "Particle", type = "boolean", defaultValue = "false")
     public static final String LOOPSPRITE = "particleLoopSprite";
 
-    /** Encoded list of texts used by text-rendering particles. */
+    /// Encoded list of texts used by text-rendering particles.
     @TmxPropertyInfo(name = "particleTexts", description = "Comma-separated list of texts used by text-rendering particles.", category = "Particle", type = "string")
     public static final String TEXTS = "particleTexts";
 
-    /** Whether particles fade out over their lifetime. */
+    /// Whether particles fade out over their lifetime.
     @TmxPropertyInfo(name = "particleFade", description = "Whether particles fade out over their lifetime.", category = "Particle", type = "boolean", defaultValue = "true")
     public static final String FADE = "particleFade";
 
-    /** Whether particles fade upon collision. */
+    /// Whether particles fade upon collision.
     @TmxPropertyInfo(name = "particleFadeOnCollision", description = "Whether particles fade upon collision.", category = "Particle", type = "boolean", defaultValue = "false")
     public static final String FADEONCOLLISION = "particleFadeOnCollision";
 
-    /** Whether shape-based particles are rendered as outlines only. */
+    /// Whether shape-based particles are rendered as outlines only.
     @TmxPropertyInfo(name = "particleOutlineOnly", description = "Whether shape-based particles are rendered as outlines only.", category = "Particle", type = "boolean", defaultValue = "false")
     public static final String OUTLINEONLY = "particleOutlineOnly";
 
-    /** Minimum outline thickness for outline-rendered particles. */
+    /// Minimum outline thickness for outline-rendered particles.
     @TmxPropertyInfo(name = "particleMinOutlineThickness", description = "Minimum outline thickness for outline-rendered particles.", category = "Particle", type = "float", defaultValue = "1")
     public static final String OUTLINETHICKNESS_MIN = "particleMinOutlineThickness";
 
-    /** Maximum outline thickness for outline-rendered particles. */
+    /// Maximum outline thickness for outline-rendered particles.
     @TmxPropertyInfo(name = "particleMaxOutlineThickness", description = "Maximum outline thickness for outline-rendered particles.", category = "Particle", type = "float", defaultValue = "1")
     public static final String OUTLINETHICKNESS_MAX = "particleMaxOutlineThickness";
 
-    /** Whether particles are rendered with anti-aliasing. */
+    /// Whether particles are rendered with anti-aliasing.
     @TmxPropertyInfo(name = "particleAntiAliasing", description = "Whether particles are rendered with anti-aliasing.", category = "Particle", type = "boolean", defaultValue = "false")
     public static final String ANTIALIASING = "particleAntiAliasing";
 
@@ -438,11 +427,9 @@ public final class MapObjectProperty {
   private MapObjectProperty() {
   }
 
-  /**
-   * Returns the lazily-computed list of all built-in property names defined by this class and its nested {@link Emitter} and {@link Particle} classes.
-   *
-   * @return the list of available built-in property names
-   */
+  /// Returns the lazily-computed list of all built-in property names defined by this class and its nested [Emitter] and [Particle] classes.
+  ///
+  /// @return the list of available built-in property names
   public static List<String> getAvailableProperties() {
     if (availableProperties.isEmpty()) {
       addAvailableProperties(MapObjectProperty.class);
@@ -453,12 +440,10 @@ public final class MapObjectProperty {
     return availableProperties;
   }
 
-  /**
-   * Determines whether the given property name is a custom (user-defined) property, i.e. not part of the built-in property names.
-   *
-   * @param name the property name to test
-   * @return {@code true} if the name is not part of the built-in properties; {@code false} otherwise
-   */
+  /// Determines whether the given property name is a custom (user-defined) property, i.e. not part of the built-in property names.
+  ///
+  /// @param name the property name to test
+  /// @return `true` if the name is not part of the built-in properties; `false` otherwise
   public static boolean isCustom(final String name) {
     return getAvailableProperties().stream().noneMatch(x -> x.equalsIgnoreCase(name));
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectPropertyDefinition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectPropertyDefinition.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Describes an editor-visible property on a project-defined map object type. */
+/// Describes an editor-visible property on a project-defined map object type.
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MapObjectPropertyDefinition {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectPropertyType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectPropertyType.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.environment.tilemap;
 
-/** Supported value types for project-defined map object properties. */
+/// Supported value types for project-defined map object properties.
 public enum MapObjectPropertyType {
   STRING,
   BOOLEAN,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapObjectType.java
@@ -1,47 +1,45 @@
 package de.gurkenlabs.litiengine.environment.tilemap;
 
-/**
- * Enumerates the built-in map object types LITIengine recognizes when loading {@code .tmx} maps. Each value matches the {@code type} attribute used
- * by the engine's map object loaders to instantiate the matching engine entity.
- */
+/// Enumerates the built-in map object types LITIengine recognizes when loading `.tmx` maps. Each value matches the `type` attribute used
+/// by the engine's map object loaders to instantiate the matching engine entity.
 public enum MapObjectType {
-  /** A generic area without a dedicated entity representation. */
+  /// A generic area without a dedicated entity representation.
   @TmxTypeInfo(name = "Area", description = "A generic area region without a dedicated entity representation.")
   AREA,
 
-  /** A static collision rectangle. */
+  /// A static collision rectangle.
   @TmxTypeInfo(name = "Collision Box", description = "A static collision rectangle that obstructs entity movement.")
   COLLISIONBOX,
 
-  /** A particle emitter. */
+  /// A particle emitter.
   @TmxTypeInfo(name = "Particle Emitter", description = "Spawns and simulates visual particle effects.")
   EMITTER,
 
-  /** A dynamic light source. */
+  /// A dynamic light source.
   @TmxTypeInfo(name = "Light Source", description = "Emits dynamic ambient lighting into the scene.")
   LIGHTSOURCE,
 
-  /** A prop entity. */
+  /// A prop entity.
   @TmxTypeInfo(name = "Prop", description = "An interactive or decorative static/destructible object.")
   PROP,
 
-  /** A creature entity. */
+  /// A creature entity.
   @TmxTypeInfo(name = "Creature", description = "A mobile or combat-capable entity (NPC, monster, player).")
   CREATURE,
 
-  /** A point/area emitting a sound. */
+  /// A point/area emitting a sound.
   @TmxTypeInfo(name = "Sound Source", description = "Emits ambient or positional sound effects.")
   SOUNDSOURCE,
 
-  /** A spawn point for dynamically spawned entities. */
+  /// A spawn point for dynamically spawned entities.
   @TmxTypeInfo(name = "Spawn Point", description = "Defines a spawn location and orientation for entities.")
   SPAWNPOINT,
 
-  /** A trigger that fires messages when activated. */
+  /// A trigger that fires messages when activated.
   @TmxTypeInfo(name = "Trigger", description = "Fires target messages upon collision or interaction.")
   TRIGGER,
 
-  /** A static (baked) shadow. */
+  /// A static (baked) shadow.
   @TmxTypeInfo(name = "Static Shadow", description = "Bakes a static shadow graphic onto the environment.")
   STATICSHADOW;
 
@@ -49,25 +47,21 @@ public enum MapObjectType {
    * Note that this is not part of the enum since we consider this enum a set of valid types in many places in the engine.
    * Usually there is no need to use this explicitly. This is only used to identify {@code MapObjects} that don't have a type specified (aka. raw Tiled MapObjects).
    */
-  /** Sentinel value used to identify {@link IMapObject} instances without an explicit type attribute. */
+  /// Sentinel value used to identify [IMapObject] instances without an explicit type attribute.
   public static final String UNDEFINED_MAPOBJECTTYPE = "UNDEFINED";
 
-  /**
-   * Returns the enum value at the given ordinal.
-   *
-   * @param n the ordinal
-   * @return the matching enum value
-   */
+  /// Returns the enum value at the given ordinal.
+  ///
+  /// @param n the ordinal
+  /// @return the matching enum value
   public static MapObjectType fromOrdinal(final int n) {
     return values()[n];
   }
 
-  /**
-   * Returns the enum value matching the supplied name, or {@code null} if the name is blank or does not match any known value.
-   *
-   * @param mapObjectType the type name
-   * @return the matching enum value, or {@code null}
-   */
+  /// Returns the enum value matching the supplied name, or `null` if the name is blank or does not match any known value.
+  ///
+  /// @param mapObjectType the type name
+  /// @return the matching enum value, or `null`
   public static MapObjectType get(final String mapObjectType) {
     if (mapObjectType == null || mapObjectType.isEmpty()) {
       return null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapOrientations.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapOrientations.java
@@ -8,74 +8,51 @@ import java.awt.Shape;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-/**
- * A class containing various standard map orientations.
- */
+/// A class containing various standard map orientations.
 public class MapOrientations {
-  /**
-   * <p>
-   * An {@code IMapOrientation} for orthogonal maps, consistent with the behavior of Tiled.
-   *
-   * <p>
-   * With this orientation, tiles are treated as rectangles with dimensions equal to the tile size, layed out in rows and
-   * columns starting with the origin.
-   */
+  /// An `IMapOrientation` for orthogonal maps, consistent with the behavior of Tiled.
+  ///
+  /// With this orientation, tiles are treated as rectangles with dimensions equal to the tile size, layed out in rows and
+  /// columns starting with the origin.
   public static final IMapOrientation ORTHOGONAL = new Orthogonal();
 
-  /**
-   * <p>
-   * An isometric {@code IMapOrientation}, consistent with the behavior of Tiled.
-   *
-   * <p>
-   * With this orientation, the shapes of tiles are transformed into an isometric coordinate system via the transformation
-   * {@code (x, y) -> ((x-y)/2, (x+y)/2)}. Rectangles within this coordinate system are rendered as diamond shapes. Points
-   * are also translated such that every tile in a map fits in the first quadrant.
-   *
-   * <p>
-   * This orientation does <em>not</em> transform map objects into its coordinate system. Maps with an odd-numbered tile
-   * width or height will throw {@code IllegalArgumentException}s when using this orientation.
-   */
+  /// An isometric `IMapOrientation`, consistent with the behavior of Tiled.
+  ///
+  /// With this orientation, the shapes of tiles are transformed into an isometric coordinate system via the transformation
+  /// `(x, y) -> ((x-y)/2, (x+y)/2)`. Rectangles within this coordinate system are rendered as diamond shapes. Points
+  /// are also translated such that every tile in a map fits in the first quadrant.
+  ///
+  /// This orientation does *not* transform map objects into its coordinate system. Maps with an odd-numbered tile
+  /// width or height will throw `IllegalArgumentException`s when using this orientation.
   public static final IMapOrientation ISOMETRIC = new Isometric();
 
-  /**
-   * <p>
-   * A staggered isometric {@code IMapOrientation}, consistent with the behavior of Tiled.
-   *
-   * <p>
-   * This orientation is similar to the isometric orientation, but the tile coordinates are changed to be arranged in a
-   * rectangular area. The locations of tiles are positioned using rectangular coordinates, with tiles with parity on the
-   * stagger axis matching the stagger index filling the gaps between the other tiles.
-   *
-   * <p>
-   * This orientation requires that a stagger axis and stagger index be set. If either are missing, an
-   * {@code IllegalArgumentException} will be thrown. Like the standard isometric orientation, this orientation will also
-   * throw an {@code IllegalArgumentException} when used with a map with an odd-numbered tile width or height.
-   */
+  /// A staggered isometric `IMapOrientation`, consistent with the behavior of Tiled.
+  ///
+  /// This orientation is similar to the isometric orientation, but the tile coordinates are changed to be arranged in a
+  /// rectangular area. The locations of tiles are positioned using rectangular coordinates, with tiles with parity on the
+  /// stagger axis matching the stagger index filling the gaps between the other tiles.
+  ///
+  /// This orientation requires that a stagger axis and stagger index be set. If either are missing, an
+  /// `IllegalArgumentException` will be thrown. Like the standard isometric orientation, this orientation will also
+  /// throw an `IllegalArgumentException` when used with a map with an odd-numbered tile width or height.
   public static final IMapOrientation ISOMETRIC_STAGGERED = new StaggeredIsometric();
 
-  /**
-   * <p>
-   * A hexagonal {@code IMapOrientation}, consistent with the behavior of Tiled.
-   *
-   * <p>
-   * Tiles are arranged in the same manner as the staggered isometric orientation (the staggered isometric orientation can
-   * be viewed as a special case of this orientation with a hex side length of 0), with extra space between tiles (the hex
-   * side length) added on the stagger axis to allow for a hexagonal shape.
-   *
-   * <p>
-   * This orientation has the same requirements as staggered isometric, with the additional restriction that the hex side
-   * length must be an even number.
-   */
+  /// A hexagonal `IMapOrientation`, consistent with the behavior of Tiled.
+  ///
+  /// Tiles are arranged in the same manner as the staggered isometric orientation (the staggered isometric orientation can
+  /// be viewed as a special case of this orientation with a hex side length of 0), with extra space between tiles (the hex
+  /// side length) added on the stagger axis to allow for a hexagonal shape.
+  ///
+  /// This orientation has the same requirements as staggered isometric, with the additional restriction that the hex side
+  /// length must be an even number.
   public static final IMapOrientation HEXAGONAL = new Hexagonal();
 
-  /**
-   * Determines the appropriate {@code IMapOrientation} instance for the given name. If no such orientation exists, this
-   * method returns {@code null}.
-   *
-   * @param name
-   *          The name of the orientation, as stored in the TMX file
-   * @return The {@code IMapOrientation} by the given name
-   */
+  /// Determines the appropriate `IMapOrientation` instance for the given name. If no such orientation exists, this
+  /// method returns `null`.
+  ///
+  /// @param name
+  /// The name of the orientation, as stored in the TMX file
+  /// @return The `IMapOrientation` by the given name
   public static IMapOrientation forName(String name) {
     if ("orthogonal".equals(name)) {
       return ORTHOGONAL;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapProperty.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapProperty.java
@@ -7,37 +7,29 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Defines the built-in custom property names that LITIengine recognizes on {@link IMap} instances. These keys are referenced when reading map-level
- * settings such as ambient color or gravity.
- */
+/// Defines the built-in custom property names that LITIengine recognizes on [IMap] instances. These keys are referenced when reading map-level
+/// settings such as ambient color or gravity.
 public final class MapProperty {
   private static final Logger log = Logger.getLogger(MapProperty.class.getName());
 
-  /**
-   * Ambient color tint applied to the map.
-   */
+  /// Ambient color tint applied to the map.
   public static final String AMBIENTCOLOR = "AMBIENTLIGHT";
-  /**
-   * Color used for static shadows on the map.
-   */
+  /// Color used for static shadows on the map.
   public static final String SHADOWCOLOR = "SHADOWCOLOR";
-  /** Description text associated with the map. */
+  /// Description text associated with the map.
   public static final String MAP_DESCRIPTION = "MAP_DESCRIPTION";
-  /** Display title of the map. */
+  /// Display title of the map.
   public static final String MAP_TITLE = "MAP_TITLE";
-  /** Gravity value applied to physics simulations on this map. */
+  /// Gravity value applied to physics simulations on this map.
   public static final String GRAVITY = "GRAVITY";
 
   private MapProperty() {}
 
   private static List<String> availableProperties = new ArrayList<>();
 
-  /**
-   * Returns the lazily-computed list of all built-in map property names defined by this class.
-   *
-   * @return the available property names
-   */
+  /// Returns the lazily-computed list of all built-in map property names defined by this class.
+  ///
+  /// @return the available property names
   public static List<String> getAvailableProperties() {
     if (availableProperties.isEmpty()) {
       for (final Field field : MapProperty.class.getDeclaredFields()) {
@@ -53,12 +45,10 @@ public final class MapProperty {
     return availableProperties;
   }
 
-  /**
-   * Determines whether the given property name is a custom (user-defined) property.
-   *
-   * @param name the property name to test
-   * @return {@code true} if the name is not one of the built-in properties
-   */
+  /// Determines whether the given property name is a custom (user-defined) property.
+  ///
+  /// @param name the property name to test
+  /// @return `true` if the name is not one of the built-in properties
   public static boolean isCustom(final String name) {
     return getAvailableProperties().stream().noneMatch(x -> x.equalsIgnoreCase(name));
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapRenderer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapRenderer.java
@@ -34,38 +34,30 @@ public class MapRenderer {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Adds the specified layer rendered listener to receive events when a layer has been rendered.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified layer rendered listener to receive events when a layer has been rendered.
+  ///
+  /// @param listener The listener to add.
   public static void onLayerRendered(LayerRenderedListener listener) {
     layerRenderedListeners.add(listener);
   }
 
-  /**
-   * Removes the specified layer rendered listener..
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified layer rendered listener..
+  ///
+  /// @param listener The listener to remove.
   public static void removeLayerRenderedListener(LayerRenderedListener listener) {
     layerRenderedListeners.remove(listener);
   }
 
-  /**
-   * Adds the specified layer render condition to control whether layers should be rendered.
-   *
-   * @param condition The condition to add.
-   */
+  /// Adds the specified layer render condition to control whether layers should be rendered.
+  ///
+  /// @param condition The condition to add.
   public static void addLayerRenderCondition(LayerRenderCondition condition) {
     layerRenderConditions.add(condition);
   }
 
-  /**
-   * Removes the specified layer render condition.
-   *
-   * @param condition The condition to remove.
-   */
+  /// Removes the specified layer render condition.
+  ///
+  /// @param condition The condition to remove.
   public static void removeLayerRenderCondition(LayerRenderCondition condition) {
     layerRenderConditions.remove(condition);
   }
@@ -227,34 +219,26 @@ public class MapRenderer {
     }
   }
 
-  /**
-   * This listener interface receives events when a layer was rendered.
-   *
-   * @see MapRenderer#onLayerRendered(LayerRenderedListener)
-   */
+  /// This listener interface receives events when a layer was rendered.
+  ///
+  /// @see MapRenderer#onLayerRendered(LayerRenderedListener)
   @FunctionalInterface
   public interface LayerRenderedListener extends EventListener {
-    /**
-     * Invoked when a layer has been rendered.
-     *
-     * @param event The layer render event.
-     */
+    /// Invoked when a layer has been rendered.
+    ///
+    /// @param event The layer render event.
     void rendered(LayerRenderEvent event);
   }
 
-  /**
-   * This listener interface provides a condition callback to contol whether a layer should be rendered.
-   *
-   * @see MapRenderer#addLayerRenderCondition(LayerRenderCondition)
-   */
+  /// This listener interface provides a condition callback to contol whether a layer should be rendered.
+  ///
+  /// @see MapRenderer#addLayerRenderCondition(LayerRenderCondition)
   @FunctionalInterface
   public interface LayerRenderCondition extends EventListener {
-    /**
-     * Invoked before the rendering of a layer to determine if it should be rendered.
-     *
-     * @param event The layer render event.
-     * @return Return true if the layer should be rendered; otherwise false.
-     */
+    /// Invoked before the rendering of a layer to determine if it should be rendered.
+    ///
+    /// @param event The layer render event.
+    /// @return Return true if the layer should be rendered; otherwise false.
     boolean canRender(LayerRenderEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/MapUtilities.java
@@ -10,22 +10,18 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Static utility methods for working with TMX-style maps, map objects, tiles and tile coordinates. Most overloads default to the map of the currently
- * loaded environment.
- */
+/// Static utility methods for working with TMX-style maps, map objects, tiles and tile coordinates. Most overloads default to the map of the currently
+/// loaded environment.
 public final class MapUtilities {
 
   private MapUtilities() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Computes the combined axis-aligned bounding box of the supplied map objects.
-   *
-   * @param objects the map objects whose bounding boxes are merged
-   * @return the union bounding box
-   */
+  /// Computes the combined axis-aligned bounding box of the supplied map objects.
+  ///
+  /// @param objects the map objects whose bounding boxes are merged
+  /// @return the union bounding box
   public static Rectangle2D getBounds(IMapObject... objects) {
     double x = Double.MAX_VALUE;
     double y = Double.MAX_VALUE;
@@ -42,13 +38,11 @@ public final class MapUtilities {
     return new Rectangle2D.Double(x, y, maxX - x, maxY - y);
   }
 
-  /**
-   * Returns the maximum {@link IMapObject#getId() id} of any map object on the given map. Returns {@code 0} if the map is {@code null} or contains no
-   * map object layers.
-   *
-   * @param map the map to inspect
-   * @return the maximum map object id
-   */
+  /// Returns the maximum [id][IMapObject#getId()] of any map object on the given map. Returns `0` if the map is `null` or contains no
+  /// map object layers.
+  ///
+  /// @param map the map to inspect
+  /// @return the maximum map object id
   public static int getMaxMapId(final IMap map) {
     int maxId = 0;
     if (map == null || map.getMapObjectLayers() == null) {
@@ -74,13 +68,11 @@ public final class MapUtilities {
     return maxId;
   }
 
-  /**
-   * Snaps the given pixel-space rectangle to the bounding box of the tiles it covers on the given map.
-   *
-   * @param map the map providing tile size and orientation
-   * @param box the pixel-space rectangle to snap
-   * @return the bounding box that covers all enclosed tiles
-   */
+  /// Snaps the given pixel-space rectangle to the bounding box of the tiles it covers on the given map.
+  ///
+  /// @param map the map providing tile size and orientation
+  /// @param box the pixel-space rectangle to snap
+  /// @return the bounding box that covers all enclosed tiles
   public static Rectangle2D getTileBoundingBox(final IMap map, final Rectangle2D box) {
     final int minX = (int) Math.clamp(box.getX(), 0, map.getSizeInPixels().getWidth() - 1);
     final int minY = (int) Math.clamp(box.getY(), 0, map.getSizeInPixels().getHeight() - 1);
@@ -113,14 +105,12 @@ public final class MapUtilities {
       maxTileBounds.getMaxY() - minTileBounds.getY());
   }
 
-  /**
-   * Get the corresponding tile for a given pixel map location. This is an overload taking the Map from the current environment to calculate a tile
-   * location.
-   *
-   * @param mapLocation the pixel map location.
-   * @return The x / y tile coordinate for the given location.
-   * @see MapUtilities#getTile(IMap, Point2D)
-   */
+  /// Get the corresponding tile for a given pixel map location. This is an overload taking the Map from the current environment to calculate a tile
+  /// location.
+  ///
+  /// @param mapLocation the pixel map location.
+  /// @return The x / y tile coordinate for the given location.
+  /// @see MapUtilities#getTile(IMap, Point2D)
   public static Point getTile(final Point2D mapLocation) {
     if (Game.world().environment() == null) {
       return new Point(-1, -1);
@@ -128,13 +118,11 @@ public final class MapUtilities {
     return getTile(Game.world().environment().getMap(), mapLocation);
   }
 
-  /**
-   * Get the corresponding tile for a given pixel map location.
-   *
-   * @param map         The map on which to calculate the tile location.
-   * @param mapLocation the pixel map location.
-   * @return The x / y tile coordinate for the given mapLocation.
-   */
+  /// Get the corresponding tile for a given pixel map location.
+  ///
+  /// @param map         The map on which to calculate the tile location.
+  /// @param mapLocation the pixel map location.
+  /// @return The x / y tile coordinate for the given mapLocation.
   public static Point getTile(IMap map, final Point2D mapLocation) {
     if (map == null) {
       return new Point(-1, -1);
@@ -142,38 +130,32 @@ public final class MapUtilities {
     return map.getOrientation().getTile(mapLocation, map);
   }
 
-  /**
-   * Check if the row or column with the given index is staggered.
-   *
-   * @param staggerIndex the staggerIndex property of the map. Every second row (or column, depending on the {@link StaggerAxis} of the map is
-   *                     staggered half a tile.
-   * @param index        the index of the current row or column for which we want to determine if it's staggered or not.
-   * @return a boolean representing if the row or column with the given index is staggered.
-   */
+  /// Check if the row or column with the given index is staggered.
+  ///
+  /// @param staggerIndex the staggerIndex property of the map. Every second row (or column, depending on the [StaggerAxis] of the map is
+  /// staggered half a tile.
+  /// @param index        the index of the current row or column for which we want to determine if it's staggered or not.
+  /// @return a boolean representing if the row or column with the given index is staggered.
   public static boolean isStaggeredRowOrColumn(StaggerIndex staggerIndex, int index) {
     return (staggerIndex == StaggerIndex.ODD && MathUtilities.isOddNumber(index))
       || (staggerIndex == StaggerIndex.EVEN && !MathUtilities.isOddNumber(index));
   }
 
-  /**
-   * Converts a tile coordinate to its pixel-space top-left location on the given map.
-   *
-   * @param map          the map providing tile size
-   * @param tileLocation the tile coordinate
-   * @return the pixel-space location of the tile's top-left corner
-   */
+  /// Converts a tile coordinate to its pixel-space top-left location on the given map.
+  ///
+  /// @param map          the map providing tile size
+  /// @param tileLocation the tile coordinate
+  /// @return the pixel-space location of the tile's top-left corner
   public static Point2D getMapLocation(final IMap map, final Point tileLocation) {
     return new Point2D.Double(tileLocation.x * map.getTileSize().getWidth(),
       tileLocation.y * map.getTileSize().getHeight());
   }
 
-  /**
-   * Gets the top-left map location at which the image of a tile is rendered.
-   *
-   * @param map  the map containing the tile
-   * @param tile the tile
-   * @return the rendered image location, or {@code null} if the tile has no image or coordinate
-   */
+  /// Gets the top-left map location at which the image of a tile is rendered.
+  ///
+  /// @param map  the map containing the tile
+  /// @param tile the tile
+  /// @return the rendered image location, or `null` if the tile has no image or coordinate
   public static Point2D getTileImageLocation(final IMap map, final ITile tile) {
     if (map == null || tile == null || tile.getTileCoordinate() == null) {
       return null;
@@ -197,13 +179,11 @@ public final class MapUtilities {
     return new Point2D.Double(locationX, locationY);
   }
 
-  /**
-   * Returns all tiles from any tile layer on the given map that contain the supplied pixel-space location.
-   *
-   * @param map      the map to inspect
-   * @param location the pixel-space location
-   * @return the matching tiles, ordered by layer (bottom to top)
-   */
+  /// Returns all tiles from any tile layer on the given map that contain the supplied pixel-space location.
+  ///
+  /// @param map      the map to inspect
+  /// @param location the pixel-space location
+  /// @return the matching tiles, ordered by layer (bottom to top)
   public static List<ITile> getTilesByPixelLocation(final IMap map, final Point2D location) {
     final List<ITile> tilesAtLocation = new ArrayList<>();
     if (map.getTileLayers() == null || map.getTileLayers().isEmpty()) {
@@ -221,12 +201,10 @@ public final class MapUtilities {
     return tilesAtLocation;
   }
 
-  /**
-   * Returns the top-most non-empty tile at the given pixel-space location on the current environment's map.
-   *
-   * @param location the pixel-space location
-   * @return the top-most tile, or {@code null} if no environment or tile is found
-   */
+  /// Returns the top-most non-empty tile at the given pixel-space location on the current environment's map.
+  ///
+  /// @param location the pixel-space location
+  /// @return the top-most tile, or `null` if no environment or tile is found
   public static ITile getTopMostTile(final Point2D location) {
     if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return null;
@@ -235,13 +213,11 @@ public final class MapUtilities {
     return getTopMostTile(Game.world().environment().getMap(), location);
   }
 
-  /**
-   * Returns the top-most non-empty tile at the given pixel-space location on the supplied map.
-   *
-   * @param map      the map to inspect
-   * @param location the pixel-space location
-   * @return the top-most tile, or {@code null} if no tile is found
-   */
+  /// Returns the top-most non-empty tile at the given pixel-space location on the supplied map.
+  ///
+  /// @param map      the map to inspect
+  /// @param location the pixel-space location
+  /// @return the top-most tile, or `null` if no tile is found
   public static ITile getTopMostTile(final IMap map, final Point2D location) {
     if (map.getTileLayers() == null || map.getTileLayers().isEmpty()) {
       return null;
@@ -250,12 +226,10 @@ public final class MapUtilities {
     return getTopMostTile(map.getOrientation().getTile(location, map));
   }
 
-  /**
-   * Returns the top-most non-empty tile at the given tile coordinate on the current environment's map.
-   *
-   * @param point the tile coordinate
-   * @return the top-most tile, or {@code null} if no environment or tile is found
-   */
+  /// Returns the top-most non-empty tile at the given tile coordinate on the current environment's map.
+  ///
+  /// @param point the tile coordinate
+  /// @return the top-most tile, or `null` if no environment or tile is found
   public static ITile getTopMostTile(final Point point) {
     if (Game.world().environment() == null || Game.world().environment().getMap() == null) {
       return null;
@@ -264,13 +238,11 @@ public final class MapUtilities {
     return getTopMostTile(Game.world().environment().getMap(), point);
   }
 
-  /**
-   * Returns the top-most non-empty tile at the given tile coordinate on the supplied map.
-   *
-   * @param map   the map to inspect
-   * @param point the tile coordinate
-   * @return the top-most tile, or {@code null} if no tile is found
-   */
+  /// Returns the top-most non-empty tile at the given tile coordinate on the supplied map.
+  ///
+  /// @param map   the map to inspect
+  /// @param point the tile coordinate
+  /// @return the top-most tile, or `null` if no tile is found
   public static ITile getTopMostTile(final IMap map, final Point point) {
     final Point tileLocation = point;
 
@@ -287,13 +259,11 @@ public final class MapUtilities {
     return tile;
   }
 
-  /**
-   * Searches for the tile set that contains the specified tile, identified by the grid id.
-   *
-   * @param map  the map
-   * @param tile the tile
-   * @return the tileset
-   */
+  /// Searches for the tile set that contains the specified tile, identified by the grid id.
+  ///
+  /// @param map  the map
+  /// @param tile the tile
+  /// @return the tileset
   public static ITileset findTileSet(final IMap map, final ITile tile) {
     if (map == null || tile == null) {
       return null;
@@ -311,12 +281,10 @@ public final class MapUtilities {
     return match;
   }
 
-  /**
-   * Converts a polyline or polygon map object to a {@link Path2D} in absolute (map-space) coordinates.
-   *
-   * @param mapObject the polyline or polygon map object
-   * @return the resulting path, or {@code null} if the object is not a polyline/polygon or contains no points
-   */
+  /// Converts a polyline or polygon map object to a [Path2D] in absolute (map-space) coordinates.
+  ///
+  /// @param mapObject the polyline or polygon map object
+  /// @return the resulting path, or `null` if the object is not a polyline/polygon or contains no points
   public static Path2D convertPolyshapeToPath(final IMapObject mapObject) {
     if (mapObject == null || (!mapObject.isPolygon() && !mapObject.isPolyline())) {
       return null;
@@ -345,12 +313,10 @@ public final class MapUtilities {
     return path;
   }
 
-  /**
-   * Returns the points of a polyline or polygon map object translated to absolute (map-space) coordinates.
-   *
-   * @param mapObject the polyline or polygon map object
-   * @return the absolute points, or an empty list if the object is not a polyline/polygon
-   */
+  /// Returns the points of a polyline or polygon map object translated to absolute (map-space) coordinates.
+  ///
+  /// @param mapObject the polyline or polygon map object
+  /// @return the absolute points, or an empty list if the object is not a polyline/polygon
   public static List<Point2D> getAbsolutePolyshapePoints(final IMapObject mapObject) {
     if (mapObject.isPolygon()) {
       return mapObject.getPolygon().getAbsolutePoints(mapObject.getLocation());
@@ -363,13 +329,11 @@ public final class MapUtilities {
     return new ArrayList<>();
   }
 
-  /**
-   * Searches the supplied map for a map object with the given id.
-   *
-   * @param map the map to search
-   * @param id  the id to look up
-   * @return the matching map object, or {@code null} if none exists
-   */
+  /// Searches the supplied map for a map object with the given id.
+  ///
+  /// @param map the map to search
+  /// @param id  the id to look up
+  /// @return the matching map object, or `null` if none exists
   public static IMapObject findMapObject(final IMap map, final int id) {
     for (IMapObjectLayer layer : map.getMapObjectLayers()) {
       for (IMapObject obj : layer.getMapObjects()) {
@@ -382,23 +346,19 @@ public final class MapUtilities {
     return null;
   }
 
-  /**
-   * Returns the bounding box of the tile that contains the given pixel-space location on the current environment's map.
-   *
-   * @param mapLocation the pixel-space location
-   * @return the enclosing tile's bounding box
-   */
+  /// Returns the bounding box of the tile that contains the given pixel-space location on the current environment's map.
+  ///
+  /// @param mapLocation the pixel-space location
+  /// @return the enclosing tile's bounding box
   public static Rectangle2D getTileBoundingBox(final Point2D mapLocation) {
     return getTileBoundingBox(getCurrentMap(), mapLocation);
   }
 
-  /**
-   * Returns the bounding box of the tile that contains the given pixel-space location on the supplied map.
-   *
-   * @param map         the map providing tile size and orientation
-   * @param mapLocation the pixel-space location
-   * @return the enclosing tile's bounding box, or an empty rectangle if {@code map} is {@code null}
-   */
+  /// Returns the bounding box of the tile that contains the given pixel-space location on the supplied map.
+  ///
+  /// @param map         the map providing tile size and orientation
+  /// @param mapLocation the pixel-space location
+  /// @return the enclosing tile's bounding box, or an empty rectangle if `map` is `null`
   public static Rectangle2D getTileBoundingBox(final IMap map, final Point2D mapLocation) {
     if (map == null) {
       return new Rectangle2D.Double();
@@ -407,46 +367,38 @@ public final class MapUtilities {
     return map.getOrientation().getEnclosingTileBounds(mapLocation, map);
   }
 
-  /**
-   * Returns the bounding box of the tile at the given tile coordinate on the current environment's map.
-   *
-   * @param x the tile x coordinate
-   * @param y the tile y coordinate
-   * @return the tile's bounding box
-   */
+  /// Returns the bounding box of the tile at the given tile coordinate on the current environment's map.
+  ///
+  /// @param x the tile x coordinate
+  /// @param y the tile y coordinate
+  /// @return the tile's bounding box
   public static Rectangle2D getTileBoundingBox(final int x, final int y) {
     return getTileBoundingBox(getCurrentMap(), x, y);
   }
 
-  /**
-   * Returns the bounding box of the tile at the given tile coordinate on the supplied map.
-   *
-   * @param map the map providing tile size and orientation
-   * @param x   the tile x coordinate
-   * @param y   the tile y coordinate
-   * @return the tile's bounding box
-   */
+  /// Returns the bounding box of the tile at the given tile coordinate on the supplied map.
+  ///
+  /// @param map the map providing tile size and orientation
+  /// @param x   the tile x coordinate
+  /// @param y   the tile y coordinate
+  /// @return the tile's bounding box
   public static Rectangle2D getTileBoundingBox(final IMap map, final int x, final int y) {
     return getTileBoundingBox(map, new Point(x, y));
   }
 
-  /**
-   * Returns the bounding box of the tile at the given tile coordinate on the current environment's map.
-   *
-   * @param tile the tile coordinate
-   * @return the tile's bounding box
-   */
+  /// Returns the bounding box of the tile at the given tile coordinate on the current environment's map.
+  ///
+  /// @param tile the tile coordinate
+  /// @return the tile's bounding box
   public static Rectangle2D getTileBoundingBox(final Point tile) {
     return getTileBoundingBox(getCurrentMap(), tile);
   }
 
-  /**
-   * Returns the bounding box of the tile at the given tile coordinate on the supplied map.
-   *
-   * @param map  the map providing tile size and orientation
-   * @param tile the tile coordinate
-   * @return the tile's bounding box, or an empty rectangle if {@code map} is {@code null}
-   */
+  /// Returns the bounding box of the tile at the given tile coordinate on the supplied map.
+  ///
+  /// @param map  the map providing tile size and orientation
+  /// @param tile the tile coordinate
+  /// @return the tile's bounding box, or an empty rectangle if `map` is `null`
   public static Rectangle2D getTileBoundingBox(final IMap map, final Point tile) {
     if (map == null) {
       return new Rectangle2D.Double();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxProperty.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxProperty.java
@@ -5,16 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * This annotation identifies which name is used by the map-object property related to the annotated member.
- */
+/// This annotation identifies which name is used by the map-object property related to the annotated member.
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TmxProperty {
-  /**
-   * The name of the annotated member in the context of the TMX map.
-   * 
-   * @return The name of the TMX map-object property.
-   */
+  /// The name of the annotated member in the context of the TMX map.
+  ///
+  /// @return The name of the TMX map-object property.
   String name();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxPropertyInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxPropertyInfo.java
@@ -5,53 +5,39 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Provides rich metadata for a TMX map object property, including canonical English documentation,
- * category grouping, value type, default values, and translation keys for localization.
- */
+/// Provides rich metadata for a TMX map object property, including canonical English documentation,
+/// category grouping, value type, default values, and translation keys for localization.
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TmxPropertyInfo {
 
-  /**
-   * The property name key as stored in TMX map objects.
-   *
-   * @return The TMX property key name.
-   */
+  /// The property name key as stored in TMX map objects.
+  ///
+  /// @return The TMX property key name.
   String name();
 
-  /**
-   * Canonical English description of the property for documentation and tooltips.
-   *
-   * @return The English description.
-   */
+  /// Canonical English description of the property for documentation and tooltips.
+  ///
+  /// @return The English description.
   String description() default "";
 
-  /**
-   * Category or group name for organizing properties in inspectors and docs (e.g. "Combat", "Collision", "Graphics").
-   *
-   * @return The property category.
-   */
+  /// Category or group name for organizing properties in inspectors and docs (e.g. "Combat", "Collision", "Graphics").
+  ///
+  /// @return The property category.
   String category() default "General";
 
-  /**
-   * Expected value type (e.g. "string", "int", "float", "boolean", "color", "enum").
-   *
-   * @return The value type string.
-   */
+  /// Expected value type (e.g. "string", "int", "float", "boolean", "color", "enum").
+  ///
+  /// @return The value type string.
   String type() default "string";
 
-  /**
-   * Default value representation string.
-   *
-   * @return The default value string.
-   */
+  /// Default value representation string.
+  ///
+  /// @return The default value string.
   String defaultValue() default "";
 
-  /**
-   * Localization resource key for translated descriptions.
-   *
-   * @return The resource key.
-   */
+  /// Localization resource key for translated descriptions.
+  ///
+  /// @return The resource key.
   String resourceKey() default "";
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxPropertyMetadataRegistry.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxPropertyMetadataRegistry.java
@@ -12,13 +12,10 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Thread-safe registry that indexes all annotated map object properties and types in LITIengine.
- * <p>
- * Provides canonical English documentation, data types, default values, and category groupings
- * for MCP exposure and in-editor documentation, while resolving translations via {@link Resources#strings()}.
- * </p>
- */
+/// Thread-safe registry that indexes all annotated map object properties and types in LITIengine.
+///
+/// Provides canonical English documentation, data types, default values, and category groupings
+/// for MCP exposure and in-editor documentation, while resolving translations via [Resources#strings()].
 public final class TmxPropertyMetadataRegistry {
   private static final Logger log = Logger.getLogger(TmxPropertyMetadataRegistry.class.getName());
 
@@ -30,12 +27,10 @@ public final class TmxPropertyMetadataRegistry {
       String defaultValue,
       String resourceKey) {
 
-    /**
-     * Gets the localized description if a resource key translation is available,
-     * falling back to the canonical English description.
-     *
-     * @return The localized or canonical description.
-     */
+    /// Gets the localized description if a resource key translation is available,
+    /// falling back to the canonical English description.
+    ///
+    /// @return The localized or canonical description.
     public String getTranslatedDescription() {
       if (resourceKey != null && !resourceKey.isEmpty()) {
         try {
@@ -56,11 +51,9 @@ public final class TmxPropertyMetadataRegistry {
       String description,
       String resourceKey) {
 
-    /**
-     * Gets the localized description if available, falling back to the canonical English description.
-     *
-     * @return The localized or canonical description.
-     */
+    /// Gets the localized description if available, falling back to the canonical English description.
+    ///
+    /// @return The localized or canonical description.
     public String getTranslatedDescription() {
       if (resourceKey != null && !resourceKey.isEmpty()) {
         try {
@@ -146,31 +139,25 @@ public final class TmxPropertyMetadataRegistry {
     }
   }
 
-  /**
-   * Retrieves metadata for a registered TMX property by name.
-   *
-   * @param propertyName The property name key.
-   * @return The {@link PropertyMetadata}, or {@code null} if not registered.
-   */
+  /// Retrieves metadata for a registered TMX property by name.
+  ///
+  /// @param propertyName The property name key.
+  /// @return The [PropertyMetadata], or `null` if not registered.
   public static PropertyMetadata getProperty(String propertyName) {
     return propertyName != null ? PROPERTIES.get(propertyName) : null;
   }
 
-  /**
-   * Retrieves all registered property metadata objects.
-   *
-   * @return Unmodifiable list of property metadata.
-   */
+  /// Retrieves all registered property metadata objects.
+  ///
+  /// @return Unmodifiable list of property metadata.
   public static List<PropertyMetadata> getAllProperties() {
     return Collections.unmodifiableList(new ArrayList<>(PROPERTIES.values()));
   }
 
-  /**
-   * Retrieves all properties belonging to a specific category.
-   *
-   * @param category The category name.
-   * @return List of matching property metadata objects.
-   */
+  /// Retrieves all properties belonging to a specific category.
+  ///
+  /// @param category The category name.
+  /// @return List of matching property metadata objects.
   public static List<PropertyMetadata> getPropertiesByCategory(String category) {
     if (category == null || category.isEmpty()) {
       return getAllProperties();
@@ -184,21 +171,17 @@ public final class TmxPropertyMetadataRegistry {
     return Collections.unmodifiableList(list);
   }
 
-  /**
-   * Retrieves metadata for a map object type.
-   *
-   * @param typeName The type name string.
-   * @return The {@link TypeMetadata}, or {@code null} if not registered.
-   */
+  /// Retrieves metadata for a map object type.
+  ///
+  /// @param typeName The type name string.
+  /// @return The [TypeMetadata], or `null` if not registered.
   public static TypeMetadata getType(String typeName) {
     return typeName != null ? TYPES.get(typeName) : null;
   }
 
-  /**
-   * Retrieves all registered map object type metadata objects.
-   *
-   * @return Unmodifiable list of type metadata.
-   */
+  /// Retrieves all registered map object type metadata objects.
+  ///
+  /// @return Unmodifiable list of type metadata.
   public static List<TypeMetadata> getAllTypes() {
     return Collections.unmodifiableList(new ArrayList<>(TYPES.values()));
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxPropertyMetadataRegistry.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxPropertyMetadataRegistry.java
@@ -19,6 +19,14 @@ import java.util.logging.Logger;
 public final class TmxPropertyMetadataRegistry {
   private static final Logger log = Logger.getLogger(TmxPropertyMetadataRegistry.class.getName());
 
+  /// Documentation and serialization metadata for one TMX property.
+  ///
+  /// @param name The serialized property name.
+  /// @param description The canonical English description.
+  /// @param category The editor grouping.
+  /// @param type The serialized value type.
+  /// @param defaultValue The default represented as text.
+  /// @param resourceKey The optional localization key.
   public record PropertyMetadata(
       String name,
       String description,
@@ -45,6 +53,12 @@ public final class TmxPropertyMetadataRegistry {
     }
   }
 
+  /// Documentation and localization metadata for one TMX object type.
+  ///
+  /// @param typeName The serialized type identifier.
+  /// @param displayName The editor-facing type name.
+  /// @param description The canonical English description.
+  /// @param resourceKey The optional localization key.
   public record TypeMetadata(
       String typeName,
       String displayName,
@@ -78,6 +92,9 @@ public final class TmxPropertyMetadataRegistry {
   private TmxPropertyMetadataRegistry() {
   }
 
+  /// Rebuilds the registry from the engine's annotated TMX model classes.
+  ///
+  /// Existing immutable snapshots are replaced atomically after indexing completes.
   public static synchronized void initialize() {
     Map<String, PropertyMetadata> newProperties = new LinkedHashMap<>();
     Map<String, TypeMetadata> newTypes = new LinkedHashMap<>();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxTypeInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/TmxTypeInfo.java
@@ -5,32 +5,24 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Provides metadata for built-in map object types, including canonical English names,
- * descriptions, and translation keys.
- */
+/// Provides metadata for built-in map object types, including canonical English names,
+/// descriptions, and translation keys.
 @Target({ElementType.TYPE, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TmxTypeInfo {
 
-  /**
-   * Human-readable English display name for the map object type.
-   *
-   * @return The display name.
-   */
+  /// Human-readable English display name for the map object type.
+  ///
+  /// @return The display name.
   String name();
 
-  /**
-   * Canonical English description of the map object type.
-   *
-   * @return The English description.
-   */
+  /// Canonical English description of the map object type.
+  ///
+  /// @return The English description.
   String description() default "";
 
-  /**
-   * Localization resource key for translated descriptions.
-   *
-   * @return The resource key.
-   */
+  /// Localization resource key for translated descriptions.
+  ///
+  /// @return The resource key.
   String resourceKey() default "";
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/package-info.java
@@ -1,0 +1,6 @@
+/// Engine-facing interfaces and utilities for tile maps, layers, tilesets, and terrain data.
+///
+/// The interfaces in this package separate game code from the JAXB-backed TMX implementations in
+/// [de.gurkenlabs.litiengine.environment.tilemap.xml]. Maps are normally obtained through
+/// [de.gurkenlabs.litiengine.resources.Maps].
+package de.gurkenlabs.litiengine.environment.tilemap;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Blueprint.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Blueprint.java
@@ -11,20 +11,14 @@ import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * The {@code Blueprint} class extends the {@code MapObject} class. It represents a blueprint that can contain multiple map objects and provides
- * functionality to build these objects at specified locations.
- */
+/// The `Blueprint` class extends the `MapObject` class. It represents a blueprint that can contain multiple map objects and provides
+/// functionality to build these objects at specified locations.
 @XmlRootElement(name = "template")
 public class Blueprint extends MapObject {
-  /**
-   * Templates in this format typically come from the Tiled editor and only support a single MapObject.
-   */
+  /// Templates in this format typically come from the Tiled editor and only support a single MapObject.
   public static final String TEMPLATE_FILE_EXTENSION = "tx";
 
-  /**
-   * Blueprint in this format support multiple map objects as children (extended template XML).
-   */
+  /// Blueprint in this format support multiple map objects as children (extended template XML).
   public static final String BLUEPRINT_FILE_EXTENSION = "xtx";
 
   @XmlElement(name = "object")
@@ -33,30 +27,24 @@ public class Blueprint extends MapObject {
   @XmlTransient
   private boolean keepIds;
 
-  /**
-   * Initializes a new instance of the {@code Blueprint} map object.
-   */
+  /// Initializes a new instance of the `Blueprint` map object.
   public Blueprint() {
     super();
   }
 
-  /**
-   * Initializes a new instance of the {@code Blueprint} map object.
-   *
-   * @param name       The name of the blueprint.
-   * @param mapObjects The map objects to build the blueprint from.
-   */
+  /// Initializes a new instance of the `Blueprint` map object.
+  ///
+  /// @param name       The name of the blueprint.
+  /// @param mapObjects The map objects to build the blueprint from.
   public Blueprint(String name, MapObject... mapObjects) {
     this(name, false, mapObjects);
   }
 
-  /**
-   * Initializes a new instance of the {@code Blueprint} map object.
-   *
-   * @param name       The name of the blueprint.
-   * @param keepIds    A flag indicating whether the IDs of the specified map objects should be kept.
-   * @param mapObjects The map objects to build the blueprint from.
-   */
+  /// Initializes a new instance of the `Blueprint` map object.
+  ///
+  /// @param name       The name of the blueprint.
+  /// @param keepIds    A flag indicating whether the IDs of the specified map objects should be kept.
+  /// @param mapObjects The map objects to build the blueprint from.
   public Blueprint(String name, boolean keepIds, MapObject... mapObjects) {
     this.keepIds = keepIds;
     this.setType(MapObjectType.AREA.toString());
@@ -76,43 +64,35 @@ public class Blueprint extends MapObject {
     }
   }
 
-  /**
-   * Gets the list of map objects contained in this blueprint.
-   *
-   * @return An iterable collection of map objects.
-   */
+  /// Gets the list of map objects contained in this blueprint.
+  ///
+  /// @return An iterable collection of map objects.
   @XmlTransient
   public Iterable<MapObject> getItems() {
     return this.items;
   }
 
-  /**
-   * Gets a value that indicates whether the IDs if this blueprint's map-objects should be kept. This is currently used when objects are cut and
-   * pasted afterwards.
-   *
-   * @return True if the ids for all {@link IMapObject}s of this {@link Blueprint} should be re-applied after building new instances.
-   */
+  /// Gets a value that indicates whether the IDs if this blueprint's map-objects should be kept. This is currently used when objects are cut and
+  /// pasted afterwards.
+  ///
+  /// @return True if the ids for all [IMapObject]s of this [Blueprint] should be re-applied after building new instances.
   public boolean keepIds() {
     return this.keepIds;
   }
 
-  /**
-   * Builds a list of map objects at the specified location.
-   *
-   * @param location The location where the map objects should be built.
-   * @return A list of built map objects.
-   */
+  /// Builds a list of map objects at the specified location.
+  ///
+  /// @param location The location where the map objects should be built.
+  /// @return A list of built map objects.
   public List<IMapObject> build(Point2D location) {
     return this.build(Math.round((float) location.getX()), Math.round((float) location.getY()));
   }
 
-  /**
-   * Builds a list of map objects at the specified coordinates.
-   *
-   * @param x The x-coordinate where the map objects should be built.
-   * @param y The y-coordinate where the map objects should be built.
-   * @return A list of built map objects.
-   */
+  /// Builds a list of map objects at the specified coordinates.
+  ///
+  /// @param x The x-coordinate where the map objects should be built.
+  /// @param y The y-coordinate where the map objects should be built.
+  /// @return A list of built map objects.
   public List<IMapObject> build(float x, float y) {
     List<IMapObject> builtObjects = new ArrayList<>();
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/BooleanIntegerAdapter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/BooleanIntegerAdapter.java
@@ -2,29 +2,23 @@ package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
-/**
- * Adapter class for converting between Boolean objects and their Integer representations
- * in XML using JAXB.
- */
+/// Adapter class for converting between Boolean objects and their Integer representations
+/// in XML using JAXB.
 public class BooleanIntegerAdapter extends XmlAdapter<Integer, Boolean> {
 
-  /**
-   * Converts an Integer value to a Boolean object.
-   *
-   * @param s the Integer value to be converted
-   * @return the corresponding Boolean object, or null if the input is null
-   */
+  /// Converts an Integer value to a Boolean object.
+  ///
+  /// @param s the Integer value to be converted
+  /// @return the corresponding Boolean object, or null if the input is null
   @Override
   public Boolean unmarshal(Integer s) {
     return s == null ? null : s == 1;
   }
 
-  /**
-   * Converts a Boolean object to its Integer representation.
-   *
-   * @param c the Boolean object to be converted
-   * @return the corresponding Integer representation, or null if the input is null
-   */
+  /// Converts a Boolean object to its Integer representation.
+  ///
+  /// @param c the Boolean object to be converted
+  /// @return the corresponding Integer representation, or null if the input is null
   @Override
   public Integer marshal(Boolean c) {
     if (c == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/ColorAdapter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/ColorAdapter.java
@@ -6,29 +6,23 @@ import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 import de.gurkenlabs.litiengine.util.ColorHelper;
 
-/**
- * Adapter class for converting between Color objects and their String representations
- * in XML using JAXB.
- */
+/// Adapter class for converting between Color objects and their String representations
+/// in XML using JAXB.
 public class ColorAdapter extends XmlAdapter<String, Color> {
 
-  /**
-   * Converts a String value to a Color object.
-   *
-   * @param v the String value to be converted
-   * @return the corresponding Color object
-   */
+  /// Converts a String value to a Color object.
+  ///
+  /// @param v the String value to be converted
+  /// @return the corresponding Color object
   @Override
   public Color unmarshal(String v) {
     return ColorHelper.decode(v);
   }
 
-  /**
-   * Converts a Color object to its String representation.
-   *
-   * @param v the Color object to be converted
-   * @return the corresponding String representation
-   */
+  /// Converts a Color object to its String representation.
+  ///
+  /// @param v the Color object to be converted
+  /// @return the corresponding String representation
   @Override
   public String marshal(Color v) {
     return ColorHelper.encode(v);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomProperty.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomProperty.java
@@ -7,67 +7,53 @@ import java.math.BigDecimal;
 import java.net.URL;
 import java.util.Objects;
 
-/**
- * The {@code CustomProperty} class is an implementation of the {@link ICustomProperty} interface.
- *
- * <p>This class provides functionality for managing custom properties with various data types,
- * including methods for setting and retrieving property values, handling property types, and supporting XML serialization and deserialization.
- */
+/// The `CustomProperty` class is an implementation of the [ICustomProperty] interface.
+///
+/// This class provides functionality for managing custom properties with various data types,
+/// including methods for setting and retrieving property values, handling property types, and supporting XML serialization and deserialization.
 public class CustomProperty implements ICustomProperty {
 
   private String type;
   private String value;
   private URL location;
 
-  /**
-   * Instantiates a new {@code CustomProperty} instance.
-   *
-   * <p>
-   * The default type for a custom property is {@code string} if not explicitly specified.
-   * </p>
-   */
+  /// Instantiates a new `CustomProperty` instance.
+  ///
+  /// The default type for a custom property is `string` if not explicitly specified.
   public CustomProperty() {
     this.type = CustomPropertyType.STRING;
     this.value = "";
   }
 
-  /**
-   * Instantiates a new {@code CustomProperty} instance.
-   *
-   * @param value The value of this custom property.
-   */
+  /// Instantiates a new `CustomProperty` instance.
+  ///
+  /// @param value The value of this custom property.
   public CustomProperty(String value) {
     this.type = CustomPropertyType.STRING;
     this.value = Objects.requireNonNull(value);
   }
 
-  /**
-   * Instantiates a new {@code CustomProperty} instance.
-   *
-   * @param type  The type of this custom property.
-   * @param value The value of this custom property.
-   */
+  /// Instantiates a new `CustomProperty` instance.
+  ///
+  /// @param type  The type of this custom property.
+  /// @param value The value of this custom property.
   public CustomProperty(String type, String value) {
     this.type = Objects.requireNonNull(type);
     this.value = Objects.requireNonNull(value);
   }
 
-  /**
-   * Instantiates a new {@code CustomProperty} instance.
-   *
-   * @param location The location of the file represented by this custom property.
-   */
+  /// Instantiates a new `CustomProperty` instance.
+  ///
+  /// @param location The location of the file represented by this custom property.
   public CustomProperty(URL location) {
     this.type = CustomPropertyType.FILE;
     this.value = location.toExternalForm();
     this.location = location;
   }
 
-  /**
-   * Instantiates a new {@code CustomProperty} instance by copying from the specified instance.
-   *
-   * @param propertyToBeCopied The property to be copied.
-   */
+  /// Instantiates a new `CustomProperty` instance by copying from the specified instance.
+  ///
+  /// @param propertyToBeCopied The property to be copied.
   public CustomProperty(ICustomProperty propertyToBeCopied) {
     this.type = propertyToBeCopied.getType();
     this.value = propertyToBeCopied.getAsString();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyAdapter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyAdapter.java
@@ -19,20 +19,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * The {@code CustomPropertyAdapter} class is an implementation of the {@link XmlAdapter} that facilitates the conversion between a
- * {@link PropertyList} and a {@link Map} of custom properties.
- *
- * <p>This adapter is used for XML serialization and deserialization of custom properties,
- * ensuring proper handling of property types, values, and locations.
- */
+/// The `CustomPropertyAdapter` class is an implementation of the [XmlAdapter] that facilitates the conversion between a
+/// [PropertyList] and a [Map] of custom properties.
+///
+/// This adapter is used for XML serialization and deserialization of custom properties,
+/// ensuring proper handling of property types, values, and locations.
 public class CustomPropertyAdapter extends XmlAdapter<CustomPropertyAdapter.PropertyList, Map<String, ICustomProperty>> {
-  /**
-   * Represents a custom property with attributes for name, type, value, and location.
-   *
-   * <p>This class is used for XML serialization and deserialization of individual properties.
-   * It implements the {@link Comparable} interface to allow sorting by property name.
-   */
+  /// Represents a custom property with attributes for name, type, value, and location.
+  ///
+  /// This class is used for XML serialization and deserialization of individual properties.
+  /// It implements the [Comparable] interface to allow sorting by property name.
   @XmlAccessorType(XmlAccessType.FIELD) static class Property implements Comparable<Property> {
     @XmlAttribute String name;
     @XmlAttribute String type;
@@ -44,14 +40,12 @@ public class CustomPropertyAdapter extends XmlAdapter<CustomPropertyAdapter.Prop
       // keep for serialization
     }
 
-    /**
-     * Constructs a new {@code Property} instance with the specified name and type.
-     *
-     * <p>If the provided type is {@code null} or invalid, it defaults to {@code CustomPropertyType.STRING}.
-     *
-     * @param name the name of the property
-     * @param type the type of the property, which must be a valid {@code CustomPropertyType}
-     */
+    /// Constructs a new `Property` instance with the specified name and type.
+    ///
+    /// If the provided type is `null` or invalid, it defaults to `CustomPropertyType.STRING`.
+    ///
+    /// @param name the name of the property
+    /// @param type the type of the property, which must be a valid `CustomPropertyType`
     Property(String name, String type) {
       this.name = name;
       this.type = type == null || !CustomPropertyType.isValid(type) ? CustomPropertyType.STRING : type;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/CustomPropertyProvider.java
@@ -19,31 +19,25 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
-/**
- * The {@code CustomPropertyProvider} class provides an implementation of the {@link ICustomPropertyProvider} interface.
- *
- * <p>This class manages custom properties using a map, allowing for the storage,
- * retrieval, and manipulation of various property types. It supports operations such as setting, getting, and removing properties, as well as
- * handling default values and type conversions.
- */
+/// The `CustomPropertyProvider` class provides an implementation of the [ICustomPropertyProvider] interface.
+///
+/// This class manages custom properties using a map, allowing for the storage,
+/// retrieval, and manipulation of various property types. It supports operations such as setting, getting, and removing properties, as well as
+/// handling default values and type conversions.
 @XmlAccessorType(XmlAccessType.FIELD) public class CustomPropertyProvider implements ICustomPropertyProvider {
   @XmlElement @XmlJavaTypeAdapter(CustomPropertyAdapter.class) private Map<String, ICustomProperty> properties;
 
-  /**
-   * Default constructor for the {@code CustomPropertyProvider} class.
-   *
-   * <p>Initializes the properties map as a {@link Hashtable} to ensure
-   * that null keys and null values are not allowed.
-   */
+  /// Default constructor for the `CustomPropertyProvider` class.
+  ///
+  /// Initializes the properties map as a [Hashtable] to ensure
+  /// that null keys and null values are not allowed.
   public CustomPropertyProvider() {
     this.properties = new Hashtable<>(); // use Hashtable because it rejects null keys and null values
   }
 
-  /**
-   * Copy Constructor for copying instances of CustomPropertyProviders.
-   *
-   * @param propertyProviderToBeCopied the PropertyProvider we want to copy
-   */
+  /// Copy Constructor for copying instances of CustomPropertyProviders.
+  ///
+  /// @param propertyProviderToBeCopied the PropertyProvider we want to copy
   public CustomPropertyProvider(ICustomPropertyProvider propertyProviderToBeCopied) {
     this.properties = propertyProviderToBeCopied.getProperties().entrySet().stream()
       .collect(Collectors.toMap(Entry::getKey, e -> new CustomProperty((e.getValue()))));

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/DecimalFloatAdapter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/DecimalFloatAdapter.java
@@ -2,40 +2,33 @@ package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
-/**
- * An adapter for converting between `String` and `Float` values during XML serialization and deserialization.
- *
- * <p>This implementation ensures that float values are serialized as integers if they have no digits
- * after the decimal point. For example:
- * <ul>
- *   <li>A float value of `5.0` will be serialized as `"5"`.</li>
- *   <li>A float value of `5.5` will remain serialized as `"5.5"`.</li>
- * </ul>
- */
+/// An adapter for converting between `String` and `Float` values during XML serialization and deserialization.
+///
+/// This implementation ensures that float values are serialized as integers if they have no digits
+/// after the decimal point. For example:
+///
+/// - A float value of `5.0` will be serialized as `"5"`.
+/// - A float value of `5.5` will remain serialized as `"5.5"`.
 public class DecimalFloatAdapter extends XmlAdapter<String, Float> {
 
-  /**
-   * Converts a `String` value from the XML into a `Float` object.
-   *
-   * @param v The string value to be converted.
-   * @return The parsed `Float` value.
-   * @throws Exception If the string cannot be parsed as a float.
-   */
+  /// Converts a `String` value from the XML into a `Float` object.
+  ///
+  /// @param v The string value to be converted.
+  /// @return The parsed `Float` value.
+  /// @throws Exception If the string cannot be parsed as a float.
   @Override
   public Float unmarshal(String v) throws Exception {
     return Float.parseFloat(v);
   }
 
-  /**
-   * Converts a `Float` value into a `String` for XML serialization.
-   *
-   * <p>If the float value is `null`, this method returns `null`. If the float value has no digits
-   * after the decimal point, it is serialized as an integer string. Otherwise, it is serialized as a standard float string.
-   *
-   * @param v The float value to be converted.
-   * @return The string representation of the float value.
-   * @throws Exception If an error occurs during conversion.
-   */
+  /// Converts a `Float` value into a `String` for XML serialization.
+  ///
+  /// If the float value is `null`, this method returns `null`. If the float value has no digits
+  /// after the decimal point, it is serialized as an integer string. Otherwise, it is serialized as a standard float string.
+  ///
+  /// @param v The float value to be converted.
+  /// @return The string representation of the float value.
+  /// @throws Exception If an error occurs during conversion.
   @Override
   public String marshal(Float v) throws Exception {
     if (v == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/GroupLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/GroupLayer.java
@@ -13,9 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Represents a group layer in a tile map. This class extends the {@link Layer} class and implements the {@link IGroupLayer} interface.
- */
+/// Represents a group layer in a tile map. This class extends the [Layer] class and implements the [IGroupLayer] interface.
 public class GroupLayer extends Layer implements IGroupLayer {
 
   @XmlElements({
@@ -36,19 +34,15 @@ public class GroupLayer extends Layer implements IGroupLayer {
   private final transient List<IImageLayer> imageLayers = Collections.unmodifiableList(this.rawImageLayers);
   private final transient List<IGroupLayer> groupLayers = Collections.unmodifiableList(this.rawGroupLayers);
 
-  /**
-   * Creates an empty group for map editors and programmatic map construction.
-   */
+  /// Creates an empty group for map editors and programmatic map construction.
   public GroupLayer() {
     this.layers = new ArrayList<>();
   }
 
-  /**
-   * Copy constructor for the GroupLayer class. Creates a new instance of the GroupLayer class by copying the properties from the provided GroupLayer
-   * object.
-   *
-   * @param original The original GroupLayer object to copy from.
-   */
+  /// Copy constructor for the GroupLayer class. Creates a new instance of the GroupLayer class by copying the properties from the provided GroupLayer
+  /// object.
+  ///
+  /// @param original The original GroupLayer object to copy from.
   public GroupLayer(GroupLayer original) {
     super(original);
     this.layers = new ArrayList<>();
@@ -111,11 +105,9 @@ public class GroupLayer extends Layer implements IGroupLayer {
     }
   }
 
-  /**
-   * Removes the specified layer from the appropriate raw layer list based on its type.
-   *
-   * @param layer The layer to be removed.
-   */
+  /// Removes the specified layer from the appropriate raw layer list based on its type.
+  ///
+  /// @param layer The layer to be removed.
   private void layerRemoved(ILayer layer) {
     if (layer instanceof ITileLayer) {
       this.rawTileLayers.remove(layer);
@@ -131,11 +123,9 @@ public class GroupLayer extends Layer implements IGroupLayer {
     }
   }
 
-  /**
-   * Adds the specified layer to the appropriate raw layer list based on its type.
-   *
-   * @param layer The layer to be added.
-   */
+  /// Adds the specified layer to the appropriate raw layer list based on its type.
+  ///
+  /// @param layer The layer to be added.
   private void layerAdded(ILayer layer) {
     if (layer instanceof ITileLayer itl) {
       this.rawTileLayers.add(itl);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/ImageLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/ImageLayer.java
@@ -8,10 +8,8 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.awt.Color;
 import java.net.URL;
 
-/**
- * Represents an image layer in a tile map. This class extends the {@link Layer} class and implements the {@link IImageLayer} interface. It includes
- * attributes for repeating the image horizontally and vertically, the image itself, and a transparent color.
- */
+/// Represents an image layer in a tile map. This class extends the [Layer] class and implements the [IImageLayer] interface. It includes
+/// attributes for repeating the image horizontally and vertically, the image itself, and a transparent color.
 public class ImageLayer extends Layer implements IImageLayer {
 
   @XmlAttribute
@@ -27,19 +25,15 @@ public class ImageLayer extends Layer implements IImageLayer {
   @XmlJavaTypeAdapter(ColorAdapter.class)
   private Color trans;
 
-  /**
-   * Default no-args constructor for the {@link ImageLayer} class. Initializes a new instance of the {@link ImageLayer} class with default values.
-   */
+  /// Default no-args constructor for the [ImageLayer] class. Initializes a new instance of the [ImageLayer] class with default values.
   public ImageLayer() {
     //  default no-args constructor
   }
 
-  /**
-   * Copy constructor for the {@link ImageLayer} class. Creates a new instance of the {@link ImageLayer} class by copying the properties from the
-   * provided {@link ImageLayer} object.
-   *
-   * @param original The original {@link ImageLayer} object to copy from.
-   */
+  /// Copy constructor for the [ImageLayer] class. Creates a new instance of the [ImageLayer] class by copying the properties from the
+  /// provided [ImageLayer] object.
+  ///
+  /// @param original The original [ImageLayer] object to copy from.
   public ImageLayer(ImageLayer original) {
     super(original);
     this.repeatx = original.repeatHorizontally();
@@ -92,12 +86,10 @@ public class ImageLayer extends Layer implements IImageLayer {
     return super.getOffsetY();
   }
 
-  /**
-   * Checks if the map is infinite. This method determines whether the map associated with this layer is infinite and is an instance of
-   * {@code TmxMap}.
-   *
-   * @return {@code true} if the map is infinite and an instance of {@code TmxMap}; {@code false} otherwise.
-   */
+  /// Checks if the map is infinite. This method determines whether the map associated with this layer is infinite and is an instance of
+  /// `TmxMap`.
+  ///
+  /// @return `true` if the map is infinite and an instance of `TmxMap`; `false` otherwise.
   private boolean isInfiniteMap() {
     return this.getMap() != null && this.getMap().isInfinite() && this.getMap() instanceof TmxMap;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/InvalidTileLayerException.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/InvalidTileLayerException.java
@@ -2,9 +2,7 @@ package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
 import java.io.Serial;
 
-/**
- * Thrown when an exception occurs while parsing tile data.
- */
+/// Thrown when an exception occurs while parsing tile data.
 public class InvalidTileLayerException extends TmxException {
 
   @Serial private static final long serialVersionUID = -863575375538927793L;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
@@ -12,10 +12,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.geom.Point2D;
 
-/**
- * Represents an abstract layer in a tile map. This class extends the {@link CustomPropertyProvider} class and implements the {@link ILayer}
- * interface.
- */
+/// Represents an abstract layer in a tile map. This class extends the [CustomPropertyProvider] class and implements the [ILayer]
+/// interface.
 public abstract class Layer extends CustomPropertyProvider implements ILayer {
 
   @XmlAttribute
@@ -60,19 +58,15 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer {
   private transient RenderType renderType;
   private transient boolean renderTypeLoaded;
 
-  /**
-   * Default constructor for the {@link Layer} class. Initializes a new instance of the {@link Layer} class with default values.
-   */
+  /// Default constructor for the [Layer] class. Initializes a new instance of the [Layer] class with default values.
   protected Layer() {
     super();
   }
 
-  /**
-   * Copy constructor for the {@link Layer} class. Creates a new instance of the {@link Layer} class by copying the properties from the provided
-   * {@link Layer} object.
-   *
-   * @param layerToBeCopied The {@link Layer} object to copy from.
-   */
+  /// Copy constructor for the [Layer] class. Creates a new instance of the [Layer] class by copying the properties from the provided
+  /// [Layer] object.
+  ///
+  /// @param layerToBeCopied The [Layer] object to copy from.
   protected Layer(Layer layerToBeCopied) {
     super(layerToBeCopied);
     this.setWidth(layerToBeCopied.getWidth());
@@ -92,11 +86,9 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer {
     this.id = id;
   }
 
-  /**
-   * Gets the height.
-   *
-   * @return the height
-   */
+  /// Gets the height.
+  ///
+  /// @return the height
   @Override
   public int getHeight() {
     if (this.height == null) {
@@ -196,11 +188,9 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer {
     return new Dimension(this.getWidth(), this.getHeight());
   }
 
-  /**
-   * Gets the width.
-   *
-   * @return the width
-   */
+  /// Gets the width.
+  ///
+  /// @return the width
   @Override
   public int getWidth() {
     if (this.width == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MapImage.java
@@ -32,19 +32,15 @@ public class MapImage extends CustomPropertyProvider implements IMapImage {
   @XmlTransient
   private URL absolutePath;
 
-  /**
-   * Instantiates a new {@code MapImage} instance.
-   */
+  /// Instantiates a new `MapImage` instance.
   public MapImage() {
     super();
   }
 
-  /**
-   * Instantiates a new {@code MapImage} instance by copying the specified original.
-   *
-   * @param original
-   *          the original we want to copy
-   */
+  /// Instantiates a new `MapImage` instance by copying the specified original.
+  ///
+  /// @param original
+  /// the original we want to copy
   public MapImage(MapImage original) {
     super(original);
 
@@ -143,12 +139,10 @@ public class MapImage extends CustomPropertyProvider implements IMapImage {
     return this.getTransparentColor().equals(other.getTransparentColor()) && this.getAbsoluteSourcePath().equals(other.getAbsoluteSourcePath());
   }
 
-  /**
-   * Computes a hash code for this map image. The hash code for a map image is equal to the hash code of its absolute
-   * source path xor the hash code of its transparent color.
-   *
-   * @return The hash code for this map image
-   */
+  /// Computes a hash code for this map image. The hash code for a map image is equal to the hash code of its absolute
+  /// source path xor the hash code of its transparent color.
+  ///
+  /// @return The hash code for this map image
   @Override
   public int hashCode() {
     return this.getAbsoluteSourcePath().hashCode() ^ this.getTransparentColor().hashCode();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObject.java
@@ -76,30 +76,23 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
 
   private transient MapObjectLayer layer;
 
-  /**
-   * Instantiates a new {@code MapObject} instance.
-   */
+  /// Instantiates a new `MapObject` instance.
   public MapObject() {}
 
-  /**
-   * Instantiates a new {@code MapObject} instance.
-   *
-   * @param type
-   *          The type of this map object.
-   */
+  /// Instantiates a new `MapObject` instance.
+  ///
+  /// @param type
+  /// The type of this map object.
   public MapObject(String type) {
     this.type = type;
   }
 
-  /**
-   * Instantiates a new {@code MapObject} instance by copying the specified original instance.
-   * <p>
-   * This variant of the constructor will assign an entirely new ID to the newly created MapObject.
-   * </p>
-   *
-   * @param original
-   *          the MapObject we want to copy
-   */
+  /// Instantiates a new `MapObject` instance by copying the specified original instance.
+  ///
+  /// This variant of the constructor will assign an entirely new ID to the newly created MapObject.
+  ///
+  /// @param original
+  /// the MapObject we want to copy
   public MapObject(MapObject original) {
     this(original, Game.world().environment().getNextMapId(), true);
   }
@@ -122,30 +115,25 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
     this.point = original.point;
   }
 
-  /**
-   * Instantiates a new {@code MapObject} instance by copying the specified original instance.
-   * <p>
-   * This variant of the constructor lets you decide if the copy instance will get the same ID as the old MapObject or get
-   * a new ID.
-   * </p>
-   *
-   * @param original
-   *          the MapObject we want to copy
-   * @param keepID
-   *          decide if the new instance will adopt the old MapObject's ID or get a new, unique one.
-   */
+  /// Instantiates a new `MapObject` instance by copying the specified original instance.
+  ///
+  /// This variant of the constructor lets you decide if the copy instance will get the same ID as the old MapObject or get
+  /// a new ID.
+  ///
+  /// @param original
+  /// the MapObject we want to copy
+  /// @param keepID
+  /// decide if the new instance will adopt the old MapObject's ID or get a new, unique one.
   public MapObject(MapObject original, boolean keepID) {
     this(original, keepID ? original.getId() : Game.world().environment().getNextMapId(), true);
   }
 
-  /**
-   * Instantiates a new {@code MapObject} instance by copying the specified original instance.
-   *
-   * @param original
-   *          the MapObject we want to copy
-   * @param id
-   *          The id of this instance.
-   */
+  /// Instantiates a new `MapObject` instance by copying the specified original instance.
+  ///
+  /// @param original
+  /// the MapObject we want to copy
+  /// @param id
+  /// The id of this instance.
   public MapObject(MapObject original, int id) {
     this(original, id, true);
   }
@@ -204,11 +192,9 @@ public class MapObject extends CustomPropertyProvider implements IMapObject {
     return this.name;
   }
 
-  /**
-   * Gets the type.
-   *
-   * @return the type
-   */
+  /// Gets the type.
+  ///
+  /// @return the type
   @Override
   public String getType() {
     return this.type;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObjectLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MapObjectLayer.java
@@ -29,19 +29,15 @@ public class MapObjectLayer extends Layer implements IMapObjectLayer {
 
   private transient boolean added;
 
-  /**
-   * Instantiates a new {@code MapObjectLayer} instance.
-   */
+  /// Instantiates a new `MapObjectLayer` instance.
   public MapObjectLayer() {
     super();
   }
 
-  /**
-   * Instantiates a new {@code MapObjectLayer} instance by copying from the specified original.
-   *
-   * @param original
-   *          the layer we want to copy
-   */
+  /// Instantiates a new `MapObjectLayer` instance by copying from the specified original.
+  ///
+  /// @param original
+  /// the layer we want to copy
   public MapObjectLayer(MapObjectLayer original) {
     this(original, false);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MissingTmxResourceException.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/MissingTmxResourceException.java
@@ -2,9 +2,7 @@ package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
 import java.io.Serial;
 
-/**
- * Thrown to indicate that an external resource for a TMX file could not be found or loaded.
- */
+/// Thrown to indicate that an external resource for a TMX file could not be found or loaded.
 public class MissingTmxResourceException extends TmxException {
 
   @Serial private static final long serialVersionUID = 2649018991304386841L;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/NumberAdapter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/NumberAdapter.java
@@ -2,17 +2,14 @@ package de.gurkenlabs.litiengine.environment.tilemap.xml;
 
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
-/**
- * XML adapter that converts between a {@link String} representation and a generic {@link Number}.
- * <p>
- * Used to serialize {@code Number}-typed fields of generic classes (e.g.
- * {@link de.gurkenlabs.litiengine.attributes.Attribute}) where the concrete numeric type cannot be
- * recovered at unmarshalling time. The adapter always returns a {@link Double} when the value
- * contains a decimal point (or scientific notation) and a {@link Long} otherwise. Consumers are
- * expected to convert the returned {@code Number} to the desired concrete type via
- * {@link Number#floatValue()}, {@link Number#longValue()}, etc.
- * </p>
- */
+/// XML adapter that converts between a [String] representation and a generic [Number].
+///
+/// Used to serialize `Number`-typed fields of generic classes (e.g.
+/// [de.gurkenlabs.litiengine.attributes.Attribute]) where the concrete numeric type cannot be
+/// recovered at unmarshalling time. The adapter always returns a [Double] when the value
+/// contains a decimal point (or scientific notation) and a [Long] otherwise. Consumers are
+/// expected to convert the returned `Number` to the desired concrete type via
+/// [Number#floatValue()], [Number#longValue()], etc.
 public class NumberAdapter extends XmlAdapter<String, Number> {
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/PolyShape.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/PolyShape.java
@@ -14,20 +14,16 @@ public class PolyShape implements IPolyShape {
   @XmlJavaTypeAdapter(PolylineAdapter.class)
   private List<Point2D> points;
 
-  /**
-   * Instantiates a new {@code PolyShape} instance.
-   */
+  /// Instantiates a new `PolyShape` instance.
   public PolyShape() {
     super();
     this.points = new ArrayList<>();
   }
 
-  /**
-   * Instantiates a new {@code PolyShape} instance by copying from the specified original.
-   *
-   * @param original
-   *          The poly line to be copied.
-   */
+  /// Instantiates a new `PolyShape` instance by copying from the specified original.
+  ///
+  /// @param original
+  /// The poly line to be copied.
   public PolyShape(IPolyShape original) {
     this();
     if (original == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Tile.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Tile.java
@@ -35,17 +35,13 @@ public class Tile extends CustomPropertyProvider implements ITile {
   private transient boolean flippedVertically;
   private transient boolean flipped;
 
-  /**
-   * Instantiates a new {@code Tile} instance.
-   */
+  /// Instantiates a new `Tile` instance.
   public Tile() {
   }
 
-  /**
-   * Instantiates a new {@code Tile} instance with the same attributes as a given {@code Tile}.
-   *
-   * @param original The original tile from which the values will be copied to this new instance.
-   */
+  /// Instantiates a new `Tile` instance with the same attributes as a given `Tile`.
+  ///
+  /// @param original The original tile from which the values will be copied to this new instance.
   public Tile(Tile original) {
     this.flipped = original.isFlipped();
     this.flippedDiagonally = original.isFlippedDiagonally();
@@ -56,14 +52,12 @@ public class Tile extends CustomPropertyProvider implements ITile {
     this.tileCoordinate = original.getTileCoordinate();
   }
 
-  /**
-   * Instantiates a new {@code Tile} instance.
-   *
-   * @param gidBitmask The grid ID bitmask used to identify flags of this instance.
-   * @see Tile#FLIPPED_HORIZONTALLY_FLAG
-   * @see Tile#FLIPPED_DIAGONALLY_FLAG
-   * @see Tile#FLIPPED_VERTICALLY_FLAG
-   */
+  /// Instantiates a new `Tile` instance.
+  ///
+  /// @param gidBitmask The grid ID bitmask used to identify flags of this instance.
+  /// @see Tile#FLIPPED_HORIZONTALLY_FLAG
+  /// @see Tile#FLIPPED_DIAGONALLY_FLAG
+  /// @see Tile#FLIPPED_VERTICALLY_FLAG
   public Tile(int gidBitmask) {
     // Clear the flags
     this.flippedDiagonally = (gidBitmask & FLIPPED_DIAGONALLY_FLAG) != 0;
@@ -192,20 +186,16 @@ public class Tile extends CustomPropertyProvider implements ITile {
     return this.getGridId() + String.valueOf(this.getTilesetEntry());
   }
 
-  /**
-   * Sets the tileset entry for this tile.
-   *
-   * @param entry The tileset entry to set.
-   */
+  /// Sets the tileset entry for this tile.
+  ///
+  /// @param entry The tileset entry to set.
   void setTilesetEntry(ITilesetEntry entry) {
     this.tilesetEntry = entry;
   }
 
-  /**
-   * Sets the grid ID for this tile.
-   *
-   * @param gid The grid ID to set.
-   */
+  /// Sets the grid ID for this tile.
+  ///
+  /// @param gid The grid ID to set.
   void setGridId(int gid) {
     this.flippedDiagonally = (gid & FLIPPED_DIAGONALLY_FLAG) != 0;
     this.flippedHorizontally = (gid & FLIPPED_HORIZONTALLY_FLAG) != 0;
@@ -214,11 +204,9 @@ public class Tile extends CustomPropertyProvider implements ITile {
     this.gid = gid & ~(FLIPPED_HORIZONTALLY_FLAG | FLIPPED_VERTICALLY_FLAG | FLIPPED_DIAGONALLY_FLAG);
   }
 
-  /**
-   * Sets the tile coordinate.
-   *
-   * @param tileCoordinate the new tile coordinate
-   */
+  /// Sets the tile coordinate.
+  ///
+  /// @param tileCoordinate the new tile coordinate
   void setTileCoordinate(final Point tileCoordinate) {
     this.tileCoordinate = tileCoordinate;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TileChunk.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TileChunk.java
@@ -5,9 +5,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlValue;
 
-/**
- * This class represents a chunk of tiles in an infinite map.
- */
+/// This class represents a chunk of tiles in an infinite map.
 @XmlRootElement(name = "chunk")
 public class TileChunk implements Comparable<TileChunk> {
   @XmlAttribute

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TileData.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TileData.java
@@ -25,74 +25,50 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.InflaterInputStream;
 
-/**
- * Represents the tile data for a tile map. This class handles the encoding, compression, and storage of tile data.
- */
+/// Represents the tile data for a tile map. This class handles the encoding, compression, and storage of tile data.
 public class TileData {
   private static final Logger log = Logger.getLogger(TileData.class.getName());
 
-  /**
-   * Utility class for tile data encoding types. Provides constants and validation methods for encoding types.
-   */
+  /// Utility class for tile data encoding types. Provides constants and validation methods for encoding types.
   public static class Encoding {
-    /**
-     * Constant for Base64 encoding.
-     */
+    /// Constant for Base64 encoding.
     public static final String BASE64 = "base64";
 
-    /**
-     * Constant for CSV encoding.
-     */
+    /// Constant for CSV encoding.
     public static final String CSV = "csv";
 
-    /**
-     * Private constructor to prevent instantiation.
-     */
+    /// Private constructor to prevent instantiation.
     private Encoding() {
     }
 
-    /**
-     * Validates if the provided encoding is valid.
-     *
-     * @param encoding The encoding to validate.
-     * @return {@code true} if the encoding is valid, {@code false} otherwise.
-     */
+    /// Validates if the provided encoding is valid.
+    ///
+    /// @param encoding The encoding to validate.
+    /// @return `true` if the encoding is valid, `false` otherwise.
     public static boolean isValid(String encoding) {
       return encoding != null && !encoding.isEmpty() && (encoding.equals(BASE64) || encoding.equals(CSV));
     }
   }
 
-  /**
-   * Utility class for tile data compression types. Provides constants and validation methods for compression types.
-   */
+  /// Utility class for tile data compression types. Provides constants and validation methods for compression types.
   public static class Compression {
-    /**
-     * Constant for GZIP compression.
-     */
+    /// Constant for GZIP compression.
     public static final String GZIP = "gzip";
 
-    /**
-     * Constant for ZLIB compression.
-     */
+    /// Constant for ZLIB compression.
     public static final String ZLIB = "zlib";
 
-    /**
-     * Constant for no compression.
-     */
+    /// Constant for no compression.
     public static final String NONE = null;
 
-    /**
-     * Private constructor to prevent instantiation.
-     */
+    /// Private constructor to prevent instantiation.
     private Compression() {
     }
 
-    /**
-     * Validates if the provided compression is valid.
-     *
-     * @param compression The compression to validate.
-     * @return {@code true} if the compression is valid, {@code false} otherwise.
-     */
+    /// Validates if the provided compression is valid.
+    ///
+    /// @param compression The compression to validate.
+    /// @return `true` if the compression is valid, `false` otherwise.
     public static boolean isValid(String compression) {
       // null equals no compression which is an accepted value
       return compression == null || !compression.isEmpty() && (compression.equals(GZIP) || compression.equals(ZLIB));
@@ -139,23 +115,19 @@ public class TileData {
   @XmlTransient
   private boolean dirty;
 
-  /**
-   * Default constructor for the {@code TileData} class. This constructor is required for serialization purposes.
-   */
+  /// Default constructor for the `TileData` class. This constructor is required for serialization purposes.
   public TileData() {
     // keep for serialization
   }
 
-  /**
-   * Constructs a new {@code TileData} instance with the specified parameters.
-   *
-   * @param tiles       The list of tiles.
-   * @param width       The width of the tile data.
-   * @param height      The height of the tile data.
-   * @param encoding    The encoding type of the tile data.
-   * @param compression The compression type of the tile data.
-   * @throws TmxException If the encoding or compression type is invalid.
-   */
+  /// Constructs a new `TileData` instance with the specified parameters.
+  ///
+  /// @param tiles       The list of tiles.
+  /// @param width       The width of the tile data.
+  /// @param height      The height of the tile data.
+  /// @param encoding    The encoding type of the tile data.
+  /// @param compression The compression type of the tile data.
+  /// @throws TmxException If the encoding or compression type is invalid.
   public TileData(List<Tile> tiles, int width, int height, String encoding, String compression) throws TmxException {
     if (!Encoding.isValid(encoding)) {
       throw new TmxException(
@@ -175,12 +147,10 @@ public class TileData {
     this.dirty = true;
   }
 
-  /**
-   * Copy constructor for the {@link TileData} class. Creates a new instance of the {@link TileData} class by copying the properties from the provided
-   * {@link TileData} object.
-   *
-   * @param original The original {@link TileData} object to copy from.
-   */
+  /// Copy constructor for the [TileData] class. Creates a new instance of the [TileData] class by copying the properties from the provided
+  /// [TileData] object.
+  ///
+  /// @param original The original [TileData] object to copy from.
   public TileData(TileData original) {
     this.encoding = original.getEncoding();
     this.compression = original.getCompression();
@@ -230,29 +200,23 @@ public class TileData {
     return this.value;
   }
 
-  /**
-   * Sets the encoding type for the tile data.
-   *
-   * @param encoding The encoding type to set.
-   */
+  /// Sets the encoding type for the tile data.
+  ///
+  /// @param encoding The encoding type to set.
   public void setEncoding(String encoding) {
     this.encoding = encoding;
   }
 
-  /**
-   * Sets the compression type for the tile data.
-   *
-   * @param compression The compression type to set.
-   */
+  /// Sets the compression type for the tile data.
+  ///
+  /// @param compression The compression type to set.
   public void setCompression(String compression) {
     this.compression = compression;
   }
 
-  /**
-   * Sets the value for the tile data and updates the raw value list.
-   *
-   * @param value The value to set.
-   */
+  /// Sets the value for the tile data and updates the raw value list.
+  ///
+  /// @param value The value to set.
   public void setValue(String value) {
     this.value = value;
     if (this.rawValue == null) {
@@ -267,12 +231,10 @@ public class TileData {
     this.dirty = true;
   }
 
-  /**
-   * Retrieves the list of tiles for the tile data. If the tiles are already parsed, it returns the cached list. Otherwise, it parses the tile data
-   * based on the encoding and compression.
-   *
-   * @return The list of tiles.
-   */
+  /// Retrieves the list of tiles for the tile data. If the tiles are already parsed, it returns the cached list. Otherwise, it parses the tile data
+  /// based on the encoding and compression.
+  ///
+  /// @return The list of tiles.
   public List<Tile> getTiles() {
     if (this.tiles != null) {
       return this.tiles;
@@ -296,13 +258,11 @@ public class TileData {
     return this.tiles;
   }
 
-  /**
-   * Encodes the provided {@code TileData} instance into a string based on its encoding type.
-   *
-   * @param data The {@code TileData} instance to encode.
-   * @return The encoded string representation of the tile data.
-   * @throws IOException If an I/O error occurs during encoding.
-   */
+  /// Encodes the provided `TileData` instance into a string based on its encoding type.
+  ///
+  /// @param data The `TileData` instance to encode.
+  /// @return The encoded string representation of the tile data.
+  /// @throws IOException If an I/O error occurs during encoding.
   public static String encode(TileData data) throws IOException {
     if (data.getEncoding() == null) {
       return null;
@@ -317,12 +277,10 @@ public class TileData {
     return null;
   }
 
-  /**
-   * Encodes the tile data into a CSV string format.
-   *
-   * @param data The {@code TileData} instance containing the tile data to encode.
-   * @return The encoded CSV string representation of the tile data.
-   */
+  /// Encodes the tile data into a CSV string format.
+  ///
+  /// @param data The `TileData` instance containing the tile data to encode.
+  /// @return The encoded CSV string representation of the tile data.
   private static String encodeCsv(TileData data) {
     StringBuilder sb = new StringBuilder();
     if (!data.getTiles().isEmpty()) {
@@ -344,13 +302,11 @@ public class TileData {
     return sb.toString();
   }
 
-  /**
-   * Encodes the tile data into a Base64 string format.
-   *
-   * @param data The {@code TileData} instance containing the tile data to encode.
-   * @return The encoded Base64 string representation of the tile data.
-   * @throws IOException If an I/O error occurs during encoding.
-   */
+  /// Encodes the tile data into a Base64 string format.
+  ///
+  /// @param data The `TileData` instance containing the tile data to encode.
+  /// @return The encoded Base64 string representation of the tile data.
+  /// @throws IOException If an I/O error occurs during encoding.
   private static String encodeBase64(TileData data) throws IOException {
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
       OutputStream out = baos;
@@ -388,31 +344,25 @@ public class TileData {
     }
   }
 
-  /**
-   * Sets the minimum chunk offsets for the tile data.
-   *
-   * @param x The minimum chunk offset on the x-axis.
-   * @param y The minimum chunk offset on the y-axis.
-   */
+  /// Sets the minimum chunk offsets for the tile data.
+  ///
+  /// @param x The minimum chunk offset on the x-axis.
+  /// @param y The minimum chunk offset on the y-axis.
   protected void setMinChunkOffsets(int x, int y) {
     this.minChunkOffsetXMap = x;
     this.minChunkOffsetYMap = y;
   }
 
-  /**
-   * Checks if the tile data represents an infinite map.
-   *
-   * @return {@code true} if the map is infinite, {@code false} otherwise.
-   */
+  /// Checks if the tile data represents an infinite map.
+  ///
+  /// @return `true` if the map is infinite, `false` otherwise.
   protected boolean isInfinite() {
     return this.chunks != null && !this.chunks.isEmpty();
   }
 
-  /**
-   * Retrieves the width of the tile data. For infinite maps, the width is adjusted based on the chunk offsets.
-   *
-   * @return The width of the tile data.
-   */
+  /// Retrieves the width of the tile data. For infinite maps, the width is adjusted based on the chunk offsets.
+  ///
+  /// @return The width of the tile data.
   protected int getWidth() {
     if (this.isInfinite() && this.minChunkOffsetXMap != 0) {
       return this.width + (this.offsetX - this.minChunkOffsetXMap);
@@ -421,11 +371,9 @@ public class TileData {
     return this.width;
   }
 
-  /**
-   * Retrieves the height of the tile data. For infinite maps, the height is adjusted based on the chunk offsets.
-   *
-   * @return The height of the tile data.
-   */
+  /// Retrieves the height of the tile data. For infinite maps, the height is adjusted based on the chunk offsets.
+  ///
+  /// @return The height of the tile data.
   protected int getHeight() {
     if (this.isInfinite() && this.minChunkOffsetYMap != 0) {
       return this.height + (this.offsetY - this.minChunkOffsetYMap);
@@ -439,32 +387,26 @@ public class TileData {
     this.height = height;
   }
 
-  /**
-   * Retrieves the x-axis offset of the tile data.
-   *
-   * @return The x-axis offset.
-   */
+  /// Retrieves the x-axis offset of the tile data.
+  ///
+  /// @return The x-axis offset.
   protected int getOffsetX() {
     return this.offsetX;
   }
 
-  /**
-   * Retrieves the y-axis offset of the tile data.
-   *
-   * @return The y-axis offset.
-   */
+  /// Retrieves the y-axis offset of the tile data.
+  ///
+  /// @return The y-axis offset.
   protected int getOffsetY() {
     return this.offsetY;
   }
 
-  /**
-   * Parses the tile data from a Base64 encoded string.
-   *
-   * @param value       The Base64 encoded string containing the tile data.
-   * @param compression The compression type used on the tile data (e.g., GZIP, ZLIB, or null for no compression).
-   * @return A list of {@code Tile} objects parsed from the Base64 encoded string.
-   * @throws InvalidTileLayerException If the Base64 string is invalid or an I/O error occurs during parsing.
-   */
+  /// Parses the tile data from a Base64 encoded string.
+  ///
+  /// @param value       The Base64 encoded string containing the tile data.
+  /// @param compression The compression type used on the tile data (e.g., GZIP, ZLIB, or null for no compression).
+  /// @return A list of `Tile` objects parsed from the Base64 encoded string.
+  /// @throws InvalidTileLayerException If the Base64 string is invalid or an I/O error occurs during parsing.
   protected static List<Tile> parseBase64Data(String value, String compression) throws InvalidTileLayerException {
     List<Tile> parsed = new ArrayList<>();
 
@@ -518,13 +460,11 @@ public class TileData {
     return parsed;
   }
 
-  /**
-   * Parses the tile data from a CSV formatted string.
-   *
-   * @param value The CSV formatted string containing the tile data.
-   * @return A list of {@code Tile} objects parsed from the CSV string.
-   * @throws InvalidTileLayerException If the CSV string is invalid or an error occurs during parsing.
-   */
+  /// Parses the tile data from a CSV formatted string.
+  ///
+  /// @param value The CSV formatted string containing the tile data.
+  /// @return A list of `Tile` objects parsed from the CSV string.
+  /// @throws InvalidTileLayerException If the CSV string is invalid or an error occurs during parsing.
   protected static List<Tile> parseCsvData(String value) throws InvalidTileLayerException {
 
     List<Tile> parsed = new ArrayList<>();
@@ -593,10 +533,8 @@ public class TileData {
     }
   }
 
-  /**
-   * This method processes the {@link XmlMixed} contents that were unmarshalled and extract either the string value containing the information about
-   * the layer of a set of {@link TileChunk}s if the map is infinite.
-   */
+  /// This method processes the [XmlMixed] contents that were unmarshalled and extract either the string value containing the information about
+  /// the layer of a set of [TileChunk]s if the map is infinite.
   private void processMixedData() {
     if (this.rawValue == null || this.rawValue.isEmpty()) {
       return;
@@ -625,10 +563,8 @@ public class TileData {
     this.chunks = rawChunks;
   }
 
-  /**
-   * Updates the dimensions of the tile data based on the contained tile chunks. This method calculates the minimum and maximum x and y coordinates of
-   * the chunks and adjusts the width and height of the tile data accordingly.
-   */
+  /// Updates the dimensions of the tile data based on the contained tile chunks. This method calculates the minimum and maximum x and y coordinates of
+  /// the chunks and adjusts the width and height of the tile data accordingly.
   private void updateDimensionsByTileData() {
     int minX = 0;
     int maxX = 0;
@@ -664,13 +600,11 @@ public class TileData {
     this.offsetY = minY;
   }
 
-  /**
-   * Parses the tile data from the contained tile chunks. This method processes the chunks based on the encoding type and fills a two-dimensional
-   * array with the tile information. It also ensures that the rest of the map is filled with {@code Tile.EMPTY}.
-   *
-   * @return A list of {@code Tile} objects parsed from the chunks.
-   * @throws InvalidTileLayerException If an error occurs during parsing.
-   */
+  /// Parses the tile data from the contained tile chunks. This method processes the chunks based on the encoding type and fills a two-dimensional
+  /// array with the tile information. It also ensures that the rest of the map is filled with `Tile.EMPTY`.
+  ///
+  /// @return A list of `Tile` objects parsed from the chunks.
+  /// @throws InvalidTileLayerException If an error occurs during parsing.
   private List<Tile> parseChunkData() throws InvalidTileLayerException {
     // first fill a two-dimensional array with all the information of the chunks
     Tile[][] tileArr = new Tile[this.getHeight()][this.getWidth()];
@@ -701,14 +635,12 @@ public class TileData {
     return ArrayUtilities.toList(tileArr);
   }
 
-  /**
-   * Adds tiles from a chunk to the specified two-dimensional tile array. This method places the tiles from the chunk into the correct positions in
-   * the tile array.
-   *
-   * @param tileArr    The two-dimensional array to which the tiles will be added.
-   * @param chunk      The tile chunk containing the tiles to be added.
-   * @param chunkTiles The list of tiles from the chunk to be added to the array.
-   */
+  /// Adds tiles from a chunk to the specified two-dimensional tile array. This method places the tiles from the chunk into the correct positions in
+  /// the tile array.
+  ///
+  /// @param tileArr    The two-dimensional array to which the tiles will be added.
+  /// @param chunk      The tile chunk containing the tiles to be added.
+  /// @param chunkTiles The list of tiles from the chunk to be added to the array.
   private void addTiles(Tile[][] tileArr, TileChunk chunk, List<Tile> chunkTiles) {
     int startX = chunk.getX() - this.minChunkOffsetXMap;
     int startY = chunk.getY() - this.minChunkOffsetYMap;
@@ -723,12 +655,10 @@ public class TileData {
     }
   }
 
-  /**
-   * Parses the tile data based on the encoding type. This method processes the tile data string and converts it into a list of {@code Tile} objects.
-   *
-   * @return A list of {@code Tile} objects parsed from the tile data string.
-   * @throws InvalidTileLayerException If an error occurs during parsing.
-   */
+  /// Parses the tile data based on the encoding type. This method processes the tile data string and converts it into a list of `Tile` objects.
+  ///
+  /// @return A list of `Tile` objects parsed from the tile data string.
+  /// @throws InvalidTileLayerException If an error occurs during parsing.
   private List<Tile> parseData() throws InvalidTileLayerException {
     List<Tile> tmpTiles;
     if (this.getEncoding().equals(Encoding.BASE64)) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TileLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TileLayer.java
@@ -12,9 +12,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * Represents a layer of tiles in the tile map. This class extends the {@link Layer} class and implements the {@link ITileLayer} interface.
- */
+/// Represents a layer of tiles in the tile map. This class extends the [Layer] class and implements the [ITileLayer] interface.
 public class TileLayer extends Layer implements ITileLayer {
 
   @XmlElement
@@ -24,28 +22,22 @@ public class TileLayer extends Layer implements ITileLayer {
 
   private transient Tile[][] tiles;
 
-  /**
-   * Instantiates a new {@code TileLayer} instance.
-   */
+  /// Instantiates a new `TileLayer` instance.
   public TileLayer() {
     // keep for serialization
   }
 
-  /**
-   * Instantiates a new {@code TileLayer} instance with the specified data.
-   *
-   * @param data The tile data of this instance.
-   */
+  /// Instantiates a new `TileLayer` instance with the specified data.
+  ///
+  /// @param data The tile data of this instance.
   public TileLayer(TileData data) {
     this.data = data;
   }
 
-  /**
-   * Creates an empty, editable tile layer with the specified dimensions.
-   *
-   * @param width the layer width in tiles
-   * @param height the layer height in tiles
-   */
+  /// Creates an empty, editable tile layer with the specified dimensions.
+  ///
+  /// @param width the layer width in tiles
+  /// @param height the layer height in tiles
   public TileLayer(int width, int height) {
     if (width < 1 || height < 1) {
       throw new IllegalArgumentException("Tile layer dimensions must be positive.");
@@ -71,12 +63,10 @@ public class TileLayer extends Layer implements ITileLayer {
     }
   }
 
-  /**
-   * Copy constructor for the {@code TileLayer} class. Creates a new instance of the {@code TileLayer} class by copying the properties from the
-   * provided {@code TileLayer} object.
-   *
-   * @param original The original {@code TileLayer} object to copy from.
-   */
+  /// Copy constructor for the `TileLayer` class. Creates a new instance of the `TileLayer` class by copying the properties from the
+  /// provided `TileLayer` object.
+  ///
+  /// @param original The original `TileLayer` object to copy from.
   public TileLayer(TileLayer original) {
     super(original);
     this.data = original.data != null ? new TileData(original.data) : null;
@@ -166,20 +156,16 @@ public class TileLayer extends Layer implements ITileLayer {
     return super.getHeight();
   }
 
-  /**
-   * Gets the list of tiles in this layer.
-   *
-   * @return A list of {@link Tile} objects representing the tiles in this layer.
-   */
+  /// Gets the list of tiles in this layer.
+  ///
+  /// @return A list of [Tile] objects representing the tiles in this layer.
   protected List<Tile> getData() {
     return data.getTiles();
   }
 
-  /**
-   * Gets the raw tile data for this layer.
-   *
-   * @return The {@link TileData} object containing the raw tile data.
-   */
+  /// Gets the raw tile data for this layer.
+  ///
+  /// @return The [TileData] object containing the raw tile data.
   protected TileData getRawTileData() {
     return data;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/Tileset.java
@@ -35,10 +35,8 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The {@code Tileset} class represents a collection of tiles used in a tile-based map. It extends the {@code CustomPropertyProvider} class and
- * implements the {@code ITileset} interface. This class provides various properties and methods to manage and access tileset information.
- */
+/// The `Tileset` class represents a collection of tiles used in a tile-based map. It extends the `CustomPropertyProvider` class and
+/// implements the `ITileset` interface. This class provides various properties and methods to manage and access tileset information.
 @XmlRootElement(name = "tileset")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Tileset extends CustomPropertyProvider implements ITileset {
@@ -118,21 +116,17 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
 
   private transient Spritesheet spriteSheet;
 
-  /**
-   * Default constructor for the {@code Tileset} class. Initializes a new instance of the {@code Tileset} class and sets up a listener to clear the
-   * sprite sheet when images are cleared.
-   */
+  /// Default constructor for the `Tileset` class. Initializes a new instance of the `Tileset` class and sets up a listener to clear the
+  /// sprite sheet when images are cleared.
   public Tileset() {
     this.allTiles = new ArrayList<>();
     Resources.images().addClearedListener(() -> this.spriteSheet = null);
   }
 
-  /**
-   * Copy constructor for the {@code Tileset} class. Creates a new instance of the {@code Tileset} class by copying the properties from the provided
-   * {@code Tileset} object.
-   *
-   * @param original The original {@code Tileset} object to copy from.
-   */
+  /// Copy constructor for the `Tileset` class. Creates a new instance of the `Tileset` class by copying the properties from the provided
+  /// `Tileset` object.
+  ///
+  /// @param original The original `Tileset` object to copy from.
   public Tileset(Tileset original) {
     super(original.source == null ? original : new CustomPropertyProvider());
 
@@ -175,12 +169,10 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     this.spriteSheet = original.sourceTileset != null ? original.sourceTileset.spriteSheet : original.spriteSheet;
   }
 
-  /**
-   * Creates a map-local copy of a tileset with the supplied first global tile ID.
-   *
-   * @param original the project tileset to copy
-   * @param firstGridId the first global tile ID assigned to the copy
-   */
+  /// Creates a map-local copy of a tileset with the supplied first global tile ID.
+  ///
+  /// @param original the project tileset to copy
+  /// @param firstGridId the first global tile ID assigned to the copy
   public Tileset(Tileset original, int firstGridId) {
     this(original);
     this.setFirstGridId(firstGridId);
@@ -432,11 +424,9 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     return this.firstgid;
   }
 
-  /**
-   * Sets the first global tile ID used by this tileset in its containing map.
-   *
-   * @param firstGridId the first global tile ID, starting at {@code 1}
-   */
+  /// Sets the first global tile ID used by this tileset in its containing map.
+  ///
+  /// @param firstGridId the first global tile ID, starting at `1`
   public void setFirstGridId(int firstGridId) {
     if (firstGridId < 1) {
       throw new IllegalArgumentException("The first grid ID must be positive.");
@@ -476,11 +466,9 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     this.spriteSheet = null;
   }
 
-  /**
-   * Gets the margin.
-   *
-   * @return the margin
-   */
+  /// Gets the margin.
+  ///
+  /// @return the margin
   @Override
   public int getMargin() {
     if (this.sourceTileset != null) {
@@ -520,11 +508,9 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     this.source = source;
   }
 
-  /**
-   * Gets the spacing.
-   *
-   * @return the spacing
-   */
+  /// Gets the spacing.
+  ///
+  /// @return the spacing
   @Override
   public int getSpacing() {
     if (this.sourceTileset != null) {
@@ -567,21 +553,17 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     return this.sourceTileset != null ? this.sourceTileset.getTileDimension() : new Dimension(this.getTileWidth(), this.getTileHeight());
   }
 
-  /**
-   * Gets the tile height.
-   *
-   * @return the tile height
-   */
+  /// Gets the tile height.
+  ///
+  /// @return the tile height
   @Override
   public int getTileHeight() {
     return this.sourceTileset != null ? this.sourceTileset.getTileHeight() : this.tileheight != null ? this.tileheight : 0;
   }
 
-  /**
-   * Gets the tile width.
-   *
-   * @return the tile width
-   */
+  /// Gets the tile width.
+  ///
+  /// @return the tile width
   @Override
   public int getTileWidth() {
     return this.sourceTileset != null ? this.sourceTileset.getTileWidth() : this.tilewidth != null ? this.tilewidth : 0;
@@ -683,29 +665,23 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     return this.allTiles != null && id < this.allTiles.size() ? this.allTiles.get(id) : null;
   }
 
-  /**
-   * Gets the tile transformations.
-   *
-   * @return the tile transformations
-   */
+  /// Gets the tile transformations.
+  ///
+  /// @return the tile transformations
   public TileTransformations getTransformations() {
     return this.sourceTileset != null ? this.sourceTileset.getTransformations() : this.transformations;
   }
 
-  /**
-   * Gets the tileset class.
-   *
-   * @return the tileset class
-   */
+  /// Gets the tileset class.
+  ///
+  /// @return the tileset class
   public String getTilesetClass() {
     return this.sourceTileset != null ? this.sourceTileset.getTilesetClass() : this.tilesetClass;
   }
 
-  /**
-   * Gets the object alignment.
-   *
-   * @return the object alignment
-   */
+  /// Gets the object alignment.
+  ///
+  /// @return the object alignment
   public String getObjectalignment() {
     return this.sourceTileset != null ? this.sourceTileset.getObjectalignment() : this.objectalignment;
   }
@@ -718,11 +694,9 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     this.objectalignment = objectalignment == null || objectalignment.isBlank() ? null : objectalignment;
   }
 
-  /**
-   * Gets the tile render size.
-   *
-   * @return the tile render size
-   */
+  /// Gets the tile render size.
+  ///
+  /// @return the tile render size
   public String getTilerendersize() {
     return this.sourceTileset != null ? this.sourceTileset.getTilerendersize() : this.tilerendersize;
   }
@@ -735,11 +709,9 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     this.tilerendersize = tilerendersize == null || tilerendersize.isBlank() ? null : tilerendersize;
   }
 
-  /**
-   * Gets the fill mode.
-   *
-   * @return the fill mode
-   */
+  /// Gets the fill mode.
+  ///
+  /// @return the fill mode
   public String getFillmode() {
     return this.sourceTileset != null ? this.sourceTileset.getFillmode() : this.fillmode;
   }
@@ -825,11 +797,9 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     }
   }
 
-  /**
-   * Saves the source tileset to the specified base path.
-   *
-   * @param path The base path where the source tileset should be saved.
-   */
+  /// Saves the source tileset to the specified base path.
+  ///
+  /// @param path The base path where the source tileset should be saved.
   public void saveSource(Path path) {
     if (this.sourceTileset == null) {
       return;
@@ -838,20 +808,16 @@ public class Tileset extends CustomPropertyProvider implements ITileset {
     XmlUtilities.save(this.sourceTileset, path.resolve(source), FILE_EXTENSION);
   }
 
-  /**
-   * Checks if the tileset is external.
-   *
-   * @return true if the tileset is external, false otherwise.
-   */
+  /// Checks if the tileset is external.
+  ///
+  /// @return true if the tileset is external, false otherwise.
   public boolean isExternal() {
     return this.source != null;
   }
 
-  /**
-   * Loads the source tileset from the provided list of raw tilesets.
-   *
-   * @param rawTilesets The list of raw tilesets to load the source tileset from.
-   */
+  /// Loads the source tileset from the provided list of raw tilesets.
+  ///
+  /// @param rawTilesets The list of raw tilesets to load the source tileset from.
   public void load(List<Tileset> rawTilesets) {
     if (this.source == null) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TilesetEntry.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TilesetEntry.java
@@ -42,21 +42,17 @@ public class TilesetEntry extends CustomPropertyProvider implements ITilesetEntr
   @XmlElement(name = "objectgroup")
   private MapObjectLayer collisionData;
 
-  /**
-   * Instantiates a new {@code TilesetEntry}.
-   */
+  /// Instantiates a new `TilesetEntry`.
   public TilesetEntry() {
     // keep for serialization
   }
 
-  /**
-   * Instantiates a new {@code TilesetEntry} from the specified tileset.
-   *
-   * @param tileset
-   *          The tileset that contains this entry.
-   * @param id
-   *          The identifier of this instance.
-   */
+  /// Instantiates a new `TilesetEntry` from the specified tileset.
+  ///
+  /// @param tileset
+  /// The tileset that contains this entry.
+  /// @param id
+  /// The identifier of this instance.
   public TilesetEntry(Tileset tileset, int id) {
     this.tileset = tileset;
     this.id = id;
@@ -146,11 +142,9 @@ public class TilesetEntry extends CustomPropertyProvider implements ITilesetEntr
     return this.collisionData;
   }
 
-  /**
-   * Gets the collision layer for this tile, creating it if necessary.
-   *
-   * @return the collision layer
-   */
+  /// Gets the collision layer for this tile, creating it if necessary.
+  ///
+  /// @return the collision layer
   public MapObjectLayer getOrCreateCollisionInfo() {
     if (this.collisionData == null) {
       this.collisionData = new MapObjectLayer();
@@ -168,9 +162,7 @@ public class TilesetEntry extends CustomPropertyProvider implements ITilesetEntr
     return this.collisionData;
   }
 
-  /**
-   * Removes all collision information from this tile.
-   */
+  /// Removes all collision information from this tile.
   public void clearCollisionInfo() {
     this.collisionData = null;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxException.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxException.java
@@ -3,9 +3,7 @@ package de.gurkenlabs.litiengine.environment.tilemap.xml;
 import java.io.IOException;
 import java.io.Serial;
 
-/**
- * Thrown to indicate that something has gone wrong with the processing of a TMX file.
- */
+/// Thrown to indicate that something has gone wrong with the processing of a TMX file.
 public class TmxException extends IOException {
 
   @Serial private static final long serialVersionUID = -2404149074008693966L;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/TmxMap.java
@@ -38,29 +38,23 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * JAXB-bound representation of a Tiled (TMX) map. Implements {@link IMap} so the loaded data integrates seamlessly with the engine's map/environment
- * API and serves as the in-memory model when the engine reads {@code .tmx} files.
- */
+/// JAXB-bound representation of a Tiled (TMX) map. Implements [IMap] so the loaded data integrates seamlessly with the engine's map/environment
+/// API and serves as the in-memory model when the engine reads `.tmx` files.
 @XmlRootElement(name = "map")
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class TmxMap extends CustomPropertyProvider implements IMap {
 
-  /**
-   * File extension used by Tiled map files.
-   */
+  /// File extension used by Tiled map files.
   public static final String FILE_EXTENSION = "tmx";
-  /**
-   * Maximum supported TMX major version.
-   */
+  /// Maximum supported TMX major version.
   public static final int MAX_MAJOR = 1;
-  /** Maximum supported TMX minor version. */
+  /// Maximum supported TMX minor version.
   public static final int MAX_MINOR = 10;
 
-  /** Minimum supported TMX major version. */
+  /// Minimum supported TMX major version.
   public static final int MIN_MAJOR = 1;
 
-  /** Minimum supported TMX minor version. */
+  /// Minimum supported TMX minor version.
   public static final int MIN_MINOR = 5;
 
   private static final Logger log = Logger.getLogger(TmxMap.class.getName());
@@ -135,31 +129,25 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
   @XmlTransient
   private int chunkOffsetY;
 
-  /**
-   * Creates a new {@code TmxMap}. Intended for XML deserialization; populated fields will be initialized by JAXB.
-   */
+  /// Creates a new `TmxMap`. Intended for XML deserialization; populated fields will be initialized by JAXB.
   public TmxMap() {
     // keep for serialization
   }
 
-  /**
-   * Creates a new {@code TmxMap} with the given map orientation, defaulting the render order to right-down and the Tiled version to the maximum
-   * supported value.
-   *
-   * @param orientation the map orientation
-   */
+  /// Creates a new `TmxMap` with the given map orientation, defaulting the render order to right-down and the Tiled version to the maximum
+  /// supported value.
+  ///
+  /// @param orientation the map orientation
   public TmxMap(IMapOrientation orientation) {
     this.mapOrientation = orientation;
     this.renderorder = RenderOrder.RIGHT_DOWN;
     this.setTiledVersion(MAX_MAJOR + "." + MAX_MINOR + ".0");
   }
 
-  /**
-   * Copy constructor for the {@code TmxMap} class. Creates a new instance of the {@code TmxMap} class by copying the properties from the provided
-   * {@code TmxMap} object.
-   *
-   * @param original The original {@code TmxMap} object to copy from.
-   */
+  /// Copy constructor for the `TmxMap` class. Creates a new instance of the `TmxMap` class by copying the properties from the provided
+  /// `TmxMap` object.
+  ///
+  /// @param original The original `TmxMap` object to copy from.
   public TmxMap(TmxMap original) {
     super(original);
     this.version = original.getVersion();
@@ -214,11 +202,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.imageLayers;
   }
 
-  /**
-   * Gets the next object id.
-   *
-   * @return the next object id
-   */
+  /// Gets the next object id.
+  ///
+  /// @return the next object id
   @Override
   public int getNextObjectId() {
     return this.nextObjectId;
@@ -237,11 +223,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.mapOrientation;
   }
 
-  /**
-   * Sets the map's orientation.
-   *
-   * @param orientation the orientation; must not be {@code null}
-   */
+  /// Sets the map's orientation.
+  ///
+  /// @param orientation the orientation; must not be `null`
   @XmlTransient
   public void setOrientation(IMapOrientation orientation) {
     this.mapOrientation = Objects.requireNonNull(orientation);
@@ -253,11 +237,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.path;
   }
 
-  /**
-   * Sets the source URL the map was loaded from.
-   *
-   * @param path the source URL
-   */
+  /// Sets the source URL the map was loaded from.
+  ///
+  /// @param path the source URL
   public void setPath(final URL path) {
     this.path = path;
   }
@@ -267,22 +249,18 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.renderorder;
   }
 
-  /**
-   * Sets the render order used when drawing the map's tile layers.
-   *
-   * @param renderorder the render order
-   */
+  /// Sets the render order used when drawing the map's tile layers.
+  ///
+  /// @param renderorder the render order
   @XmlTransient
   public void setRenderOrder(RenderOrder renderorder) {
     this.renderorder = renderorder;
   }
 
-  /**
-   * Returns an unmodifiable snapshot of all map object layers, including layers nested in groups. Changes to the map after this call are visible only
-   * in a newly requested snapshot.
-   *
-   * @return an unmodifiable recursive snapshot of the map object layers
-   */
+  /// Returns an unmodifiable snapshot of all map object layers, including layers nested in groups. Changes to the map after this call are visible only
+  /// in a newly requested snapshot.
+  ///
+  /// @return an unmodifiable recursive snapshot of the map object layers
   @Override
   public List<IMapObjectLayer> getMapObjectLayers() {
     List<IMapObjectLayer> objectLayers = new ArrayList<>();
@@ -355,11 +333,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.tilewidth;
   }
 
-  /**
-   * Sets the width of a single tile in pixels.
-   *
-   * @param tilewidth the tile width
-   */
+  /// Sets the width of a single tile in pixels.
+  ///
+  /// @param tilewidth the tile width
   @XmlTransient
   public void setTileWidth(int tilewidth) {
     this.tilewidth = tilewidth;
@@ -370,11 +346,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.tileheight;
   }
 
-  /**
-   * Sets the height of a single tile in pixels.
-   *
-   * @param tileheight the tile height
-   */
+  /// Sets the height of a single tile in pixels.
+  ///
+  /// @param tileheight the tile height
   @XmlTransient
   public void setTileHeight(int tileheight) {
     this.tileheight = tileheight;
@@ -385,11 +359,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.version;
   }
 
-  /**
-   * Sets the TMX format version of this map.
-   *
-   * @param version the version
-   */
+  /// Sets the TMX format version of this map.
+  ///
+  /// @param version the version
   @XmlTransient
   public void setVersion(double version) {
     this.version = version;
@@ -400,11 +372,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.tiledversion;
   }
 
-  /**
-   * Sets the Tiled editor version string of this map.
-   *
-   * @param tiledversion the Tiled version string
-   */
+  /// Sets the Tiled editor version string of this map.
+  ///
+  /// @param tiledversion the Tiled version string
   @XmlTransient
   public void setTiledVersion(String tiledversion) {
     this.tiledversion = tiledversion;
@@ -430,11 +400,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.width;
   }
 
-  /**
-   * Sets the map width in tiles.
-   *
-   * @param width the width in tiles
-   */
+  /// Sets the map width in tiles.
+  ///
+  /// @param width the width in tiles
   @XmlTransient
   public void setWidth(int width) {
     this.width = width;
@@ -445,11 +413,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.height;
   }
 
-  /**
-   * Sets the map height in tiles.
-   *
-   * @param height the height in tiles
-   */
+  /// Sets the map height in tiles.
+  ///
+  /// @param height the height in tiles
   @XmlTransient
   public void setHeight(int height) {
     this.height = height;
@@ -460,11 +426,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.hexsidelength;
   }
 
-  /**
-   * Sets the hex side length used for hexagonal maps.
-   *
-   * @param hexSideLength the hex side length
-   */
+  /// Sets the hex side length used for hexagonal maps.
+  ///
+  /// @param hexSideLength the hex side length
   @XmlTransient
   public void setHexSideLength(int hexSideLength) {
     this.hexsidelength = hexSideLength;
@@ -475,11 +439,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.staggeraxis;
   }
 
-  /**
-   * Sets the stagger axis used for staggered and hexagonal maps.
-   *
-   * @param staggerAxis the stagger axis
-   */
+  /// Sets the stagger axis used for staggered and hexagonal maps.
+  ///
+  /// @param staggerAxis the stagger axis
   @XmlTransient
   public void setStaggerAxis(StaggerAxis staggerAxis) {
     this.staggeraxis = staggerAxis;
@@ -490,11 +452,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.staggerindex;
   }
 
-  /**
-   * Sets the stagger index used for staggered and hexagonal maps.
-   *
-   * @param staggerIndex the stagger index
-   */
+  /// Sets the stagger index used for staggered and hexagonal maps.
+  ///
+  /// @param staggerIndex the stagger index
   @XmlTransient
   public void setStaggerIndex(StaggerIndex staggerIndex) {
     this.staggerindex = staggerIndex;
@@ -601,11 +561,9 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     return this.layers;
   }
 
-  /**
-   * Returns the list of external tilesets referenced by this map (i.e. tilesets defined in separate {@code .tsx} files).
-   *
-   * @return the list of external tilesets
-   */
+  /// Returns the list of external tilesets referenced by this map (i.e. tilesets defined in separate `.tsx` files).
+  ///
+  /// @return the list of external tilesets
   public List<Tileset> getExternalTilesets() {
     List<Tileset> externalTilesets = new ArrayList<>();
     for (ITileset set : this.getTilesets()) {
@@ -766,9 +724,7 @@ public final class TmxMap extends CustomPropertyProvider implements IMap {
     }
   }
 
-  /**
-   * Update width and height by the max width and height of the tile layers in the infinite map.
-   */
+  /// Update width and height by the max width and height of the tile layers in the infinite map.
   private void updateDimensionsByTileLayers() {
 
     int minChunkOffsetX = 0;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/WangColor.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/WangColor.java
@@ -7,6 +7,12 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.awt.*;
 import java.util.Objects;
 
+/// One terrain material (a Tiled `wangcolor`) within a [WangSet].
+///
+/// The representative tile and probability guide terrain painting; tile references use local
+/// tileset IDs and `-1` means that no representative tile is configured.
+///
+/// @see de.gurkenlabs.litiengine.environment.tilemap.ITerrain
 @XmlRootElement(name = "wangcolor")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class WangColor extends CustomPropertyProvider implements ITerrain {
@@ -27,10 +33,15 @@ public class WangColor extends CustomPropertyProvider implements ITerrain {
   @XmlAttribute
   private double probability;
 
+  /// Creates a white terrain named `Terrain` without a representative tile.
   public WangColor() {
     this("Terrain", Color.WHITE);
   }
 
+  /// Creates a terrain with default probability `1`.
+  ///
+  /// @param name The terrain name.
+  /// @param color The editor display color.
   public WangColor(String name, Color color) {
     this.name = name;
     this.color = color;
@@ -38,6 +49,9 @@ public class WangColor extends CustomPropertyProvider implements ITerrain {
     this.probability = 1;
   }
 
+  /// Creates a copy, including custom properties.
+  ///
+  /// @param original The terrain to copy.
   public WangColor(WangColor original) {
     super(original);
     this.name = original.name;
@@ -52,6 +66,9 @@ public class WangColor extends CustomPropertyProvider implements ITerrain {
     return this.name;
   }
 
+  /// Sets the terrain name; blank values are normalized to `null`.
+  ///
+  /// @param name The new name.
   public void setName(String name) {
     this.name = name == null || name.isBlank() ? null : name;
   }
@@ -61,14 +78,25 @@ public class WangColor extends CustomPropertyProvider implements ITerrain {
     return this.color;
   }
 
+  /// Sets the editor display color.
+  ///
+  /// @param color The non-null color.
+  /// @throws NullPointerException if `color` is `null`.
   public void setColor(Color color) {
     this.color = Objects.requireNonNull(color);
   }
 
+  /// Returns the local ID of the representative tile.
+  ///
+  /// @return The tile ID, or `-1` when none is configured.
   public int getTileId() {
     return this.tile;
   }
 
+  /// Sets the representative local tile ID.
+  ///
+  /// @param tileId The tile ID, or `-1` for none.
+  /// @throws IllegalArgumentException if `tileId` is less than `-1`.
   public void setTileId(int tileId) {
     if (tileId < -1) {
       throw new IllegalArgumentException("Representative tile ID must be -1 or greater.");
@@ -81,6 +109,10 @@ public class WangColor extends CustomPropertyProvider implements ITerrain {
     return this.probability;
   }
 
+  /// Sets the relative probability used by terrain painting tools.
+  ///
+  /// @param probability A finite, non-negative weight.
+  /// @throws IllegalArgumentException if the value is negative or not finite.
   public void setProbability(double probability) {
     if (!Double.isFinite(probability) || probability < 0) {
       throw new IllegalArgumentException("Terrain probability must be finite and non-negative.");

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/WangSet.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/WangSet.java
@@ -12,6 +12,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+/// A Tiled terrain or Wang set containing terrain colors and per-tile edge/corner assignments.
+///
+/// Terrain references in [WangTile] are one-based indexes into [#getTerrains()]; index zero means
+/// no terrain. The eight positions alternate corners and edges in the order defined by the TMX
+/// format. The returned terrain and Wang-tile lists are live JAXB model collections.
+///
+/// @see de.gurkenlabs.litiengine.environment.tilemap.ITerrainSet
+/// @see WangColor
+/// @see WangTile
 @XmlAccessorType(XmlAccessType.FIELD)
 public class WangSet extends CustomPropertyProvider implements ITerrainSet {
 
@@ -33,10 +42,15 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
   @XmlElement(name = "wangtile")
   private List<WangTile> wangtiles;
 
+  /// Creates an empty mixed terrain set named `Terrain Set`.
   public WangSet() {
     this("Terrain Set", TerrainType.MIXED);
   }
 
+  /// Creates an empty terrain set.
+  ///
+  /// @param name The set name.
+  /// @param type Whether assignments describe corners, edges, or both.
   public WangSet(String name, TerrainType type) {
     this.name = name;
     this.type = type;
@@ -45,6 +59,9 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     this.wangtiles = new ArrayList<>();
   }
 
+  /// Creates a deep copy of a terrain set.
+  ///
+  /// @param original The set to copy.
   public WangSet(WangSet original) {
     super(original);
     this.name = original.name;
@@ -68,6 +85,9 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     return this.name;
   }
 
+  /// Sets the display name; blank values are normalized to `null`.
+  ///
+  /// @param name The new name.
   public void setName(String name) {
     this.name = name == null || name.isBlank() ? null : name;
   }
@@ -77,10 +97,17 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     return this.type;
   }
 
+  /// Sets which Wang positions this set uses.
+  ///
+  /// @param type The non-null terrain type.
+  /// @throws NullPointerException if `type` is `null`.
   public void setType(TerrainType type) {
     this.type = Objects.requireNonNull(type);
   }
 
+  /// Returns the live terrain list in Wang-index order.
+  ///
+  /// @return The mutable terrain list.
   @Override
   public List<ITerrain> getTerrains() {
     if (this.wangcolor == null) {
@@ -89,6 +116,9 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     return this.wangcolor;
   }
 
+  /// Returns the live list of per-tile assignments.
+  ///
+  /// @return The mutable Wang-tile list.
   public List<WangTile> getWangTiles() {
     if (this.wangtiles == null) {
       this.wangtiles = new ArrayList<>();
@@ -96,6 +126,11 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     return this.wangtiles;
   }
 
+  /// Finds or creates the assignment for a local tile ID.
+  ///
+  /// @param tileId The non-negative local tile ID.
+  /// @return The existing or newly added assignment.
+  /// @throws IllegalArgumentException if `tileId` is negative.
   public WangTile getOrCreateWangTile(int tileId) {
     if (tileId < 0) {
       throw new IllegalArgumentException("Wang tile ID must be non-negative.");
@@ -110,6 +145,10 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     return wangtile;
   }
 
+  /// Returns the eight Wang indexes assigned to a local tile.
+  ///
+  /// @param tileId The local tile ID.
+  /// @return A defensive copy, or eight zeroes if the tile has no assignment.
   public int[] getWangId(int tileId) {
     for (WangTile wangtile : getWangTiles()) {
       if (wangtile.getTileId() == tileId) {
@@ -119,6 +158,9 @@ public class WangSet extends CustomPropertyProvider implements ITerrainSet {
     return new int[8];
   }
 
+  /// Removes a tile assignment if all eight of its indexes are zero.
+  ///
+  /// @param tileId The local tile ID to inspect.
   public void removeWangTileIfEmpty(int tileId) {
     getWangTiles().removeIf(wangtile -> wangtile.getTileId() == tileId
       && Arrays.stream(wangtile.getWangId()).allMatch(id -> id == 0));

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/WangTile.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/WangTile.java
@@ -5,6 +5,11 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+/// Associates one local tile ID with the terrains at its four corners and four edges.
+///
+/// Wang IDs always contain eight entries in Tiled order. Zero means no terrain; positive values are
+/// one-based indexes into [WangSet#getTerrains()]. Arrays supplied to or returned from this class are
+/// defensively copied.
 @XmlAccessorType(XmlAccessType.FIELD)
 public class WangTile {
   private static final int WANG_ID_LENGTH = 8;
@@ -16,32 +21,55 @@ public class WangTile {
   @XmlJavaTypeAdapter(IntegerArrayAdapter.class)
   private int[] wangid;
 
+  /// Creates tile zero with no assigned terrains.
   public WangTile() {
     this(0, new int[WANG_ID_LENGTH]);
   }
 
+  /// Creates a tile assignment.
+  ///
+  /// @param tileId The local tileset tile ID.
+  /// @param wangId Up to eight terrain indexes; missing entries become zero.
   public WangTile(int tileId, int[] wangId) {
     this.tileid = tileId;
     this.wangid = normalize(wangId);
   }
 
+  /// Creates an independent copy.
+  ///
+  /// @param original The assignment to copy.
   public WangTile(WangTile original) {
     this(original.tileid, original.wangid);
   }
 
+  /// Returns the local tileset tile ID.
+  ///
+  /// @return The tile ID.
   public int getTileId() {
     return this.tileid;
   }
 
+  /// Returns the eight terrain indexes.
+  ///
+  /// @return A defensive copy of the Wang ID.
   public int[] getWangId() {
     this.wangid = normalize(this.wangid);
     return this.wangid.clone();
   }
 
+  /// Replaces all terrain indexes.
+  ///
+  /// @param wangId Up to eight indexes; negative values become zero.
   public void setWangId(int[] wangId) {
     this.wangid = normalize(wangId);
   }
 
+  /// Assigns one corner or edge position.
+  ///
+  /// @param position The Tiled Wang position from zero through seven.
+  /// @param terrain The non-negative, one-based terrain index, or zero for none.
+  /// @throws IndexOutOfBoundsException if `position` is outside zero through seven.
+  /// @throws IllegalArgumentException if `terrain` is negative.
   public void setTerrain(int position, int terrain) {
     if (position < 0 || position >= WANG_ID_LENGTH) {
       throw new IndexOutOfBoundsException(position);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/environment/tilemap/xml/package-info.java
@@ -1,6 +1,4 @@
-/**
- * This package contains classes for handling XML serialization and deserialization of tile maps in the environment.
- */
+/// This package contains classes for handling XML serialization and deserialization of tile maps in the environment.
 @XmlSchema(location = "http://mapeditor.org/dtd/1.0/map.dtd")
 package de.gurkenlabs.litiengine.environment.tilemap.xml;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/AmbientLight.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/AmbientLight.java
@@ -15,32 +15,24 @@ import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-/**
- * This class represents the ambient light in an environment. It extends the ColorLayer class and provides methods to render light sources and
- * shadows.
- */
+/// This class represents the ambient light in an environment. It extends the ColorLayer class and provides methods to render light sources and
+/// shadows.
 public class AmbientLight extends ColorLayer {
-  /**
-   * The default color for the ambient light.
-   */
+  /// The default color for the ambient light.
   public static final Color DEFAULT_COLOR = new Color(0, 0, 0, 0);
 
-  /**
-   * Constructor for the AmbientLight class.
-   *
-   * @param environment  The environment to which this instance is assigned.
-   * @param ambientColor The color of this instance.
-   */
+  /// Constructor for the AmbientLight class.
+  ///
+  /// @param environment  The environment to which this instance is assigned.
+  /// @param ambientColor The color of this instance.
   public AmbientLight(final Environment environment, final Color ambientColor) {
     super(environment, ambientColor);
   }
 
-  /**
-   * Renders a section of the environment with the ambient light and light sources.
-   *
-   * @param g       The Graphics2D object to render on.
-   * @param section The section of the environment to render.
-   */
+  /// Renders a section of the environment with the ambient light and light sources.
+  ///
+  /// @param g       The Graphics2D object to render on.
+  /// @param section The section of the environment to render.
   @Override
   protected void renderSection(Graphics2D g, Rectangle2D section) {
     renderAmbient(g, section);
@@ -51,12 +43,10 @@ public class AmbientLight extends ColorLayer {
     getEnvironment().getLightSources().forEach(light -> renderActualLight(g, light, section));
   }
 
-  /**
-   * Clears a section of the environment.
-   *
-   * @param g       The Graphics2D object to clear on.
-   * @param section The section of the environment to clear.
-   */
+  /// Clears a section of the environment.
+  ///
+  /// @param g       The Graphics2D object to clear on.
+  /// @param section The section of the environment to clear.
   @Override
   protected void clearSection(Graphics2D g, Rectangle2D section) {
     g.setColor(new Color(0, 0, 0, 0));
@@ -67,13 +57,11 @@ public class AmbientLight extends ColorLayer {
       (int) section.getHeight());
   }
 
-  /**
-   * Carves out a light source from the ambient light.
-   *
-   * @param g       The Graphics2D object to carve on.
-   * @param light   The light source to carve out.
-   * @param section The section of the environment to carve from.
-   */
+  /// Carves out a light source from the ambient light.
+  ///
+  /// @param g       The Graphics2D object to carve on.
+  /// @param light   The light source to carve out.
+  /// @param section The section of the environment to carve from.
   private void carveOutLight(Graphics2D g, LightSource light, Rectangle2D section) {
     if (!light.getBoundingBox().intersects(section) || !light.isActive()) {
       return;
@@ -81,13 +69,11 @@ public class AmbientLight extends ColorLayer {
     renderLightSource(g, light, section);
   }
 
-  /**
-   * Renders an actual light source on the environment.
-   *
-   * @param g       The Graphics2D object to render on.
-   * @param light   The light source to render.
-   * @param section The section of the environment to render on.
-   */
+  /// Renders an actual light source on the environment.
+  ///
+  /// @param g       The Graphics2D object to render on.
+  /// @param light   The light source to render.
+  /// @param section The section of the environment to render on.
   private void renderActualLight(Graphics2D g, LightSource light, Rectangle2D section) {
     if (!light.getBoundingBox().intersects(section)
       || !light.isActive()
@@ -100,24 +86,20 @@ public class AmbientLight extends ColorLayer {
     renderLightSource(g, light, section);
   }
 
-  /**
-   * Renders the ambient light on the environment.
-   *
-   * @param g       The Graphics2D object to render on.
-   * @param section The section of the environment to render.
-   */
+  /// Renders the ambient light on the environment.
+  ///
+  /// @param g       The Graphics2D object to render on.
+  /// @param section The section of the environment to render.
   private void renderAmbient(Graphics2D g, Rectangle2D section) {
     g.setColor(getColor());
     g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_IN, 1));
     ShapeRenderer.render(g, section);
   }
 
-  /**
-   * Subtracts a shadow from a light area.
-   *
-   * @param lightArea The light area to subtract from.
-   * @param shadow    The shadow to subtract.
-   */
+  /// Subtracts a shadow from a light area.
+  ///
+  /// @param lightArea The light area to subtract from.
+  /// @param shadow    The shadow to subtract.
   private void subtractShadow(Area lightArea, StaticShadow shadow) {
     if (!lightArea.intersects(shadow.getBoundingBox())) {
       return;
@@ -163,13 +145,11 @@ public class AmbientLight extends ColorLayer {
     }
   }
 
-  /**
-   * Renders a light source on the environment.
-   *
-   * @param g       The Graphics2D object to render on.
-   * @param light   The light source to render.
-   * @param section The section of the environment to render on.
-   */
+  /// Renders a light source on the environment.
+  ///
+  /// @param g       The Graphics2D object to render on.
+  /// @param light   The light source to render.
+  /// @param section The section of the environment to render on.
   private void renderLightSource(final Graphics2D g, final LightSource light, Rectangle2D section) {
 
     Area lightArea = new Area(light.getLightShape());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/Camera.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/Camera.java
@@ -15,9 +15,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Represents the camera used for rendering the game world. The camera handles focus, zoom, shake effects, and viewport calculations.
- */
+/// Represents the camera used for rendering the game world. The camera handles focus, zoom, shake effects, and viewport calculations.
 public class Camera implements ICamera, Tweenable {
   private final Collection<ZoomChangedListener> zoomListeners = ConcurrentHashMap.newKeySet();
   private final Collection<FocusChangedListener> focusChangedListeners =
@@ -52,9 +50,7 @@ public class Camera implements ICamera, Tweenable {
   private Align align = Align.LEFT;
   private Valign valign = Valign.TOP;
 
-  /**
-   * Instantiates a new {@code Camera} instance.
-   */
+  /// Instantiates a new `Camera` instance.
   public Camera() {
     this.focus = new Point2D.Double();
     this.viewport = new Rectangle2D.Double();
@@ -295,17 +291,14 @@ public class Camera implements ICamera, Tweenable {
     this.pan(new Point2D.Double(x, y), duration);
   }
 
-  /**
-   * Clamps a given focus point to ensure it remains within the visible bounds of the current map.
-   * <p>
-   * This method ensures that the camera's focus point does not move outside the boundaries of the map. It centers the camera around the focus point,
-   * but only to the extent that the map dimensions allow. If the viewport is larger than the map in either dimension, the Camera's Align and VAlign
-   * is applied to determine how to handle the excess space.
-   * </p>
-   *
-   * @param focus the desired focus point in map coordinates.
-   * @return a new {@link Point2D} representing the clamped focus point, adjusted to remain within the bounds of the map view.
-   */
+  /// Clamps a given focus point to ensure it remains within the visible bounds of the current map.
+  ///
+  /// This method ensures that the camera's focus point does not move outside the boundaries of the map. It centers the camera around the focus point,
+  /// but only to the extent that the map dimensions allow. If the viewport is larger than the map in either dimension, the Camera's Align and VAlign
+  /// is applied to determine how to handle the excess space.
+  ///
+  /// @param focus the desired focus point in map coordinates.
+  /// @return a new [Point2D] representing the clamped focus point, adjusted to remain within the bounds of the map view.
   protected Point2D clampToMap(Point2D focus) {
 
     if (Game.world().environment() == null
@@ -335,43 +328,35 @@ public class Camera implements ICamera, Tweenable {
     return new Point2D.Double(x, y);
   }
 
-  /**
-   * Gets the remaining pan time for the camera.
-   *
-   * @return The remaining time (in ticks) for the camera to complete its pan operation.
-   */
+  /// Gets the remaining pan time for the camera.
+  ///
+  /// @return The remaining time (in ticks) for the camera to complete its pan operation.
   protected int panTime() {
     return this.panTime;
   }
 
-  /**
-   * Calculates the width of the camera's viewport in world units.
-   * <p>
-   * The viewport width is determined by dividing the game window's resolution width by the current render scale.
-   *
-   * @return The width of the viewport in world units.
-   */
+  /// Calculates the width of the camera's viewport in world units.
+  ///
+  /// The viewport width is determined by dividing the game window's resolution width by the current render scale.
+  ///
+  /// @return The width of the viewport in world units.
   protected double getViewportWidth() {
     return Game.window().getResolution().getWidth() / this.getRenderScale();
   }
 
-  /**
-   * Calculates the height of the camera's viewport in world units.
-   * <p>
-   * The viewport height is determined by dividing the game window's resolution height by the current render scale.
-   *
-   * @return The height of the viewport in world units.
-   */
+  /// Calculates the height of the camera's viewport in world units.
+  ///
+  /// The viewport height is determined by dividing the game window's resolution height by the current render scale.
+  ///
+  /// @return The height of the viewport in world units.
   protected double getViewportHeight() {
     return Game.window().getResolution().getHeight() / this.getRenderScale();
   }
 
-  /**
-   * Apply shake effect.
-   *
-   * @param cameraLocation the camera location
-   * @return the point2 d
-   */
+  /// Apply shake effect.
+  ///
+  /// @param cameraLocation the camera location
+  /// @return the point2 d
   private Point2D applyShakeEffect(final Point2D cameraLocation) {
     if (this.isShakeEffectActive()) {
       return new Point2D.Double(
@@ -381,68 +366,54 @@ public class Camera implements ICamera, Tweenable {
     return cameraLocation;
   }
 
-  /**
-   * Gets the shake duration.
-   *
-   * @return the shake duration
-   */
+  /// Gets the shake duration.
+  ///
+  /// @return the shake duration
   private int getShakeDuration() {
     return this.shakeDuration;
   }
 
-  /**
-   * Gets the shake offset.
-   *
-   * @return the shake offset
-   */
+  /// Gets the shake offset.
+  ///
+  /// @return the shake offset
   private double getShakeIntensity() {
     return this.shakeIntensity;
   }
 
-  /**
-   * Gets the shake tick.
-   *
-   * @return the shake tick
-   */
+  /// Gets the shake tick.
+  ///
+  /// @return the shake tick
   private long getShakeTick() {
     return this.shakeTick;
   }
 
-  /**
-   * Calculates the horizontal center of the viewport in world units.
-   *
-   * @return The X-coordinate of the viewport's center.
-   */
+  /// Calculates the horizontal center of the viewport in world units.
+  ///
+  /// @return The X-coordinate of the viewport's center.
   private double getViewPortCenterX() {
     return this.getViewportWidth() * 0.5;
   }
 
-  /**
-   * Calculates the vertical center of the viewport in world units.
-   *
-   * @return The Y-coordinate of the viewport's center.
-   */
+  /// Calculates the vertical center of the viewport in world units.
+  ///
+  /// @return The Y-coordinate of the viewport's center.
   private double getViewPortCenterY() {
     return this.getViewportHeight() * 0.5;
   }
 
-  /**
-   * Checks if the camera's shake effect is currently active.
-   * <p>
-   * The shake effect is considered active if the shake tick is non-zero and the time since the shake tick is less than the shake duration.
-   *
-   * @return {@code true} if the shake effect is active; {@code false} otherwise.
-   */
+  /// Checks if the camera's shake effect is currently active.
+  ///
+  /// The shake effect is considered active if the shake tick is non-zero and the time since the shake tick is less than the shake duration.
+  ///
+  /// @return `true` if the shake effect is active; `false` otherwise.
   private boolean isShakeEffectActive() {
     return this.getShakeTick() != 0
       && Game.time().since(this.getShakeTick()) < this.getShakeDuration();
   }
 
-  /**
-   * Provides current tween values for camera-related {@link TweenType}s so that the camera can be animated by the
-   * {@link de.gurkenlabs.litiengine.tweening.TweenEngine}. Supports {@link TweenType#ZOOM}, {@link TweenType#LOCATION_X},
-   * {@link TweenType#LOCATION_Y} and {@link TweenType#LOCATION_XY} for zooming and panning.
-   */
+  /// Provides current tween values for camera-related [TweenType]s so that the camera can be animated by the
+  /// [de.gurkenlabs.litiengine.tweening.TweenEngine]. Supports [TweenType#ZOOM], [TweenType#LOCATION_X],
+  /// [TweenType#LOCATION_Y] and [TweenType#LOCATION_XY] for zooming and panning.
   @Override
   public float[] getTweenValues(final TweenType tweenType) {
     return switch (tweenType) {
@@ -454,9 +425,7 @@ public class Camera implements ICamera, Tweenable {
     };
   }
 
-  /**
-   * Applies interpolated tween values to the camera. See {@link #getTweenValues(TweenType)} for the list of supported tween types.
-   */
+  /// Applies interpolated tween values to the camera. See [#getTweenValues(TweenType)] for the list of supported tween types.
   @Override
   public void setTweenValues(final TweenType tweenType, final float[] newValues) {
     switch (tweenType) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CameraEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CameraEvent.java
@@ -3,32 +3,24 @@ package de.gurkenlabs.litiengine.graphics;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * Represents an abstract event related to the camera. This class serves as the base for all camera-related events in the game engine.
- */
+/// Represents an abstract event related to the camera. This class serves as the base for all camera-related events in the game engine.
 public abstract class CameraEvent extends EventObject {
   @Serial private static final long serialVersionUID = 6376977651819216179L;
 
-  /**
-   * The camera associated with this event. This field is transient to avoid serialization issues.
-   */
+  /// The camera associated with this event. This field is transient to avoid serialization issues.
   private final transient ICamera camera;
 
-  /**
-   * Initializes a new instance of the {@code CameraEvent} class.
-   *
-   * @param source The camera that is the source of this event.
-   */
+  /// Initializes a new instance of the `CameraEvent` class.
+  ///
+  /// @param source The camera that is the source of this event.
   CameraEvent(ICamera source) {
     super(source);
     this.camera = source;
   }
 
-  /**
-   * Gets the camera associated with this event.
-   *
-   * @return The {@code ICamera} instance that triggered this event.
-   */
+  /// Gets the camera associated with this event.
+  ///
+  /// @return The `ICamera` instance that triggered this event.
   public ICamera getCamera() {
     return this.camera;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ColorLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ColorLayer.java
@@ -10,21 +10,17 @@ import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 
-/**
- * Represents an abstract color layer that can be rendered and updated.
- */
+/// Represents an abstract color layer that can be rendered and updated.
 public abstract class ColorLayer implements IRenderable {
   private final Environment environment;
   private final BufferedImage layer;
 
   private Color color;
 
-  /**
-   * Constructs a new ColorLayer with the specified environment and color.
-   *
-   * @param env   The environment associated with this color layer.
-   * @param color The initial color of the layer.
-   */
+  /// Constructs a new ColorLayer with the specified environment and color.
+  ///
+  /// @param env   The environment associated with this color layer.
+  /// @param color The initial color of the layer.
   protected ColorLayer(Environment env, final Color color) {
     this.environment = env;
     this.color = color;
@@ -40,20 +36,16 @@ public abstract class ColorLayer implements IRenderable {
     ImageRenderer.render(g, this.layer, -viewport.getX(), -viewport.getY());
   }
 
-  /**
-   * Gets the current color of the layer.
-   *
-   * @return The current color of the layer.
-   */
+  /// Gets the current color of the layer.
+  ///
+  /// @return The current color of the layer.
   public Color getColor() {
     return this.color;
   }
 
-  /**
-   * Sets the alpha value of the current color.
-   *
-   * @param ambientAlpha The alpha value to set, clamped between 0 and 255.
-   */
+  /// Sets the alpha value of the current color.
+  ///
+  /// @param ambientAlpha The alpha value to set, clamped between 0 and 255.
   public void setAlpha(int ambientAlpha) {
     this.setColor(
       new Color(
@@ -64,11 +56,9 @@ public abstract class ColorLayer implements IRenderable {
     this.updateSection(this.environment.getMap().getBounds());
   }
 
-  /**
-   * Sets the color of the layer.
-   *
-   * @param color The color to set. If null, the method returns without making changes.
-   */
+  /// Sets the color of the layer.
+  ///
+  /// @param color The color to set. If null, the method returns without making changes.
   public void setColor(final Color color) {
     if (color == null) {
       return;
@@ -78,11 +68,9 @@ public abstract class ColorLayer implements IRenderable {
     this.updateSection(this.environment.getMap().getBounds());
   }
 
-  /**
-   * Updates a specific section of the layer.
-   *
-   * @param section The section of the layer to update.
-   */
+  /// Updates a specific section of the layer.
+  ///
+  /// @param section The section of the layer to update.
   public void updateSection(Rectangle2D section) {
     if (this.getColor() == null || section == null || section.isEmpty()) {
       return;
@@ -101,27 +89,21 @@ public abstract class ColorLayer implements IRenderable {
     g.dispose();
   }
 
-  /**
-   * Renders a specific section of the layer.
-   *
-   * @param g       The graphics context to use for rendering.
-   * @param section The section of the layer to render.
-   */
+  /// Renders a specific section of the layer.
+  ///
+  /// @param g       The graphics context to use for rendering.
+  /// @param section The section of the layer to render.
   protected abstract void renderSection(Graphics2D g, Rectangle2D section);
 
-  /**
-   * Clears a specific section of the layer.
-   *
-   * @param g       The graphics context to use for clearing.
-   * @param section The section of the layer to clear.
-   */
+  /// Clears a specific section of the layer.
+  ///
+  /// @param g       The graphics context to use for clearing.
+  /// @param section The section of the layer to clear.
   protected abstract void clearSection(Graphics2D g, Rectangle2D section);
 
-  /**
-   * Gets the environment associated with this color layer.
-   *
-   * @return The environment associated with this color layer.
-   */
+  /// Gets the environment associated with this color layer.
+  ///
+  /// @return The environment associated with this color layer.
   protected Environment getEnvironment() {
     return this.environment;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CreatureAnimationState.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CreatureAnimationState.java
@@ -2,55 +2,44 @@ package de.gurkenlabs.litiengine.graphics;
 
 import java.util.Locale;
 
-/**
- * Represents the different animation states for a creature in the game.
- *
- * <p>The {@code CreatureAnimationState} enum defines three states:
- * <ul>
- *   <li>{@link #IDLE} - The creature is idle and not moving.</li>
- *   <li>{@link #MOVE} - The creature is moving.</li>
- *   <li>{@link #DEAD} - The creature is dead.</li>
- * </ul>
- *
- * <p>Each state is associated with a sprite string, which is derived from the
- * name of the state in lowercase.
- */
+/// Represents the different animation states for a creature in the game.
+///
+/// The `CreatureAnimationState` enum defines three states:
+///
+/// - [#IDLE] - The creature is idle and not moving.
+/// - [#MOVE] - The creature is moving.
+/// - [#DEAD] - The creature is dead.
+///
+/// Each state is associated with a sprite string, which is derived from the
+/// name of the state in lowercase.
 public enum CreatureAnimationState {
   IDLE,
   MOVE,
   DEAD;
 
-  /**
-   * The sprite string associated with the animation state.
-   */
+  /// The sprite string associated with the animation state.
   private final String spriteString;
 
-  /**
-   * Initializes the {@code CreatureAnimationState} with its corresponding sprite string.
-   *
-   * <p>The sprite string is derived from the name of the state in lowercase.
-   */
+  /// Initializes the `CreatureAnimationState` with its corresponding sprite string.
+  ///
+  /// The sprite string is derived from the name of the state in lowercase.
   CreatureAnimationState() {
     this.spriteString = name().toLowerCase(Locale.ROOT);
   }
 
-  /**
-   * Retrieves the sprite string associated with this animation state.
-   *
-   * @return the sprite string for this state
-   */
+  /// Retrieves the sprite string associated with this animation state.
+  ///
+  /// @return the sprite string for this state
   public String spriteString() {
     return spriteString;
   }
 
-  /**
-   * Gets the opposite animation state for this state.
-   *
-   * <p>If the current state is {@link #IDLE}, the opposite is {@link #MOVE}.
-   * Otherwise, the opposite is {@link #IDLE}.
-   *
-   * @return the opposite animation state
-   */
+  /// Gets the opposite animation state for this state.
+  ///
+  /// If the current state is [#IDLE], the opposite is [#MOVE].
+  /// Otherwise, the opposite is [#IDLE].
+  ///
+  /// @return the opposite animation state
   public CreatureAnimationState getOpposite() {
     return this == CreatureAnimationState.IDLE ? MOVE : IDLE;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CreatureShadowImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/CreatureShadowImageEffect.java
@@ -9,9 +9,7 @@ import java.awt.geom.Ellipse2D;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 
-/**
- * Represents an image effect that applies a shadow to a creature. Extends the ImageEffect class.
- */
+/// Represents an image effect that applies a shadow to a creature. Extends the ImageEffect class.
 public class CreatureShadowImageEffect extends ImageEffect {
   private static final Color DEFAULT_SHADOW_COLOR = new Color(124, 164, 174, 120);
 
@@ -21,82 +19,66 @@ public class CreatureShadowImageEffect extends ImageEffect {
   private float offsetX = 0;
   private float offsetY = 0;
 
-  /**
-   * Initializes a new instance of the {@code CreatureShadowImageEffect}.
-   *
-   * @param creature The creature to which this affect will be applied to.
-   */
+  /// Initializes a new instance of the `CreatureShadowImageEffect`.
+  ///
+  /// @param creature The creature to which this affect will be applied to.
   public CreatureShadowImageEffect(final Creature creature) {
     this(creature, DEFAULT_SHADOW_COLOR);
   }
 
-  /**
-   * Initializes a new instance of the {@code CreatureShadowImageEffect}.
-   *
-   * @param creature    The creature to which this affect will be applied to.
-   * @param shadowColor The color of the shadow.
-   */
+  /// Initializes a new instance of the `CreatureShadowImageEffect`.
+  ///
+  /// @param creature    The creature to which this affect will be applied to.
+  /// @param shadowColor The color of the shadow.
   public CreatureShadowImageEffect(final Creature creature, final Color shadowColor) {
     super(0, "shadow");
     this.creature = creature;
     this.shadowColor = shadowColor;
   }
 
-  /**
-   * Gets the creature associated with this image effect.
-   *
-   * @return the creature associated with this image effect
-   */
+  /// Gets the creature associated with this image effect.
+  ///
+  /// @return the creature associated with this image effect
   public Creature getCreature() {
     return this.creature;
   }
 
-  /**
-   * Gets the horizontal offset for the shadow.
-   *
-   * @return the horizontal offset for the shadow
-   */
+  /// Gets the horizontal offset for the shadow.
+  ///
+  /// @return the horizontal offset for the shadow
   public float getOffsetX() {
     return this.offsetX;
   }
 
-  /**
-   * Sets the horizontal offset for the shadow.
-   *
-   * @param offsetX the new horizontal offset for the shadow
-   * @return the updated CreatureShadowImageEffect instance
-   */
+  /// Sets the horizontal offset for the shadow.
+  ///
+  /// @param offsetX the new horizontal offset for the shadow
+  /// @return the updated CreatureShadowImageEffect instance
   public CreatureShadowImageEffect setOffsetX(float offsetX) {
     this.offsetX = offsetX;
     return this;
   }
 
-  /**
-   * Gets the vertical offset for the shadow.
-   *
-   * @return the vertical offset for the shadow
-   */
+  /// Gets the vertical offset for the shadow.
+  ///
+  /// @return the vertical offset for the shadow
   public float getOffsetY() {
     return this.offsetY;
   }
 
-  /**
-   * Sets the vertical offset for the shadow.
-   *
-   * @param offsetY the new vertical offset for the shadow
-   * @return the updated CreatureShadowImageEffect instance
-   */
+  /// Sets the vertical offset for the shadow.
+  ///
+  /// @param offsetY the new vertical offset for the shadow
+  /// @return the updated CreatureShadowImageEffect instance
   public CreatureShadowImageEffect setOffsetY(float offsetY) {
     this.offsetY = offsetY;
     return this;
   }
 
-  /**
-   * Applies the shadow effect to the specified BufferedImage.
-   *
-   * @param image the BufferedImage to apply the effect to
-   * @return the BufferedImage with the shadow effect applied
-   */
+  /// Applies the shadow effect to the specified BufferedImage.
+  ///
+  /// @param image the BufferedImage to apply the effect to
+  /// @return the BufferedImage with the shadow effect applied
   @Override
   public BufferedImage apply(BufferedImage image) {
     if (this.getCreature().isDead()) {
@@ -117,15 +99,13 @@ public class CreatureShadowImageEffect extends ImageEffect {
     return buffer;
   }
 
-  /**
-   * Creates an ellipse representing the shadow based on the sprite dimensions and offsets.
-   *
-   * @param spriteWidth  the width of the sprite
-   * @param spriteHeight the height of the sprite
-   * @param offsetX      the horizontal offset for the shadow
-   * @param offsetY      the vertical offset for the shadow
-   * @return an Ellipse2D object representing the shadow
-   */
+  /// Creates an ellipse representing the shadow based on the sprite dimensions and offsets.
+  ///
+  /// @param spriteWidth  the width of the sprite
+  /// @param spriteHeight the height of the sprite
+  /// @param offsetX      the horizontal offset for the shadow
+  /// @param offsetY      the vertical offset for the shadow
+  /// @return an Ellipse2D object representing the shadow
   protected Ellipse2D getShadowEllipse(
     final float spriteWidth, final float spriteHeight, float offsetX, float offsetY) {
     final double ellipseWidth = 0.60 * spriteWidth;
@@ -135,15 +115,13 @@ public class CreatureShadowImageEffect extends ImageEffect {
     return new Ellipse2D.Double(startX + offsetX, startY + offsetY, ellipseWidth, ellipseHeight);
   }
 
-  /**
-   * Draws the shadow on the specified Graphics2D context.
-   *
-   * @param graphics     the Graphics2D context to draw the shadow on
-   * @param spriteWidth  the width of the sprite
-   * @param spriteHeight the height of the sprite
-   * @param offsetX      the horizontal offset for the shadow
-   * @param offsetY      the vertical offset for the shadow
-   */
+  /// Draws the shadow on the specified Graphics2D context.
+  ///
+  /// @param graphics     the Graphics2D context to draw the shadow on
+  /// @param spriteWidth  the width of the sprite
+  /// @param spriteHeight the height of the sprite
+  /// @param offsetX      the horizontal offset for the shadow
+  /// @param offsetY      the vertical offset for the shadow
   protected void drawShadow(
     final Graphics2D graphics,
     final float spriteWidth,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/DebugRenderer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/DebugRenderer.java
@@ -26,22 +26,19 @@ import java.text.DecimalFormat;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * The {@code DebugRenderer} class provides functionality for rendering debug information in the game. It includes methods for rendering debug details
- * for entities and maps, as well as managing listeners for custom debug rendering.
- *
- * <p>This class is final and cannot be instantiated. It serves as a utility class
- * for debug rendering purposes.
- *
- * <p>Key features:
- * <ul>
- *   <li>Render debug information for entities, such as bounding boxes and hitboxes.</li>
- *   <li>Render debug information for maps, such as collision boxes and tile metrics.</li>
- *   <li>Support for adding and removing custom debug rendering listeners.</li>
- * </ul>
- *
- * <p>Note: Debug rendering is controlled by the game's debug configuration settings.
- */
+/// The `DebugRenderer` class provides functionality for rendering debug information in the game. It includes methods for rendering debug details
+/// for entities and maps, as well as managing listeners for custom debug rendering.
+///
+/// This class is final and cannot be instantiated. It serves as a utility class
+/// for debug rendering purposes.
+///
+/// Key features:
+///
+/// - Render debug information for entities, such as bounding boxes and hitboxes.
+/// - Render debug information for maps, such as collision boxes and tile metrics.
+/// - Support for adding and removing custom debug rendering listeners.
+///
+/// Note: Debug rendering is controlled by the game's debug configuration settings.
 public final class DebugRenderer {
   private static final List<MapRenderedListener> mapDebugListener;
   private static final List<EntityRenderedListener> entityDebugListeners;
@@ -55,61 +52,50 @@ public final class DebugRenderer {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Add the specified entity rendered listener to attach custom debug rendering after the default debug information for an entity has been rendered.
-   *
-   * @param listener The listener to add.
-   */
+  /// Add the specified entity rendered listener to attach custom debug rendering after the default debug information for an entity has been rendered.
+  ///
+  /// @param listener The listener to add.
   public static void addEntityDebugListener(EntityRenderedListener listener) {
     entityDebugListeners.add(listener);
   }
 
-  /**
-   * Removes the specified entity rendered listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified entity rendered listener.
+  ///
+  /// @param listener The listener to remove.
   public static void removeEntityDebugListener(EntityRenderedListener listener) {
     entityDebugListeners.remove(listener);
   }
 
-  /**
-   * Add the specified map rendered listener to attach custom debug rendering after layers of the type {@code GROUND} have beend rendered.
-   *
-   * @param listener The listener to add.
-   * @see RenderType#GROUND
-   * @see Environment#render(Graphics2D)
-   */
+  /// Add the specified map rendered listener to attach custom debug rendering after layers of the type `GROUND` have beend rendered.
+  ///
+  /// @param listener The listener to add.
+  /// @see RenderType#GROUND
+  /// @see Environment#render(Graphics2D)
   public static void addMapRenderedListener(MapRenderedListener listener) {
     mapDebugListener.add(listener);
   }
 
-  /**
-   * Removes the specified map rendered listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified map rendered listener.
+  ///
+  /// @param listener The listener to remove.
   public static void removeMapRenderedListener(MapRenderedListener listener) {
     mapDebugListener.remove(listener);
   }
 
-  /**
-   * Renders debug information for a specific entity.
-   *
-   * <p>This method draws various debug details for the provided entity, such as:
-   * <ul>
-   *   <li>Entity names, if enabled in the debug configuration.</li>
-   *   <li>Hitboxes for combat entities, highlighted in red.</li>
-   *   <li>Bounding boxes for all entities, highlighted in red, and additional range indicators for sound sources.</li>
-   *   <li>Collision boxes for collision entities, highlighted in red (active) or orange (inactive).</li>
-   * </ul>
-   *
-   * <p>After rendering the default debug information, it triggers any registered {@code EntityRenderedListener}
-   * to allow custom debug rendering.
-   *
-   * @param g      The {@code Graphics2D} object used for rendering.
-   * @param entity The entity for which debug information is rendered.
-   */
+  /// Renders debug information for a specific entity.
+  ///
+  /// This method draws various debug details for the provided entity, such as:
+  ///
+  /// - Entity names, if enabled in the debug configuration.
+  /// - Hitboxes for combat entities, highlighted in red.
+  /// - Bounding boxes for all entities, highlighted in red, and additional range indicators for sound sources.
+  /// - Collision boxes for collision entities, highlighted in red (active) or orange (inactive).
+  ///
+  /// After rendering the default debug information, it triggers any registered `EntityRenderedListener`
+  /// to allow custom debug rendering.
+  ///
+  /// @param g      The `Graphics2D` object used for rendering.
+  /// @param entity The entity for which debug information is rendered.
   public static void renderEntityDebugInfo(final Graphics2D g, final IEntity entity) {
     if (!Game.config().debug().isDebugEnabled()) {
       return;
@@ -157,21 +143,18 @@ public final class DebugRenderer {
     }
   }
 
-  /**
-   * Renders debug information for the specified map.
-   *
-   * <p>This method draws various debug details for the provided map, such as:
-   * <ul>
-   *   <li>Collision boxes from the shape layer, highlighted in red.</li>
-   *   <li>Tile metrics, including mouse tile information, if enabled in the debug configuration.</li>
-   * </ul>
-   *
-   * <p>After rendering the default debug information, it triggers any registered {@code MapRenderedListener}
-   * to allow custom debug rendering.
-   *
-   * @param g   The {@code Graphics2D} object used for rendering.
-   * @param map The map for which debug information is rendered.
-   */
+  /// Renders debug information for the specified map.
+  ///
+  /// This method draws various debug details for the provided map, such as:
+  ///
+  /// - Collision boxes from the shape layer, highlighted in red.
+  /// - Tile metrics, including mouse tile information, if enabled in the debug configuration.
+  ///
+  /// After rendering the default debug information, it triggers any registered `MapRenderedListener`
+  /// to allow custom debug rendering.
+  ///
+  /// @param g   The `Graphics2D` object used for rendering.
+  /// @param map The map for which debug information is rendered.
   public static void renderMapDebugInfo(final Graphics2D g, final IMap map) {
     if (!Game.config().debug().isDebugEnabled()) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/EntityRotationImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/EntityRotationImageEffect.java
@@ -5,12 +5,10 @@ import de.gurkenlabs.litiengine.entities.IEntity;
 public class EntityRotationImageEffect extends RotationImageEffect {
   private final IEntity entity;
 
-  /**
-   * Initializes a new instance of the {@code EntityRotationImageEffect}.
-   *
-   * @param entity
-   *          The entity to which this affect will be applied.
-   */
+  /// Initializes a new instance of the `EntityRotationImageEffect`.
+  ///
+  /// @param entity
+  /// The entity to which this affect will be applied.
   public EntityRotationImageEffect(final IEntity entity) {
     super(-1, 0);
     this.entity = entity;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/FreeFlightCamera.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/FreeFlightCamera.java
@@ -12,29 +12,25 @@ public class FreeFlightCamera extends Camera implements IUpdateable {
   private double velocity;
   private double scrollPadding;
 
-  /** Initializes a new instance of the {@code FreeFlightCamera}. */
+  /// Initializes a new instance of the `FreeFlightCamera`.
   public FreeFlightCamera() {
     this(0, 0);
   }
 
-  /**
-   * Initializes a new instance of the {@code FreeFlightCamera} with the specified initial focus.
-   *
-   * @param x
-   *          The x-coordinate of the initial focus of this instance.
-   * @param y
-   *          The y-coordinate of the initial focus of this instance.
-   */
+  /// Initializes a new instance of the `FreeFlightCamera` with the specified initial focus.
+  ///
+  /// @param x
+  /// The x-coordinate of the initial focus of this instance.
+  /// @param y
+  /// The y-coordinate of the initial focus of this instance.
   public FreeFlightCamera(double x, double y) {
     this(new Point2D.Double(x, y));
   }
 
-  /**
-   * Initializes a new instance of the {@code FreeFlightCamera} with the specified initial focus.
-   *
-   * @param focus
-   *          The initial focus of this instance.
-   */
+  /// Initializes a new instance of the `FreeFlightCamera` with the specified initial focus.
+  ///
+  /// @param focus
+  /// The initial focus of this instance.
   public FreeFlightCamera(final Point2D focus) {
     this.setFocus(focus);
     this.velocity = DEFAULT_SCROLL_PIXELS_PER_SECOND;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ICamera.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ICamera.java
@@ -9,285 +9,221 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.EventListener;
 
-/**
- * The Interface ICamera defines methods that allow to determine where entities or tiles are rendered on the current
- * screen.
- *
- * <p>
- * Camera control is based on a Focus system. Generally, the camera will always try to keep the focus point in the
- * center of the viewport.
- *
- * <p>
- * There are two coordinate systems referenced in ICamera methods: map coordinates, and screen coordinates. The camera
- * is responsible for converting between the two coordinate systems.
- */
+/// The Interface ICamera defines methods that allow to determine where entities or tiles are rendered on the current
+/// screen.
+///
+/// Camera control is based on a Focus system. Generally, the camera will always try to keep the focus point in the
+/// center of the viewport.
+///
+/// There are two coordinate systems referenced in ICamera methods: map coordinates, and screen coordinates. The camera
+/// is responsible for converting between the two coordinate systems.
 public interface ICamera extends IUpdateable {
-  /**
-   * Adds the specified zoom changed listener to receive events when the zoom of this camera changed.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified zoom changed listener to receive events when the zoom of this camera changed.
+  ///
+  /// @param listener
+  /// The listener to add.
   void onZoom(ZoomChangedListener listener);
 
-  /**
-   * Removes the specified zoom changed listener.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Removes the specified zoom changed listener.
+  ///
+  /// @param listener
+  /// The listener to add.
   void removeZoomListener(ZoomChangedListener listener);
 
-  /**
-   * Adds the specified focus changed listener to receive events when the focus of this camera changed.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified focus changed listener to receive events when the focus of this camera changed.
+  ///
+  /// @param listener
+  /// The listener to add.
   void onFocus(FocusChangedListener listener);
 
-  /**
-   * Removes the specified focus changed listener.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Removes the specified focus changed listener.
+  ///
+  /// @param listener
+  /// The listener to add.
   void removeFocusListener(FocusChangedListener listener);
 
-  /**
-   * Gets the map location that is focused by this camera.
-   *
-   * @return the focus's location in map coordinates
-   */
+  /// Gets the map location that is focused by this camera.
+  ///
+  /// @return the focus's location in map coordinates
   Point2D getFocus();
 
-  /**
-   * Converts a point in screen coordinates into a map location.
-   *
-   * @param point
-   *          the point in screen coordinates
-   * @return the map location
-   */
+  /// Converts a point in screen coordinates into a map location.
+  ///
+  /// @param point
+  /// the point in screen coordinates
+  /// @return the map location
   Point2D getMapLocation(Point2D point);
 
-  /**
-   * Gets the x coordinate of the viewport's origin.
-   *
-   * @return the offset, in screen coordinates
-   */
+  /// Gets the x coordinate of the viewport's origin.
+  ///
+  /// @return the offset, in screen coordinates
   double getPixelOffsetX();
 
-  /**
-   * Gets the y coordinate of the viewport's origin.
-   *
-   * @return the offset, in screen coordinates
-   */
+  /// Gets the y coordinate of the viewport's origin.
+  ///
+  /// @return the offset, in screen coordinates
   double getPixelOffsetY();
 
-  /**
-   * Gets the camera's viewport region, in screen coordinates.
-   *
-   * @return the viewport region, in screen coordinates
-   */
+  /// Gets the camera's viewport region, in screen coordinates.
+  ///
+  /// @return the viewport region, in screen coordinates
   Rectangle2D getViewport();
 
-  /**
-   * Gets the center of the entity, in screen coordinates.
-   *
-   * @param entity
-   *          The entity to retrieve the dimension center for.
-   * @return the center, in screen coordinates
-   */
+  /// Gets the center of the entity, in screen coordinates.
+  ///
+  /// @param entity
+  /// The entity to retrieve the dimension center for.
+  /// @return the center, in screen coordinates
   Point2D getViewportDimensionCenter(IEntity entity);
 
-  /**
-   * Converts a location in map coordinates into screen coordinates.
-   *
-   * @param x
-   *          The x-coordinate of the viewport location.
-   * @param y
-   *          The y-coordinate of the viewport location.
-   * @return the screen location
-   */
+  /// Converts a location in map coordinates into screen coordinates.
+  ///
+  /// @param x
+  /// The x-coordinate of the viewport location.
+  /// @param y
+  /// The y-coordinate of the viewport location.
+  /// @return the screen location
   Point2D getViewportLocation(double x, double y);
 
-  /**
-   * Converts the entity's location into screen coordinates.
-   *
-   * @param entity
-   *          the entity
-   * @return the screen location
-   */
+  /// Converts the entity's location into screen coordinates.
+  ///
+  /// @param entity
+  /// the entity
+  /// @return the screen location
   default Point2D getViewportLocation(IEntity entity) {
     Point2D entityLocation = entity.getLocation();
     return getViewportLocation(entityLocation.getX(), entityLocation.getY());
   }
 
-  /**
-   * Converts a location in map coordinates into screen coordinates.
-   *
-   * @param point
-   *          the point
-   * @return the screen location
-   */
+  /// Converts a location in map coordinates into screen coordinates.
+  ///
+  /// @param point
+  /// the point
+  /// @return the screen location
   default Point2D getViewportLocation(Point2D point) {
     return getViewportLocation(point.getX(), point.getY());
   }
 
-  /**
-   * Combines this camera's zoom with the game's render scale.
-   *
-   * @see RenderEngine#setBaseRenderScale(float)
-   * @return the scale factor
-   */
+  /// Combines this camera's zoom with the game's render scale.
+  ///
+  /// @see RenderEngine#setBaseRenderScale(float)
+  /// @return the scale factor
   default float getRenderScale() {
     return Game.graphics().getBaseRenderScale()
         * Game.window().getResolutionScale()
         * this.getZoom();
   }
 
-  /**
-   * The zoom factor of this camera.
-   *
-   * @return the scale factor
-   */
+  /// The zoom factor of this camera.
+  ///
+  /// @return the scale factor
   float getZoom();
 
-  /**
-   * Focuses the camera on a given point.
-   *
-   * @param focus
-   *          the point, in map coordinates
-   */
+  /// Focuses the camera on a given point.
+  ///
+  /// @param focus
+  /// the point, in map coordinates
   default void setFocus(Point2D focus) {
     setFocus(focus.getX(), focus.getY());
   }
 
-  /**
-   * Focuses the camera on a given point.
-   *
-   * @param x
-   *          the x coordinate of the point, in map coordinates
-   * @param y
-   *          the y coordinate of the point, in map coordinates
-   */
+  /// Focuses the camera on a given point.
+  ///
+  /// @param x
+  /// the x coordinate of the point, in map coordinates
+  /// @param y
+  /// the y coordinate of the point, in map coordinates
   void setFocus(double x, double y);
 
-  /**
-   * Pans the camera over the specified duration (in frames) to the target location, after accounting for modifications
-   * such as clamping to the map. Event listeners attached to this camera are notified when the pan completes.
-   *
-   * @param focus
-   *          the new focus for the camera once the panning is complete
-   * @param duration
-   *          the number of frames between this call and when the pan completes
-   */
+  /// Pans the camera over the specified duration (in frames) to the target location, after accounting for modifications
+  /// such as clamping to the map. Event listeners attached to this camera are notified when the pan completes.
+  ///
+  /// @param focus
+  /// the new focus for the camera once the panning is complete
+  /// @param duration
+  /// the number of frames between this call and when the pan completes
   void pan(Point2D focus, int duration);
 
-  /**
-   * Pans the camera over the specified duration (in frames) to the target location, after accounting for modifications
-   * such as clamping to the map. Event listeners attached to this camera are notified when the pan completes.
-   *
-   * @param x
-   *          the new X coordinate for the camera once the panning is complete
-   * @param y
-   *          the new Y coordinate for the camera once the panning is complete
-   * @param duration
-   *          the number of frames between this call and when the pan completes
-   */
+  /// Pans the camera over the specified duration (in frames) to the target location, after accounting for modifications
+  /// such as clamping to the map. Event listeners attached to this camera are notified when the pan completes.
+  ///
+  /// @param x
+  /// the new X coordinate for the camera once the panning is complete
+  /// @param y
+  /// the new Y coordinate for the camera once the panning is complete
+  /// @param duration
+  /// the number of frames between this call and when the pan completes
   void pan(double x, double y, int duration);
 
-  /**
-   * Changes the camera's zoom over the specified duration (in frames) to the target zoom.
-   *
-   * @param zoom
-   *          the new zoom scale
-   * @param duration
-   *          the number of frames between this call and when the zoom completes
-   */
+  /// Changes the camera's zoom over the specified duration (in frames) to the target zoom.
+  ///
+  /// @param zoom
+  /// the new zoom scale
+  /// @param duration
+  /// the number of frames between this call and when the zoom completes
   void setZoom(float zoom, int duration);
 
-  /**
-   * Returns whether this camera will clamp the viewport to the bounds of the map.
-   *
-   * @return True if the camera viewport is currently clamped to the map boundaries; otherwise false.
-   */
+  /// Returns whether this camera will clamp the viewport to the bounds of the map.
+  ///
+  /// @return True if the camera viewport is currently clamped to the map boundaries; otherwise false.
   boolean isClampToMap();
 
-  /**
-   * Set the camera to clamp the viewport to the bounds of the map.
-   *
-   * @param clampToMap
-   *          A flag indicating whether the camera viewport should be clamped to the map boundaries.
-   */
+  /// Set the camera to clamp the viewport to the bounds of the map.
+  ///
+  /// @param clampToMap
+  /// A flag indicating whether the camera viewport should be clamped to the map boundaries.
   void setClampToMap(final boolean clampToMap);
 
-  /**
-   * Sets the alignment for clamping the camera to the map boundaries.
-   *
-   * @param align  The horizontal alignment (e.g., left, center, or right).
-   * @param valign The vertical alignment (e.g., top, middle, or bottom).
-   */
+  /// Sets the alignment for clamping the camera to the map boundaries.
+  ///
+  /// @param align  The horizontal alignment (e.g., left, center, or right).
+  /// @param valign The vertical alignment (e.g., top, middle, or bottom).
   void setClampAlign(Align align, Valign valign);
 
-  /**
-   * Gets the current horizontal alignment used for clamping the camera to the map boundaries.
-   *
-   * @return The horizontal alignment.
-   */
+  /// Gets the current horizontal alignment used for clamping the camera to the map boundaries.
+  ///
+  /// @return The horizontal alignment.
   Align getClampAlign();
 
-  /**
-   * Gets the current vertical alignment used for clamping the camera to the map boundaries.
-   *
-   * @return The vertical alignment.
-   */
+  /// Gets the current vertical alignment used for clamping the camera to the map boundaries.
+  ///
+  /// @return The vertical alignment.
   Valign getClampValign();
 
-  /**
-   * Shake the camera for the specified duration (in frames). The way the camera shakes is implementation defined.
-   *
-   * @param intensity
-   *          The intensity of the screen shake effect.
-   * @param delay
-   *          The delay before the effect starts.
-   * @param duration
-   *          The duration of the effect.
-   */
+  /// Shake the camera for the specified duration (in frames). The way the camera shakes is implementation defined.
+  ///
+  /// @param intensity
+  /// The intensity of the screen shake effect.
+  /// @param delay
+  /// The delay before the effect starts.
+  /// @param duration
+  /// The duration of the effect.
   void shake(double intensity, final int delay, int duration);
 
-  /** Currently an update function for the shake effect. */
+  /// Currently an update function for the shake effect.
   void updateFocus();
 
-  /**
-   * This listener interface receives zoom events for a camera.
-   *
-   * @see ICamera#onZoom(ZoomChangedListener)
-   */
+  /// This listener interface receives zoom events for a camera.
+  ///
+  /// @see ICamera#onZoom(ZoomChangedListener)
   @FunctionalInterface
   interface ZoomChangedListener extends EventListener {
-    /**
-     * Invoked when the zoom of a camera changed.
-     *
-     * @param event
-     *          The zoom changed event.
-     */
+    /// Invoked when the zoom of a camera changed.
+    ///
+    /// @param event
+    /// The zoom changed event.
     void zoomChanged(ZoomChangedEvent event);
   }
 
-  /**
-   * This listener interface receives focus events for a camera.
-   *
-   * @see ICamera#onFocus(FocusChangedListener)
-   */
+  /// This listener interface receives focus events for a camera.
+  ///
+  /// @see ICamera#onFocus(FocusChangedListener)
   @FunctionalInterface
   interface FocusChangedListener extends EventListener {
-    /**
-     * Invoked when the focus of a camera changed.
-     *
-     * @param event
-     *          The focus changed event.
-     */
+    /// Invoked when the focus of a camera changed.
+    ///
+    /// @param event
+    /// The focus changed event.
     void focusChanged(FocusChangedEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ICamera.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ICamera.java
@@ -5,18 +5,23 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.IUpdateable;
 import de.gurkenlabs.litiengine.Valign;
 import de.gurkenlabs.litiengine.entities.IEntity;
+import de.gurkenlabs.litiengine.environment.GameWorld;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.EventListener;
 
-/// The Interface ICamera defines methods that allow to determine where entities or tiles are rendered on the current
-/// screen.
+/// Defines the viewport through which entities and tiles are rendered on screen.
 ///
 /// Camera control is based on a Focus system. Generally, the camera will always try to keep the focus point in the
 /// center of the viewport.
 ///
 /// There are two coordinate systems referenced in ICamera methods: map coordinates, and screen coordinates. The camera
 /// is responsible for converting between the two coordinate systems.
+///
+/// [Camera] provides the standard focus and zoom behavior. [FreeFlightCamera] allows independent
+/// movement, while [LocationLockCamera] follows a supplied location.
+///
+/// @see GameWorld#camera()
 public interface ICamera extends IUpdateable {
   /// Adds the specified zoom changed listener to receive events when the zoom of this camera changed.
   ///
@@ -27,7 +32,7 @@ public interface ICamera extends IUpdateable {
   /// Removes the specified zoom changed listener.
   ///
   /// @param listener
-  /// The listener to add.
+  /// The listener to remove.
   void removeZoomListener(ZoomChangedListener listener);
 
   /// Adds the specified focus changed listener to receive events when the focus of this camera changed.
@@ -39,7 +44,7 @@ public interface ICamera extends IUpdateable {
   /// Removes the specified focus changed listener.
   ///
   /// @param listener
-  /// The listener to add.
+  /// The listener to remove.
   void removeFocusListener(FocusChangedListener listener);
 
   /// Gets the map location that is focused by this camera.
@@ -190,14 +195,14 @@ public interface ICamera extends IUpdateable {
   /// @return The vertical alignment.
   Valign getClampValign();
 
-  /// Shake the camera for the specified duration (in frames). The way the camera shakes is implementation defined.
+  /// Shakes the camera for the specified duration. The way the camera shakes is implementation defined.
   ///
   /// @param intensity
   /// The intensity of the screen shake effect.
   /// @param delay
-  /// The delay before the effect starts.
+  /// The delay in milliseconds between randomized offset updates.
   /// @param duration
-  /// The duration of the effect.
+  /// The total duration of the effect in milliseconds.
   void shake(double intensity, final int delay, int duration);
 
   /// Currently an update function for the shake effect.

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/IRenderable.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/IRenderable.java
@@ -2,27 +2,21 @@ package de.gurkenlabs.litiengine.graphics;
 
 import java.awt.Graphics2D;
 
-/**
- * A functional interface which indicates that implementing instances can render some visual content onto a provided
- * graphics context.
- *
- * @see Graphics2D
- */
+/// A functional interface which indicates that implementing instances can render some visual content onto a provided
+/// graphics context.
+///
+/// @see Graphics2D
 @FunctionalInterface
 public interface IRenderable {
-  /**
-   * Renders the visual contents of this instance onto the provided graphics context.
-   *
-   * <p>
-   * If an {@code Entity} implements this interface, this method will be called right after the entity was rendered from
-   * the environment. Allowing for a custom rendering mechanism.
-   *
-   * <p>
-   * This interface can be implemented in general by anything that should be rendered to the game's screen.
-   *
-   * @param g
-   *          The current graphics object onto which this instance will render its visual contents.
-   * @see RenderEngine#renderEntity(Graphics2D, de.gurkenlabs.litiengine.entities.IEntity)
-   */
+  /// Renders the visual contents of this instance onto the provided graphics context.
+  ///
+  /// If an `Entity` implements this interface, this method will be called right after the entity was rendered from
+  /// the environment. Allowing for a custom rendering mechanism.
+  ///
+  /// This interface can be implemented in general by anything that should be rendered to the game's screen.
+  ///
+  /// @param g
+  /// The current graphics object onto which this instance will render its visual contents.
+  /// @see RenderEngine#renderEntity(Graphics2D, de.gurkenlabs.litiengine.entities.IEntity)
   void render(Graphics2D g);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ImageEffect.java
@@ -5,120 +5,96 @@ import de.gurkenlabs.litiengine.ITimeToLive;
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 
-/**
- * Represents an abstract image effect that can be applied to a BufferedImage. Implements ITimeToLive and Comparable interfaces.
- */
+/// Represents an abstract image effect that can be applied to a BufferedImage. Implements ITimeToLive and Comparable interfaces.
 public abstract class ImageEffect implements ITimeToLive, Comparable<ImageEffect> {
   private final long aliveTick;
   private final int ttl;
   private String name;
   private int priority;
 
-  /**
-   * Constructs a new ImageEffect with the specified name and a time-to-live of 0.
-   *
-   * @param name the name of the image effect
-   */
+  /// Constructs a new ImageEffect with the specified name and a time-to-live of 0.
+  ///
+  /// @param name the name of the image effect
   protected ImageEffect(final String name) {
     this(0, name);
   }
 
-  /**
-   * Constructs a new ImageEffect with the specified time-to-live and name.
-   *
-   * @param ttl  the time-to-live of the image effect in milliseconds
-   * @param name the name of the image effect
-   */
+  /// Constructs a new ImageEffect with the specified time-to-live and name.
+  ///
+  /// @param ttl  the time-to-live of the image effect in milliseconds
+  /// @param name the name of the image effect
   protected ImageEffect(final int ttl, final String name) {
     this.ttl = ttl;
     this.name = name;
     this.aliveTick = Game.time().now();
   }
 
-  /**
-   * Gets the time in milliseconds that this effect has been alive.
-   *
-   * @return the alive time in milliseconds
-   */
+  /// Gets the time in milliseconds that this effect has been alive.
+  ///
+  /// @return the alive time in milliseconds
   @Override
   public long getAliveTime() {
     return Game.time().since(this.aliveTick);
   }
 
-  /**
-   * Gets the name of this image effect.
-   *
-   * @return the name of the image effect
-   */
+  /// Gets the name of this image effect.
+  ///
+  /// @return the name of the image effect
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Sets the name of this image effect.
-   *
-   * @param name the new name of the image effect
-   */
+  /// Sets the name of this image effect.
+  ///
+  /// @param name the new name of the image effect
   public void setName(String name) {
     this.name = name;
   }
 
-  /**
-   * Gets the time-to-live of this image effect in milliseconds.
-   *
-   * @return the time-to-live in milliseconds
-   */
+  /// Gets the time-to-live of this image effect in milliseconds.
+  ///
+  /// @return the time-to-live in milliseconds
   @Override
   public int getTimeToLive() {
     return this.ttl;
   }
 
-  /**
-   * Checks if the time-to-live of this image effect has been reached.
-   *
-   * @return true if the time-to-live has been reached, false otherwise
-   */
+  /// Checks if the time-to-live of this image effect has been reached.
+  ///
+  /// @return true if the time-to-live has been reached, false otherwise
   @Override
   public boolean timeToLiveReached() {
     return this.getTimeToLive() > 0 && this.getAliveTime() > this.getTimeToLive();
   }
 
-  /**
-   * Gets the priority of this image effect.
-   *
-   * @return the priority of the image effect
-   */
+  /// Gets the priority of this image effect.
+  ///
+  /// @return the priority of the image effect
   public int getPriority() {
     return priority;
   }
 
-  /**
-   * Sets the priority of this image effect.
-   *
-   * @param priority the new priority of the image effect
-   */
+  /// Sets the priority of this image effect.
+  ///
+  /// @param priority the new priority of the image effect
   public void setPriority(int priority) {
     this.priority = priority;
   }
 
-  /**
-   * Compares this image effect with another image effect based on their priority.
-   *
-   * @param other the other image effect to compare to
-   * @return a negative integer, zero, or a positive integer as this image effect's priority is less than, equal to, or greater than the other image
-   * effect's priority
-   */
+  /// Compares this image effect with another image effect based on their priority.
+  ///
+  /// @param other the other image effect to compare to
+  /// @return a negative integer, zero, or a positive integer as this image effect's priority is less than, equal to, or greater than the other image
+  /// effect's priority
   @Override
   public int compareTo(ImageEffect other) {
     return Integer.compare(this.getPriority(), other.getPriority());
   }
 
-  /**
-   * Checks if this image effect is equal to another object. Two image effects are considered equal if they have the same name and priority.
-   *
-   * @param obj the object to compare to
-   * @return true if the objects are equal, false otherwise
-   */
+  /// Checks if this image effect is equal to another object. Two image effects are considered equal if they have the same name and priority.
+  ///
+  /// @param obj the object to compare to
+  /// @return true if the objects are equal, false otherwise
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -131,21 +107,17 @@ public abstract class ImageEffect implements ITimeToLive, Comparable<ImageEffect
     return priority == that.priority && Objects.equals(name, that.name);
   }
 
-  /**
-   * Returns the hash code of this image effect.
-   *
-   * @return the hash code of the image effect
-   */
+  /// Returns the hash code of this image effect.
+  ///
+  /// @return the hash code of the image effect
   @Override
   public int hashCode() {
     return Objects.hash(name, priority);
   }
 
-  /**
-   * Applies this image effect to the specified BufferedImage.
-   *
-   * @param image the BufferedImage to apply the effect to
-   * @return the BufferedImage with the effect applied
-   */
+  /// Applies this image effect to the specified BufferedImage.
+  ///
+  /// @param image the BufferedImage to apply the effect to
+  /// @return the BufferedImage with the effect applied
   public abstract BufferedImage apply(BufferedImage image);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ImageRenderer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ImageRenderer.java
@@ -5,14 +5,12 @@ import java.awt.Image;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 
-/**
- * This class provides static methods to render an {@code Image} to a given {@code Graphics2D} object at specified screen coordinates. It includes
- * methods for rendering images with transformations such as rotation, scaling, and custom affine transformations. This class is final and cannot be
- * instantiated.
- *
- * @see Image
- * @see Graphics2D
- */
+/// This class provides static methods to render an `Image` to a given `Graphics2D` object at specified screen coordinates. It includes
+/// methods for rendering images with transformations such as rotation, scaling, and custom affine transformations. This class is final and cannot be
+/// instantiated.
+///
+/// @see Image
+/// @see Graphics2D
 public final class ImageRenderer {
 
   private static final ThreadLocal<AffineTransform> TEMP_TRANSFORM =
@@ -22,14 +20,12 @@ public final class ImageRenderer {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified coordinates.
-   *
-   * @param g     The graphics object to draw on.
-   * @param image The image to be drawn.
-   * @param x     The x-coordinate of the image.
-   * @param y     The y-coordinate of the image.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified coordinates.
+  ///
+  /// @param g     The graphics object to draw on.
+  /// @param image The image to be drawn.
+  /// @param x     The x-coordinate of the image.
+  /// @param y     The y-coordinate of the image.
   public static void render(final Graphics2D g, final Image image, final double x, final double y) {
     if (image == null) {
       return;
@@ -40,31 +36,27 @@ public final class ImageRenderer {
     g.drawImage(image, t, null);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified location.
-   *
-   * @param g              The graphics object to draw on.
-   * @param image          The image to be drawn.
-   * @param renderLocation The location where the image will be drawn.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified location.
+  ///
+  /// @param g              The graphics object to draw on.
+  /// @param image          The image to be drawn.
+  /// @param renderLocation The location where the image will be drawn.
   public static void render(final Graphics2D g, final Image image, final Point2D renderLocation) {
     render(g, image, renderLocation.getX(), renderLocation.getY());
   }
 
-  /***
-   * Note that rotating an image with 90/180/270 degree is way more performant. than rotating with in other degrees.
-   *
-   * @param g
-   *          The graphics object to draw on.
-   * @param image
-   *          The image to be drawn
-   * @param x
-   *          The x-coordinate of the image.
-   * @param y
-   *          The y-coordinate of the image
-   * @param angle
-   *          The angle by which the image will be rotated.
-   */
+  /// Note that rotating an image with 90/180/270 degree is way more performant. than rotating with in other degrees.
+  ///
+  /// @param g
+  /// The graphics object to draw on.
+  /// @param image
+  /// The image to be drawn
+  /// @param x
+  /// The x-coordinate of the image.
+  /// @param y
+  /// The y-coordinate of the image
+  /// @param angle
+  /// The angle by which the image will be rotated.
   public static void renderRotated(
     final Graphics2D g, final Image image, final double x, final double y, final double angle) {
     if (image == null) {
@@ -84,55 +76,47 @@ public final class ImageRenderer {
     g.drawImage(image, t, null);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified location with rotation.
-   *
-   * @param g              The graphics object to draw on.
-   * @param image          The image to be drawn.
-   * @param renderLocation The location where the image will be drawn.
-   * @param angle          The angle by which the image will be rotated.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified location with rotation.
+  ///
+  /// @param g              The graphics object to draw on.
+  /// @param image          The image to be drawn.
+  /// @param renderLocation The location where the image will be drawn.
+  /// @param angle          The angle by which the image will be rotated.
   public static void renderRotated(
     final Graphics2D g, final Image image, final Point2D renderLocation, final double angle) {
     renderRotated(g, image, renderLocation.getX(), renderLocation.getY(), angle);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified coordinates with scaling.
-   *
-   * @param g     The graphics object to draw on.
-   * @param image The image to be drawn.
-   * @param x     The x-coordinate of the image.
-   * @param y     The y-coordinate of the image.
-   * @param scale The scale factor for both width and height.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified coordinates with scaling.
+  ///
+  /// @param g     The graphics object to draw on.
+  /// @param image The image to be drawn.
+  /// @param x     The x-coordinate of the image.
+  /// @param y     The y-coordinate of the image.
+  /// @param scale The scale factor for both width and height.
   public static void renderScaled(
     final Graphics2D g, final Image image, final double x, final double y, final double scale) {
     renderScaled(g, image, x, y, scale, scale);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified location with scaling.
-   *
-   * @param g        The graphics object to draw on.
-   * @param image    The image to be drawn.
-   * @param location The location where the image will be drawn.
-   * @param scale    The scale factor for both width and height.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified location with scaling.
+  ///
+  /// @param g        The graphics object to draw on.
+  /// @param image    The image to be drawn.
+  /// @param location The location where the image will be drawn.
+  /// @param scale    The scale factor for both width and height.
   public static void renderScaled(
     final Graphics2D g, final Image image, final Point2D location, final double scale) {
     renderScaled(g, image, location.getX(), location.getY(), scale, scale);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified location with scaling.
-   *
-   * @param g        The graphics object to draw on.
-   * @param image    The image to be drawn.
-   * @param location The location where the image will be drawn.
-   * @param scaleX   The scale factor for the width.
-   * @param scaleY   The scale factor for the height.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified location with scaling.
+  ///
+  /// @param g        The graphics object to draw on.
+  /// @param image    The image to be drawn.
+  /// @param location The location where the image will be drawn.
+  /// @param scaleX   The scale factor for the width.
+  /// @param scaleY   The scale factor for the height.
   public static void renderScaled(
     final Graphics2D g,
     final Image image,
@@ -142,16 +126,14 @@ public final class ImageRenderer {
     renderScaled(g, image, location.getX(), location.getY(), scaleX, scaleY);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified coordinates with scaling.
-   *
-   * @param g      The graphics object to draw on.
-   * @param image  The image to be drawn.
-   * @param x      The x-coordinate of the image.
-   * @param y      The y-coordinate of the image.
-   * @param scaleX The scale factor for the width.
-   * @param scaleY The scale factor for the height.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified coordinates with scaling.
+  ///
+  /// @param g      The graphics object to draw on.
+  /// @param image  The image to be drawn.
+  /// @param x      The x-coordinate of the image.
+  /// @param y      The y-coordinate of the image.
+  /// @param scaleX The scale factor for the width.
+  /// @param scaleY The scale factor for the height.
   public static void renderScaled(
     final Graphics2D g,
     final Image image,
@@ -176,14 +158,12 @@ public final class ImageRenderer {
     g.drawImage(image, t, null);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified location with a custom affine transformation.
-   *
-   * @param g              The graphics object to draw on.
-   * @param image          The image to be drawn.
-   * @param renderLocation The location where the image will be drawn.
-   * @param transform      The affine transformation to be applied to the image.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified location with a custom affine transformation.
+  ///
+  /// @param g              The graphics object to draw on.
+  /// @param image          The image to be drawn.
+  /// @param renderLocation The location where the image will be drawn.
+  /// @param transform      The affine transformation to be applied to the image.
   public static void renderTransformed(
     final Graphics2D g,
     final Image image,
@@ -192,15 +172,13 @@ public final class ImageRenderer {
     renderTransformed(g, image, renderLocation.getX(), renderLocation.getY(), transform);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object at the specified coordinates with a custom affine transformation.
-   *
-   * @param g         The graphics object to draw on.
-   * @param image     The image to be drawn.
-   * @param x         The x-coordinate of the image.
-   * @param y         The y-coordinate of the image.
-   * @param transform The affine transformation to be applied to the image.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object at the specified coordinates with a custom affine transformation.
+  ///
+  /// @param g         The graphics object to draw on.
+  /// @param image     The image to be drawn.
+  /// @param x         The x-coordinate of the image.
+  /// @param y         The y-coordinate of the image.
+  /// @param transform The affine transformation to be applied to the image.
   public static void renderTransformed(
     final Graphics2D g, final Image image, double x, double y, AffineTransform transform) {
     if (transform == null) {
@@ -216,13 +194,11 @@ public final class ImageRenderer {
     g.drawImage(image, t, null);
   }
 
-  /**
-   * Renders the specified {@code Image} to the given {@code Graphics2D} object with a custom affine transformation.
-   *
-   * @param g         The graphics object to draw on.
-   * @param image     The image to be drawn.
-   * @param transform The affine transformation to be applied to the image.
-   */
+  /// Renders the specified `Image` to the given `Graphics2D` object with a custom affine transformation.
+  ///
+  /// @param g         The graphics object to draw on.
+  /// @param image     The image to be drawn.
+  /// @param transform The affine transformation to be applied to the image.
   public static void renderTransformed(
     final Graphics2D g, final Image image, AffineTransform transform) {
     if (transform == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/LocationLockCamera.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/LocationLockCamera.java
@@ -3,16 +3,14 @@ package de.gurkenlabs.litiengine.graphics;
 import de.gurkenlabs.litiengine.entities.IEntity;
 import java.awt.geom.Point2D;
 
-/** The Class LocalPlayerCamera. */
+/// The Class LocalPlayerCamera.
 public class LocationLockCamera extends Camera {
   private final IEntity entity;
 
-  /**
-   * Initializes a new instance of the {@code LocationLockCamera}.
-   *
-   * @param entity
-   *          The entity to which the focus will be locked.
-   */
+  /// Initializes a new instance of the `LocationLockCamera`.
+  ///
+  /// @param entity
+  /// The entity to which the focus will be locked.
   public LocationLockCamera(final IEntity entity) {
     super();
     this.entity = entity;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/MapRenderedEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/MapRenderedEvent.java
@@ -16,20 +16,16 @@ public class MapRenderedEvent extends EventObject {
     this.map = map;
   }
 
-  /**
-   * Gets the graphics object on which the map is rendered.
-   *
-   * @return The graphics object on which the map is rendered.
-   */
+  /// Gets the graphics object on which the map is rendered.
+  ///
+  /// @return The graphics object on which the map is rendered.
   public Graphics2D getGraphics() {
     return graphics;
   }
 
-  /**
-   * Get the map involved with the rendering process.
-   *
-   * @return The map involved with the rendering process.
-   */
+  /// Get the map involved with the rendering process.
+  ///
+  /// @return The map involved with the rendering process.
   public IMap getMap() {
     return map;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/MouseCursor.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/MouseCursor.java
@@ -16,12 +16,11 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 
-/**
- * The visual representation of the {@code Mouse} in the LITIENGINE.<br>
- * It controls the appearance of the rendered cursor and allows to specify offsets from the actual mouse location.
- *
- * @see Mouse
- */
+/// The visual representation of the `Mouse` in the LITIENGINE.
+///
+/// It controls the appearance of the rendered cursor and allows to specify offsets from the actual mouse location.
+///
+/// @see Mouse
 public final class MouseCursor implements IRenderable {
 
   private static final Cursor DEFAULT_CURSOR = new Cursor(Cursor.DEFAULT_CURSOR);
@@ -51,7 +50,7 @@ public final class MouseCursor implements IRenderable {
     DEBUG_CURSOR_IMAGE = debugCursorImg;
   }
 
-  /** Initializes a new instance of the {@code MouseCursor} class. */
+  /// Initializes a new instance of the `MouseCursor` class.
   public MouseCursor() {
     this.visible = true;
   }
@@ -71,69 +70,55 @@ public final class MouseCursor implements IRenderable {
     }
   }
 
-  /**
-   * Gets the image currently used to render the cursor.
-   *
-   * @return the cursor image, or {@code null} if none is set
-   */
+  /// Gets the image currently used to render the cursor.
+  ///
+  /// @return the cursor image, or `null` if none is set
   public Image getImage() {
     return this.image;
   }
 
-  /**
-   * Gets the affine transform applied to the cursor image when it is rendered.
-   *
-   * @return the cursor transform
-   */
+  /// Gets the affine transform applied to the cursor image when it is rendered.
+  ///
+  /// @return the cursor transform
   public AffineTransform getTransform() {
     return this.transform;
   }
 
-  /**
-   * Gets the horizontal pixel offset from the actual mouse location to the rendered cursor.
-   *
-   * @return the horizontal offset
-   */
+  /// Gets the horizontal pixel offset from the actual mouse location to the rendered cursor.
+  ///
+  /// @return the horizontal offset
   public int getOffsetX() {
     return this.offsetX;
   }
 
-  /**
-   * Gets the vertical pixel offset from the actual mouse location to the rendered cursor.
-   *
-   * @return the vertical offset
-   */
+  /// Gets the vertical pixel offset from the actual mouse location to the rendered cursor.
+  ///
+  /// @return the vertical offset
   public int getOffsetY() {
     return this.offsetY;
   }
 
-  /**
-   * Determines whether the cursor is currently visible (and will thereby be rendered), by checking the {@code visible}
-   * flag and whether the specified cursor image is null.
-   *
-   * @return True if the cursor is currently visible; otherwise false.
-   */
+  /// Determines whether the cursor is currently visible (and will thereby be rendered), by checking the `visible`
+  /// flag and whether the specified cursor image is null.
+  ///
+  /// @return True if the cursor is currently visible; otherwise false.
   public boolean isVisible() {
     return this.visible && this.getImage() != null;
   }
 
-  /**
-   * Sets the cursor image, anchored at its top-left corner.
-   *
-   * @param img the cursor image
-   */
+  /// Sets the cursor image, anchored at its top-left corner.
+  ///
+  /// @param img the cursor image
   public void set(final Image img) {
     this.set(img, Align.LEFT, Valign.TOP);
   }
 
-  /**
-   * Sets the cursor image with the supplied pixel offsets. If a non-{@code null} image is set, the native system cursor is hidden; otherwise it is
-   * restored (unless the mouse is grabbed).
-   *
-   * @param img     the cursor image; may be {@code null} to clear the cursor
-   * @param offsetX the horizontal offset
-   * @param offsetY the vertical offset
-   */
+  /// Sets the cursor image with the supplied pixel offsets. If a non-`null` image is set, the native system cursor is hidden; otherwise it is
+  /// restored (unless the mouse is grabbed).
+  ///
+  /// @param img     the cursor image; may be `null` to clear the cursor
+  /// @param offsetX the horizontal offset
+  /// @param offsetY the vertical offset
   public void set(final Image img, final int offsetX, final int offsetY) {
     this.image = img;
     this.setOffset(offsetX, offsetY);
@@ -148,76 +133,60 @@ public final class MouseCursor implements IRenderable {
     }
   }
 
-  /**
-   * Sets the cursor image, computing the pixel offset so that the supplied alignment is anchored to the actual mouse location.
-   *
-   * @param img    the cursor image
-   * @param hAlign the horizontal alignment of the anchor
-   * @param vAlign the vertical alignment of the anchor
-   */
+  /// Sets the cursor image, computing the pixel offset so that the supplied alignment is anchored to the actual mouse location.
+  ///
+  /// @param img    the cursor image
+  /// @param hAlign the horizontal alignment of the anchor
+  /// @param vAlign the vertical alignment of the anchor
   public void set(final Image img, Align hAlign, Valign vAlign) {
     this.set(img, -hAlign.getValue(img.getWidth(null)), -vAlign.getValue(img.getHeight(null)));
   }
 
-  /**
-   * Sets the cursor offsets.
-   *
-   * @param x the horizontal offset
-   * @param y the vertical offset
-   */
+  /// Sets the cursor offsets.
+  ///
+  /// @param x the horizontal offset
+  /// @param y the vertical offset
   public void setOffset(final int x, final int y) {
     this.setOffsetX(x);
     this.setOffsetY(y);
   }
 
-  /**
-   * Sets the horizontal cursor offset.
-   *
-   * @param cursorOffsetX the horizontal offset
-   */
+  /// Sets the horizontal cursor offset.
+  ///
+  /// @param cursorOffsetX the horizontal offset
   public void setOffsetX(final int cursorOffsetX) {
     this.offsetX = cursorOffsetX;
   }
 
-  /**
-   * Sets the vertical cursor offset.
-   *
-   * @param cursorOffsetY the vertical offset
-   */
+  /// Sets the vertical cursor offset.
+  ///
+  /// @param cursorOffsetY the vertical offset
   public void setOffsetY(final int cursorOffsetY) {
     this.offsetY = cursorOffsetY;
   }
 
-  /**
-   * Sets the affine transform applied to the cursor image when it is rendered.
-   *
-   * @param transform the transform
-   */
+  /// Sets the affine transform applied to the cursor image when it is rendered.
+  ///
+  /// @param transform the transform
   public void setTransform(AffineTransform transform) {
     this.transform = transform;
   }
 
-  /**
-   * Sets whether the cursor is visible.
-   *
-   * @param visible {@code true} to show the cursor
-   */
+  /// Sets whether the cursor is visible.
+  ///
+  /// @param visible `true` to show the cursor
   public void setVisible(boolean visible) {
     this.visible = visible;
   }
 
-  /**
-   * Restores the native system cursor on the game window.
-   */
+  /// Restores the native system cursor on the game window.
   public void showDefaultCursor() {
     if (Game.window() != null && Game.window().getRenderComponent() != null) {
       Game.window().getRenderComponent().setCursor(DEFAULT_CURSOR);
     }
   }
 
-  /**
-   * Hides the native system cursor by replacing it with an empty cursor on the game window.
-   */
+  /// Hides the native system cursor by replacing it with an empty cursor on the game window.
   public void hideDefaultCursor() {
     if (Game.window() != null && Game.window().getRenderComponent() != null) {
       Game.window().getRenderComponent().setCursor(BLANK_CURSOR);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/OverlayPixelsImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/OverlayPixelsImageEffect.java
@@ -8,14 +8,12 @@ import java.awt.image.BufferedImage;
 public class OverlayPixelsImageEffect extends ImageEffect {
   private final Color color;
 
-  /**
-   * Initializes a new instance of the {@code OverlayPixelsImageEffect}.
-   *
-   * @param ttl
-   *          The time to live of this effect.
-   * @param color
-   *          The color of this effect.
-   */
+  /// Initializes a new instance of the `OverlayPixelsImageEffect`.
+  ///
+  /// @param ttl
+  /// The time to live of this effect.
+  /// @param color
+  /// The color of this effect.
   public OverlayPixelsImageEffect(final int ttl, final Color color) {
     super(ttl, "OverlayPixels" + color.getRed() + "" + color.getGreen() + "" + color.getBlue());
     this.color = color;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderComponent.java
@@ -27,20 +27,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 
-/**
- * The {@code RenderComponent} class extends {@link Canvas} and handles the rendering of the game screen, including managing fade effects, capturing
- * screenshots, and rendering the game cursor.
- */
+/// The `RenderComponent` class extends [Canvas] and handles the rendering of the game screen, including managing fade effects, capturing
+/// screenshots, and rendering the game cursor.
 public class RenderComponent extends Canvas {
   private static final Logger log = Logger.getLogger(RenderComponent.class.getName());
-  /**
-   * The default background color for the rendering component.
-   */
+  /// The default background color for the rendering component.
   public static final Color DEFAULT_BACKGROUND_COLOR = Color.BLACK;
 
-  /**
-   * The default font for rendering text in the component.
-   */
+  /// The default font for rendering text in the component.
   public static final Font DEFAULT_FONT = new Font(Font.MONOSPACED, Font.PLAIN, 12);
 
   private final transient List<IntConsumer> fpsChangedConsumer = new CopyOnWriteArrayList<>();
@@ -59,11 +53,9 @@ public class RenderComponent extends Canvas {
 
   private boolean takeScreenShot;
 
-  /**
-   * Constructs a new {@code RenderComponent} with the specified size.
-   *
-   * @param size The size of the rendering component.
-   */
+  /// Constructs a new `RenderComponent` with the specified size.
+  ///
+  /// @param size The size of the rendering component.
   public RenderComponent(final Dimension size) {
     setBackground(DEFAULT_BACKGROUND_COLOR);
     setFont(DEFAULT_FONT);
@@ -71,39 +63,31 @@ public class RenderComponent extends Canvas {
     setPreferredSize(size);
   }
 
-  /**
-   * Initiates a fade-in effect over the specified duration.
-   *
-   * @param ms The duration of the fade-in effect in milliseconds.
-   */
+  /// Initiates a fade-in effect over the specified duration.
+  ///
+  /// @param ms The duration of the fade-in effect in milliseconds.
   public void fadeIn(final int ms) {
     resetFade();
     this.fadeInStart = Game.time().now();
     this.fadeInTime = ms;
   }
 
-  /**
-   * Initiates a fade-out effect over the specified duration.
-   *
-   * @param ms The duration of the fade-out effect in milliseconds.
-   */
+  /// Initiates a fade-out effect over the specified duration.
+  ///
+  /// @param ms The duration of the fade-out effect in milliseconds.
   public void fadeOut(final int ms) {
     resetFade();
     this.fadeOutStart = Game.time().now();
     this.fadeOutTime = ms;
   }
 
-  /**
-   * Resets the fade-in and fade-out timers.
-   */
+  /// Resets the fade-in and fade-out timers.
   private void resetFade() {
     this.fadeInStart = this.fadeOutStart = -1;
     this.fadeInTime = this.fadeOutTime = 0;
   }
 
-  /**
-   * Initializes the {@code RenderComponent}, setting up the buffer strategy for rendering.
-   */
+  /// Initializes the `RenderComponent`, setting up the buffer strategy for rendering.
   public void init() {
     if (!isDisplayable()) {
       return;
@@ -116,16 +100,14 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Configures the Java2D rendering pipeline system properties from the
-   * current game configuration. This must be called <em>before</em> any
-   * {@code Graphics2D} context is created (i.e. before the first
-   * {@code BufferedImage}, {@code Canvas.createGraphics()}, or
-   * {@code createBufferStrategy()} call), because the pipeline is locked in
-   * once the first graphics context is initialized.
-   *
-   * @see de.gurkenlabs.litiengine.configuration.Java2DPipeline
-   */
+  /// Configures the Java2D rendering pipeline system properties from the
+  /// current game configuration. This must be called *before* any
+  /// `Graphics2D` context is created (i.e. before the first
+  /// `BufferedImage`, `Canvas.createGraphics()`, or
+  /// `createBufferStrategy()` call), because the pipeline is locked in
+  /// once the first graphics context is initialized.
+  ///
+  /// @see de.gurkenlabs.litiengine.configuration.Java2DPipeline
   public static void configurePipeline() {
     var pipeline = Game.config().graphics().getJava2DPipeline();
     switch (pipeline) {
@@ -145,40 +127,32 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Registers a consumer to be notified when the frames per second (FPS) change.
-   *
-   * @param fpsConsumer The consumer to notify of FPS changes.
-   */
+  /// Registers a consumer to be notified when the frames per second (FPS) change.
+  ///
+  /// @param fpsConsumer The consumer to notify of FPS changes.
   public void onFpsChanged(final IntConsumer fpsConsumer) {
     if (!fpsChangedConsumer.contains(fpsConsumer)) {
       fpsChangedConsumer.add(fpsConsumer);
     }
   }
 
-  /**
-   * Registers a consumer to be notified after the component has been rendered.
-   *
-   * @param renderedConsumer The consumer to notify after rendering.
-   */
+  /// Registers a consumer to be notified after the component has been rendered.
+  ///
+  /// @param renderedConsumer The consumer to notify after rendering.
   public void onRendered(final Consumer<Graphics2D> renderedConsumer) {
     if (!this.renderedConsumer.contains(renderedConsumer)) {
       this.renderedConsumer.add(renderedConsumer);
     }
   }
 
-  /**
-   * Unregisters a consumer from being notified after the component has been rendered.
-   *
-   * @param renderedConsumer The consumer to remove.
-   */
+  /// Unregisters a consumer from being notified after the component has been rendered.
+  ///
+  /// @param renderedConsumer The consumer to remove.
   public void removeRenderedConsumer(final Consumer<Graphics2D> renderedConsumer) {
     this.renderedConsumer.remove(renderedConsumer);
   }
 
-  /**
-   * Renders the game screen, including handling fade effects, cursor rendering, and screenshot capture.
-   */
+  /// Renders the game screen, including handling fade effects, cursor rendering, and screenshot capture.
   public void render() {
     if (!isDisplayable() || getWidth() <= 0 || getHeight() <= 0) {
       return;
@@ -222,11 +196,9 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Clears the background and renders the current screen and other graphical elements.
-   *
-   * @param g The {@link Graphics2D} object used for rendering.
-   */
+  /// Clears the background and renders the current screen and other graphical elements.
+  ///
+  /// @param g The [Graphics2D] object used for rendering.
   private void renderGraphics(Graphics2D g) {
     clearBackground(g);
     applyRenderingHints(g);
@@ -245,11 +217,9 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Clears the background of the component.
-   *
-   * @param g The {@link Graphics2D} object used for rendering.
-   */
+  /// Clears the background of the component.
+  ///
+  /// @param g The [Graphics2D] object used for rendering.
   private void clearBackground(Graphics2D g) {
     g.setColor(getBackground());
     Rectangle bounds = new Rectangle(0, 0, getWidth(), getHeight());
@@ -257,11 +227,9 @@ public class RenderComponent extends Canvas {
     g.fill(bounds);
   }
 
-  /**
-   * Applies rendering hints for antialiasing and interpolation.
-   *
-   * @param g The {@link Graphics2D} object used for rendering.
-   */
+  /// Applies rendering hints for antialiasing and interpolation.
+  ///
+  /// @param g The [Graphics2D] object used for rendering.
   private void applyRenderingHints(Graphics2D g) {
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
       Game.config().graphics().colorInterpolation() ?
@@ -272,12 +240,10 @@ public class RenderComponent extends Canvas {
         RenderingHints.VALUE_INTERPOLATION_BILINEAR : RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
   }
 
-  /**
-   * Renders the current game screen.
-   *
-   * @param g      The {@link Graphics2D} object used for rendering.
-   * @param screen The current {@link Screen} to render.
-   */
+  /// Renders the current game screen.
+  ///
+  /// @param g      The [Graphics2D] object used for rendering.
+  /// @param screen The current [Screen] to render.
   private void renderScreen(Graphics2D g, Screen screen) {
     long renderStart = System.nanoTime();
     screen.render(g);
@@ -288,11 +254,9 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Applies a fade overlay to the rendered content, if applicable.
-   *
-   * @param g The {@link Graphics2D} object used for rendering.
-   */
+  /// Applies a fade overlay to the rendered content, if applicable.
+  ///
+  /// @param g The [Graphics2D] object used for rendering.
   private void applyFadeOverlay(Graphics2D g) {
     if (!Float.isNaN(currentAlpha)) {
       int visibleAlpha = Math.clamp(Math.round(255 * (1 - currentAlpha)), 0, 255);
@@ -301,11 +265,9 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Captures and saves a screenshot of the current screen.
-   *
-   * @param screen The current {@link Screen} to capture.
-   */
+  /// Captures and saves a screenshot of the current screen.
+  ///
+  /// @param screen The current [Screen] to capture.
   private void takeAndSaveScreenshot(Screen screen) {
     BufferedImage img = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_RGB);
     Graphics2D imgGraphics = img.createGraphics();
@@ -314,16 +276,12 @@ public class RenderComponent extends Canvas {
     saveScreenshot(img);
   }
 
-  /**
-   * Signals the {@code RenderComponent} to take a screenshot on the next render cycle.
-   */
+  /// Signals the `RenderComponent` to take a screenshot on the next render cycle.
   public void takeScreenshot() {
     this.takeScreenShot = true;
   }
 
-  /**
-   * Handles the fade-in and fade-out effects, adjusting the current alpha value based on time elapsed.
-   */
+  /// Handles the fade-in and fade-out effects, adjusting the current alpha value based on time elapsed.
   private void handleFade() {
     if (fadeOutStart != -1) {
       updateAlpha(fadeOutStart, fadeOutTime, false);
@@ -338,23 +296,19 @@ public class RenderComponent extends Canvas {
     }
   }
 
-  /**
-   * Updates the alpha value for fade effects.
-   *
-   * @param startTime The start time of the fade effect.
-   * @param duration  The duration of the fade effect.
-   * @param fadeIn    {@code true} if this is a fade-in effect, {@code false} if it's a fade-out.
-   */
+  /// Updates the alpha value for fade effects.
+  ///
+  /// @param startTime The start time of the fade effect.
+  /// @param duration  The duration of the fade effect.
+  /// @param fadeIn    `true` if this is a fade-in effect, `false` if it's a fade-out.
   private void updateAlpha(long startTime, int duration, boolean fadeIn) {
     long timePassed = Game.time().since(startTime);
     currentAlpha = Math.clamp((fadeIn ? timePassed : duration - timePassed) / (float) duration, 0, 1);
   }
 
-  /**
-   * Saves the provided image as a screenshot to the file system.
-   *
-   * @param img The {@link BufferedImage} to save as a screenshot.
-   */
+  /// Saves the provided image as a screenshot to the file system.
+  ///
+  /// @param img The [BufferedImage] to save as a screenshot.
   private void saveScreenshot(BufferedImage img) {
     try {
       String timeStamp = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderEngine.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderEngine.java
@@ -26,21 +26,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * The 2D Render Engine is used to render texts, shapes and entities at their location in the {@code Environment} and with respect to the
- * {@code Camera} location and zoom.
- *
- * <p>
- * <i>Internally, it uses the static renderer implementations to actually execute the rendering
- * process. This class basically prepares the specified render subject and passed them to a renderer with the current correct context.</i>
- *
- * @see GameWorld#environment()
- * @see GameWorld#camera()
- * @see IEntity#getLocation()
- * @see ShapeRenderer
- * @see TextRenderer
- * @see ImageRenderer
- */
+/// The 2D Render Engine is used to render texts, shapes and entities at their location in the `Environment` and with respect to the
+/// `Camera` location and zoom.
+///
+/// *Internally, it uses the static renderer implementations to actually execute the rendering
+/// process. This class basically prepares the specified render subject and passed them to a renderer with the current correct context.*
+///
+/// @see GameWorld#environment()
+/// @see GameWorld#camera()
+/// @see IEntity#getLocation()
+/// @see ShapeRenderer
+/// @see TextRenderer
+/// @see ImageRenderer
 public final class RenderEngine {
 
   public static final float DEFAULT_RENDERSCALE = 3.0f;
@@ -51,11 +48,9 @@ public final class RenderEngine {
 
   private float baseRenderScale = DEFAULT_RENDERSCALE;
 
-  /**
-   * <b>You should never call this manually! Instead use the {@code Game.graphics()} instance.</b>
-   *
-   * @see Game#graphics()
-   */
+  /// **You should never call this manually! Instead use the `Game.graphics()` instance.**
+  ///
+  /// @see Game#graphics()
   public RenderEngine() {
     if (Game.graphics() != null) {
       throw new UnsupportedOperationException(
@@ -63,78 +58,62 @@ public final class RenderEngine {
     }
   }
 
-  /**
-   * Adds the specified entity rendered listener to receive events when entities were rendered.
-   *
-   * <p>
-   * This is the global equivalent to {@code IEntity.addEntityRenderedListener}
-   *
-   * @param listener The listener to add.
-   * @see IEntity#onRendered(EntityRenderedListener)
-   */
+  /// Adds the specified entity rendered listener to receive events when entities were rendered.
+  ///
+  /// This is the global equivalent to `IEntity.addEntityRenderedListener`
+  ///
+  /// @param listener The listener to add.
+  /// @see IEntity#onRendered(EntityRenderedListener)
   public void addEntityRenderedListener(final EntityRenderedListener listener) {
     this.entityRenderedListener.add(listener);
   }
 
-  /**
-   * Removes the specified entity rendered listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified entity rendered listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeEntityRenderedListener(final EntityRenderedListener listener) {
     this.entityRenderedListener.remove(listener);
   }
 
-  /**
-   * Adds the specified entity render listener to receive events and callbacks about the rendering process of entities.
-   *
-   * <p>
-   * This is the global equivalent to {@code IEntity.addEntityRenderListener}
-   *
-   * @param listener The listener to add.
-   * @see IEntity#addEntityRenderListener(EntityRenderListener)
-   */
+  /// Adds the specified entity render listener to receive events and callbacks about the rendering process of entities.
+  ///
+  /// This is the global equivalent to `IEntity.addEntityRenderListener`
+  ///
+  /// @param listener The listener to add.
+  /// @see IEntity#addEntityRenderListener(EntityRenderListener)
   public void addEntityRenderListener(final EntityRenderListener listener) {
     this.entityRenderListener.add(listener);
   }
 
-  /**
-   * Removes the specified entity render listener.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes the specified entity render listener.
+  ///
+  /// @param listener The listener to remove.
   public void removeEntityRenderListener(final EntityRenderListener listener) {
     this.entityRenderListener.remove(listener);
   }
 
-  /**
-   * Gets the base render scale of the game.
-   *
-   * @return The base render scale.
-   */
+  /// Gets the base render scale of the game.
+  ///
+  /// @return The base render scale.
   public float getBaseRenderScale() {
     return this.baseRenderScale;
   }
 
-  /**
-   * Sets the global base scale that is used to calculate the actual render scale of the game.
-   *
-   * @param scale The base render scale for the game.
-   * @see ICamera#getRenderScale()
-   */
+  /// Sets the global base scale that is used to calculate the actual render scale of the game.
+  ///
+  /// @param scale The base render scale for the game.
+  /// @see ICamera#getRenderScale()
   public void setBaseRenderScale(float scale) {
     this.baseRenderScale = scale;
   }
 
-  /**
-   * Renders the specified text to the defined map location.
-   *
-   * @param g         The graphics object to render on.
-   * @param text      The text to be rendered
-   * @param x         The x-coordinate of the text.
-   * @param y         The y-coordinate of the text
-   * @param antialias Configure whether to render the text with antialiasing.
-   */
+  /// Renders the specified text to the defined map location.
+  ///
+  /// @param g         The graphics object to render on.
+  /// @param text      The text to be rendered
+  /// @param x         The x-coordinate of the text.
+  /// @param y         The y-coordinate of the text
+  /// @param antialias Configure whether to render the text with antialiasing.
   public void renderText(
     final Graphics2D g, final String text, final double x, final double y, boolean antialias) {
     if (text == null || text.isEmpty()) {
@@ -150,71 +129,59 @@ public final class RenderEngine {
     g.setTransform(oldT);
   }
 
-  /**
-   * Renders the specified text to the defined map location.
-   *
-   * @param g    The graphics object to render on.
-   * @param text The text to be rendered
-   * @param x    The x-coordinate of the text.
-   * @param y    The y-coordinate of the text
-   */
+  /// Renders the specified text to the defined map location.
+  ///
+  /// @param g    The graphics object to render on.
+  /// @param text The text to be rendered
+  /// @param x    The x-coordinate of the text.
+  /// @param y    The y-coordinate of the text
   public void renderText(final Graphics2D g, final String text, final double x, final double y) {
     renderText(g, text, x, y, false);
   }
 
-  /**
-   * Renders the specified text to the defined map location.
-   *
-   * @param g         The graphics object to render on.
-   * @param text      The text to be rendered.
-   * @param location  The location on the map.
-   * @param antialias Configure whether to render the text with antialiasing.
-   */
+  /// Renders the specified text to the defined map location.
+  ///
+  /// @param g         The graphics object to render on.
+  /// @param text      The text to be rendered.
+  /// @param location  The location on the map.
+  /// @param antialias Configure whether to render the text with antialiasing.
   public void renderText(
     final Graphics2D g, final String text, final Point2D location, boolean antialias) {
     renderText(g, text, location.getX(), location.getY(), antialias);
   }
 
-  /**
-   * Renders the specified text to the defined map location.
-   *
-   * @param g        The graphics object to render on.
-   * @param text     The text to be rendered.
-   * @param location The location on the map.
-   */
+  /// Renders the specified text to the defined map location.
+  ///
+  /// @param g        The graphics object to render on.
+  /// @param text     The text to be rendered.
+  /// @param location The location on the map.
   public void renderText(final Graphics2D g, final String text, final Point2D location) {
     renderText(g, text, location, false);
   }
 
-  /**
-   * Renders the specified shape to the translated location in the game world.
-   *
-   * @param g     The graphics object to render on.
-   * @param shape The shape to be rendered.
-   */
+  /// Renders the specified shape to the translated location in the game world.
+  ///
+  /// @param g     The graphics object to render on.
+  /// @param shape The shape to be rendered.
   public void renderShape(final Graphics2D g, final Shape shape) {
     renderShape(g, shape, false);
   }
 
-  /**
-   * Renders the specified shape to the translated location in the game world.
-   *
-   * @param g            The graphics object to render on.
-   * @param shape        The shape to be rendered.
-   * @param antialiasing Configure whether to render the shape with antialiasing.
-   */
+  /// Renders the specified shape to the translated location in the game world.
+  ///
+  /// @param g            The graphics object to render on.
+  /// @param shape        The shape to be rendered.
+  /// @param antialiasing Configure whether to render the shape with antialiasing.
   public void renderShape(final Graphics2D g, final Shape shape, boolean antialiasing) {
     renderShape(g, shape, antialiasing, 0);
   }
 
-  /**
-   * Renders the specified shape to the translated location in the game world.
-   *
-   * @param g            The graphics object to render on.
-   * @param shape        The shape to be rendered.
-   * @param antialiasing Configure whether to render the shape with antialiasing.
-   * @param angle        The angle by which the shape will be rotated.
-   */
+  /// Renders the specified shape to the translated location in the game world.
+  ///
+  /// @param g            The graphics object to render on.
+  /// @param shape        The shape to be rendered.
+  /// @param antialiasing Configure whether to render the shape with antialiasing.
+  /// @param angle        The angle by which the shape will be rotated.
   public void renderShape(
     final Graphics2D g, final Shape shape, boolean antialiasing, double angle) {
     if (shape == null) {
@@ -240,64 +207,54 @@ public final class RenderEngine {
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, hint);
   }
 
-  /**
-   * Renders the outline of the specified shape to the translated location in the game world.
-   *
-   * @param g     The graphics object to render on.
-   * @param shape The shape to be rendered.
-   */
+  /// Renders the outline of the specified shape to the translated location in the game world.
+  ///
+  /// @param g     The graphics object to render on.
+  /// @param shape The shape to be rendered.
   public void renderOutline(final Graphics2D g, final Shape shape) {
     renderOutline(g, shape, new BasicStroke(1 / Game.world().camera().getRenderScale()));
   }
 
-  /**
-   * Renders the outline of the specified shape to the translated location in the game world.
-   *
-   * @param g            The graphics object to render on.
-   * @param shape        The shape to be rendered.
-   * @param antialiasing Configure whether to render the shape with antialiasing.
-   */
+  /// Renders the outline of the specified shape to the translated location in the game world.
+  ///
+  /// @param g            The graphics object to render on.
+  /// @param shape        The shape to be rendered.
+  /// @param antialiasing Configure whether to render the shape with antialiasing.
   public void renderOutline(final Graphics2D g, final Shape shape, boolean antialiasing) {
     renderOutline(
       g, shape, new BasicStroke(1 / Game.world().camera().getRenderScale()), antialiasing);
   }
 
-  /**
-   * Renders the outline with the defined {@code Stroke} of the specified shape to the translated location in the game world.
-   *
-   * @param g      The graphics object to render on.
-   * @param shape  The shape to be rendered.
-   * @param stroke The stroke that is used to render the shape.
-   * @see Stroke
-   */
+  /// Renders the outline with the defined `Stroke` of the specified shape to the translated location in the game world.
+  ///
+  /// @param g      The graphics object to render on.
+  /// @param shape  The shape to be rendered.
+  /// @param stroke The stroke that is used to render the shape.
+  /// @see Stroke
   public void renderOutline(final Graphics2D g, final Shape shape, final Stroke stroke) {
     this.renderOutline(g, shape, stroke, false);
   }
 
-  /**
-   * Renders the outline with the defined {@code Stroke} of the specified shape to the translated location in the game world.
-   *
-   * @param g            The graphics object to render on.
-   * @param shape        The shape to be rendered.
-   * @param stroke       The stroke that is used to render the shape.
-   * @param antialiasing Configure whether to render the shape with antialiasing.
-   * @see Stroke
-   */
+  /// Renders the outline with the defined `Stroke` of the specified shape to the translated location in the game world.
+  ///
+  /// @param g            The graphics object to render on.
+  /// @param shape        The shape to be rendered.
+  /// @param stroke       The stroke that is used to render the shape.
+  /// @param antialiasing Configure whether to render the shape with antialiasing.
+  /// @see Stroke
   public void renderOutline(
     final Graphics2D g, final Shape shape, final Stroke stroke, boolean antialiasing) {
     renderOutline(g, shape, stroke, antialiasing, 0);
   }
 
-  /**
-   * Renders the outline with the defined {@code Stroke} of the specified shape to the translated location in the game world.
-   *
-   * @param g            The graphics object to render on.
-   * @param shape        The shape to be rendered.
-   * @param stroke       The stroke that is used to render the shape.
-   * @param antialiasing Configure whether to render the shape with antialiasing.
-   * @param angle        The angle by which the shape will be rotated.
-   * @see Stroke
-   */
+  /// Renders the outline with the defined `Stroke` of the specified shape to the translated location in the game world.
+  ///
+  /// @param g            The graphics object to render on.
+  /// @param shape        The shape to be rendered.
+  /// @param stroke       The stroke that is used to render the shape.
+  /// @param antialiasing Configure whether to render the shape with antialiasing.
+  /// @param angle        The angle by which the shape will be rotated.
+  /// @see Stroke
   public void renderOutline(
     final Graphics2D g,
     final Shape shape,
@@ -333,25 +290,21 @@ public final class RenderEngine {
     return t;
   }
 
-  /**
-   * Renders the specified image at the defined map location.
-   *
-   * @param g     The graphics object to render on.
-   * @param image The image to be rendered.
-   * @param x     The x-coordinate of the image.
-   * @param y     The y-coordinate of the image
-   */
+  /// Renders the specified image at the defined map location.
+  ///
+  /// @param g     The graphics object to render on.
+  /// @param image The image to be rendered.
+  /// @param x     The x-coordinate of the image.
+  /// @param y     The y-coordinate of the image
   public void renderImage(Graphics2D g, final Image image, double x, double y) {
     renderImage(g, image, new Point2D.Double(x, y));
   }
 
-  /**
-   * Renders the specified image at the defined map location.
-   *
-   * @param g        The graphics object to render on.
-   * @param image    The image to be rendered.
-   * @param location The location of the image.
-   */
+  /// Renders the specified image at the defined map location.
+  ///
+  /// @param g        The graphics object to render on.
+  /// @param image    The image to be rendered.
+  /// @param location The location of the image.
   public void renderImage(Graphics2D g, final Image image, Point2D location) {
     Point2D viewPortLocation = Game.world().camera().getViewportLocation(location);
     ImageRenderer.render(
@@ -361,27 +314,22 @@ public final class RenderEngine {
       viewPortLocation.getY() * Game.world().camera().getRenderScale());
   }
 
-  /**
-   * Renders the specified entities at their current location in the environment.
-   *
-   * @param g        The graphics object to render on.
-   * @param entities The entities to be rendered.
-   */
+  /// Renders the specified entities at their current location in the environment.
+  ///
+  /// @param g        The graphics object to render on.
+  /// @param entities The entities to be rendered.
   public void renderEntities(final Graphics2D g, final Collection<? extends IEntity> entities) {
     this.renderEntities(g, entities, true);
   }
 
-  /**
-   * Renders the specified entities at their current location in the environment.
-   *
-   * <p>
-   * This method sorts the specified entities by their y-coordinate unless the {@code sort} parameter is set to false.
-   *
-   * @param g        The graphics object to render on.
-   * @param entities The entities to be rendered.
-   * @param sort     Defines whether the entities should be sorted by the {@code EntityYComparator} to simulate 2.5D graphics.
-   * @see EntityYComparator
-   */
+  /// Renders the specified entities at their current location in the environment.
+  ///
+  /// This method sorts the specified entities by their y-coordinate unless the `sort` parameter is set to false.
+  ///
+  /// @param g        The graphics object to render on.
+  /// @param entities The entities to be rendered.
+  /// @param sort     Defines whether the entities should be sorted by the `EntityYComparator` to simulate 2.5D graphics.
+  /// @see EntityYComparator
   public void renderEntities(
     final Graphics2D g, final Collection<? extends IEntity> entities, final boolean sort) {
     // filter out entities that are outside the viewport and always include emitters which have
@@ -415,25 +363,22 @@ public final class RenderEngine {
     }
   }
 
-  /**
-   * Renders the specified entity at its current location in the environment.
-   *
-   * <p>
-   * This method uses the {@code IEntityAnimationController} to render the appropriate {@code Animation}.<br> If the entity implements the
-   * {@code IRenderable} interface, its render method is being called afterwards.
-   *
-   * <p>
-   * To listen to events about this process, you can add a {@code EntityRenderListener} or {@code EntityRenderedListener} to the render engine.
-   *
-   * @param g      The graphics object to render on.
-   * @param entity The entity to be rendered.
-   * @see IEntity#animations()
-   * @see IAnimationController#getCurrentImage()
-   * @see IRenderable#render(Graphics2D)
-   * @see #canRender(IEntity)
-   * @see EntityRenderListener#canRender(IEntity)
-   * @see EntityRenderedListener#rendered(EntityRenderEvent)
-   */
+  /// Renders the specified entity at its current location in the environment.
+  ///
+  /// This method uses the `IEntityAnimationController` to render the appropriate `Animation`.
+  /// If the entity implements the
+  /// `IRenderable` interface, its render method is being called afterwards.
+  ///
+  /// To listen to events about this process, you can add a `EntityRenderListener` or `EntityRenderedListener` to the render engine.
+  ///
+  /// @param g      The graphics object to render on.
+  /// @param entity The entity to be rendered.
+  /// @see IEntity#animations()
+  /// @see IAnimationController#getCurrentImage()
+  /// @see IRenderable#render(Graphics2D)
+  /// @see #canRender(IEntity)
+  /// @see EntityRenderListener#canRender(IEntity)
+  /// @see EntityRenderedListener#rendered(EntityRenderEvent)
   public void renderEntity(final Graphics2D g, final IEntity entity) {
     if (entity == null) {
       return;
@@ -515,19 +460,16 @@ public final class RenderEngine {
     }
   }
 
-  /**
-   * Determines whether the specified entity can be rendered by evaluating the callbacks to all registered {@code EntityRenderListeners}.
-   *
-   * <p>
-   * If the {@code RenderType} of the specified entity is set to {@code NONE} or there are any callbacks that prevent the entity from being rendered,
-   * this method will return false.
-   *
-   * @param entity The entity to check whether it can be rendered or not.
-   * @return True if the entity can be rendered; otherwise false.
-   * @see IEntity#getRenderType()
-   * @see RenderType#NONE
-   * @see EntityRenderListener#canRender(IEntity)
-   */
+  /// Determines whether the specified entity can be rendered by evaluating the callbacks to all registered `EntityRenderListeners`.
+  ///
+  /// If the `RenderType` of the specified entity is set to `NONE` or there are any callbacks that prevent the entity from being rendered,
+  /// this method will return false.
+  ///
+  /// @param entity The entity to check whether it can be rendered or not.
+  /// @return True if the entity can be rendered; otherwise false.
+  /// @see IEntity#getRenderType()
+  /// @see RenderType#NONE
+  /// @see EntityRenderListener#canRender(IEntity)
   public boolean canRender(final IEntity entity) {
     if (entity.getRenderType() == RenderType.NONE) {
       return false;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RenderType.java
@@ -2,29 +2,23 @@ package de.gurkenlabs.litiengine.graphics;
 
 import de.gurkenlabs.litiengine.environment.Environment;
 
-/**
- * The RenderType defines how and when something is being rendered by the rendering pipeline of the {@code Environment}.
- *
- * @see Environment#render(java.awt.Graphics2D)
- */
+/// The RenderType defines how and when something is being rendered by the rendering pipeline of the `Environment`.
+///
+/// @see Environment#render(java.awt.Graphics2D)
 public enum RenderType {
-  /**
-   * Not rendered by the environment pipeline.
-   */
+  /// Not rendered by the environment pipeline.
   NONE(-1),
-  /**
-   * Background layer (rendered first).
-   */
+  /// Background layer (rendered first).
   BACKGROUND(0),
-  /** Ground layer. */
+  /// Ground layer.
   GROUND(1),
-  /** Surface layer above the ground. */
+  /// Surface layer above the ground.
   SURFACE(2),
-  /** Default rendering layer for entities. */
+  /// Default rendering layer for entities.
   NORMAL(3),
-  /** Overlay layer above the default entities. */
+  /// Overlay layer above the default entities.
   OVERLAY(4),
-  /** UI layer (rendered last). */
+  /// UI layer (rendered last).
   UI(5);
 
   private final int order;
@@ -33,11 +27,9 @@ public enum RenderType {
     this.order = order;
   }
 
-  /**
-   * Gets the integer order used to sort render types within the rendering pipeline.
-   *
-   * @return the render order
-   */
+  /// Gets the integer order used to sort render types within the rendering pipeline.
+  ///
+  /// @return the render order
   public int getOrder() {
     return this.order;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RotationImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/RotationImageEffect.java
@@ -8,33 +8,28 @@ import java.awt.image.BufferedImage;
 public class RotationImageEffect extends ImageEffect {
   private final float angle;
 
-  /**
-   * Initializes a new instance of the {@code RotationImageEffect}.
-   *
-   * @param ttl
-   *          The time to live of this effect.
-   * @param angle
-   *          The angle by which this effect rotates the base image.
-   */
+  /// Initializes a new instance of the `RotationImageEffect`.
+  ///
+  /// @param ttl
+  /// The time to live of this effect.
+  /// @param angle
+  /// The angle by which this effect rotates the base image.
   public RotationImageEffect(final int ttl, final float angle) {
     super(ttl, "RotationImageEffect_" + angle);
     this.angle = angle;
   }
 
-  /**
-   * Applies a rotation transformation to the provided {@link BufferedImage}.
-   *
-   * This method rotates the given image by a specified angle, calculates the
-   * new dimensions needed to accommodate the rotated image without cropping,
-   * and creates a new compatible {@link BufferedImage} with those dimensions.
-   *
-   * @param image the {@link BufferedImage} to be rotated.
-   *              If {@code null}, the method returns {@code null}.
-   *
-   * @return a new {@link BufferedImage} representing the rotated image,
-   *         or {@code null} if the input image was {@code null}.
-   *
-   */
+  /// Applies a rotation transformation to the provided [BufferedImage].
+  ///
+  /// This method rotates the given image by a specified angle, calculates the
+  /// new dimensions needed to accommodate the rotated image without cropping,
+  /// and creates a new compatible [BufferedImage] with those dimensions.
+  ///
+  /// @param image the [BufferedImage] to be rotated.
+  /// If `null`, the method returns `null`.
+  ///
+  /// @return a new [BufferedImage] representing the rotated image,
+  /// or `null` if the input image was `null`.
   @Override
   public BufferedImage apply(final BufferedImage image) {
     if (image == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ShapeRenderer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ShapeRenderer.java
@@ -14,12 +14,10 @@ public final class ShapeRenderer {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Renders the specified {@code Shape} to the given {@code Graphics2D} object.
-   *
-   * @param g     The graphics object to draw on.
-   * @param shape The shape to be drawn.
-   */
+  /// Renders the specified `Shape` to the given `Graphics2D` object.
+  ///
+  /// @param g     The graphics object to draw on.
+  /// @param shape The shape to be drawn.
   public static void render(final Graphics2D g, final Shape shape) {
     if (shape == null) {
       return;
@@ -27,59 +25,49 @@ public final class ShapeRenderer {
     g.fill(shape);
   }
 
-  /**
-   * Renders the specified {@code Shape} to the given {@code Graphics2D} object at the specified coordinates.
-   *
-   * @param g     The graphics object to draw on.
-   * @param shape The shape to be drawn.
-   * @param x     The x-coordinate of the shape.
-   * @param y     The y-coordinate of the shape.
-   */
+  /// Renders the specified `Shape` to the given `Graphics2D` object at the specified coordinates.
+  ///
+  /// @param g     The graphics object to draw on.
+  /// @param shape The shape to be drawn.
+  /// @param x     The x-coordinate of the shape.
+  /// @param y     The y-coordinate of the shape.
   public static void render(final Graphics2D g, final Shape shape, double x, double y) {
     g.translate(x, y);
     render(g, shape);
     g.translate(-x, -y);
   }
 
-  /**
-   * Renders the specified {@code Shape} to the given {@code Graphics2D} object at the specified location.
-   *
-   * @param g        The graphics object to draw on.
-   * @param shape    The shape to be drawn.
-   * @param location The location where the shape will be drawn.
-   */
+  /// Renders the specified `Shape` to the given `Graphics2D` object at the specified location.
+  ///
+  /// @param g        The graphics object to draw on.
+  /// @param shape    The shape to be drawn.
+  /// @param location The location where the shape will be drawn.
   public static void render(final Graphics2D g, final Shape shape, Point2D location) {
     render(g, shape, location.getX(), location.getY());
   }
 
-  /**
-   * Renders the outline of the specified {@code Shape} to the given {@code Graphics2D} object.
-   *
-   * @param g     The graphics object to draw on.
-   * @param shape The shape whose outline is to be drawn.
-   */
+  /// Renders the outline of the specified `Shape` to the given `Graphics2D` object.
+  ///
+  /// @param g     The graphics object to draw on.
+  /// @param shape The shape whose outline is to be drawn.
   public static void renderOutline(final Graphics2D g, final Shape shape) {
     renderOutline(g, shape, DEFAULT_STROKE);
   }
 
-  /**
-   * Renders the outline of the specified {@code Shape} to the given {@code Graphics2D} object with the specified stroke width.
-   *
-   * @param g      The graphics object to draw on.
-   * @param shape  The shape whose outline is to be drawn.
-   * @param stroke The stroke width for the outline.
-   */
+  /// Renders the outline of the specified `Shape` to the given `Graphics2D` object with the specified stroke width.
+  ///
+  /// @param g      The graphics object to draw on.
+  /// @param shape  The shape whose outline is to be drawn.
+  /// @param stroke The stroke width for the outline.
   public static void renderOutline(final Graphics2D g, final Shape shape, final float stroke) {
     renderOutline(g, shape, new BasicStroke(stroke));
   }
 
-  /**
-   * Renders the outline of the specified {@code Shape} to the given {@code Graphics2D} object with the specified stroke.
-   *
-   * @param g      The graphics object to draw on.
-   * @param shape  The shape whose outline is to be drawn.
-   * @param stroke The stroke for the outline.
-   */
+  /// Renders the outline of the specified `Shape` to the given `Graphics2D` object with the specified stroke.
+  ///
+  /// @param g      The graphics object to draw on.
+  /// @param shape  The shape whose outline is to be drawn.
+  /// @param stroke The stroke for the outline.
   public static void renderOutline(final Graphics2D g, final Shape shape, final Stroke stroke) {
     if (shape == null) {
       return;
@@ -90,52 +78,44 @@ public final class ShapeRenderer {
     g.setStroke(oldStroke);
   }
 
-  /**
-   * Renders the specified {@code Shape} to the given {@code Graphics2D} object with a custom affine transformation.
-   *
-   * @param g         The graphics object to draw on.
-   * @param shape     The shape to be drawn.
-   * @param transform The affine transformation to be applied to the shape.
-   */
+  /// Renders the specified `Shape` to the given `Graphics2D` object with a custom affine transformation.
+  ///
+  /// @param g         The graphics object to draw on.
+  /// @param shape     The shape to be drawn.
+  /// @param transform The affine transformation to be applied to the shape.
   public static void renderTransformed(
     final Graphics2D g, final Shape shape, AffineTransform transform) {
 
     render(g, transform.createTransformedShape(shape));
   }
 
-  /**
-   * Renders the outline of the specified {@code Shape} to the given {@code Graphics2D} object with a custom affine transformation.
-   *
-   * @param g         The graphics object to draw on.
-   * @param shape     The shape whose outline is to be drawn.
-   * @param transform The affine transformation to be applied to the shape.
-   */
+  /// Renders the outline of the specified `Shape` to the given `Graphics2D` object with a custom affine transformation.
+  ///
+  /// @param g         The graphics object to draw on.
+  /// @param shape     The shape whose outline is to be drawn.
+  /// @param transform The affine transformation to be applied to the shape.
   public static void renderOutlineTransformed(
     final Graphics2D g, final Shape shape, AffineTransform transform) {
     renderOutlineTransformed(g, shape, transform, DEFAULT_STROKE);
   }
 
-  /**
-   * Renders the outline of the specified {@code Shape} to the given {@code Graphics2D} object with a custom affine transformation and stroke width.
-   *
-   * @param g         The graphics object to draw on.
-   * @param shape     The shape whose outline is to be drawn.
-   * @param transform The affine transformation to be applied to the shape.
-   * @param stroke    The stroke width for the outline.
-   */
+  /// Renders the outline of the specified `Shape` to the given `Graphics2D` object with a custom affine transformation and stroke width.
+  ///
+  /// @param g         The graphics object to draw on.
+  /// @param shape     The shape whose outline is to be drawn.
+  /// @param transform The affine transformation to be applied to the shape.
+  /// @param stroke    The stroke width for the outline.
   public static void renderOutlineTransformed(
     final Graphics2D g, final Shape shape, AffineTransform transform, final float stroke) {
     renderOutlineTransformed(g, shape, transform, new BasicStroke(stroke));
   }
 
-  /**
-   * Renders the outline of the specified {@code Shape} to the given {@code Graphics2D} object with a custom affine transformation and stroke.
-   *
-   * @param g         The graphics object to draw on.
-   * @param shape     The shape whose outline is to be drawn.
-   * @param transform The affine transformation to be applied to the shape.
-   * @param stroke    The stroke for the outline.
-   */
+  /// Renders the outline of the specified `Shape` to the given `Graphics2D` object with a custom affine transformation and stroke.
+  ///
+  /// @param g         The graphics object to draw on.
+  /// @param shape     The shape whose outline is to be drawn.
+  /// @param transform The affine transformation to be applied to the shape.
+  /// @param stroke    The stroke for the outline.
   public static void renderOutlineTransformed(
     final Graphics2D g, final Shape shape, AffineTransform transform, final Stroke stroke) {
     if (transform == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/Spritesheet.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/Spritesheet.java
@@ -12,10 +12,8 @@ import java.awt.image.RasterFormatException;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-/**
- * Represents a single sprite sheet image carved up into individual sprite frames of equal {@linkplain #getSpriteWidth() width} and
- * {@linkplain #getSpriteHeight() height}. Sprite frames are lazily cached on first access and can be retrieved by index.
- */
+/// Represents a single sprite sheet image carved up into individual sprite frames of equal [width][#getSpriteWidth()] and
+/// [height][#getSpriteHeight()]. Sprite frames are lazily cached on first access and can be retrieved by index.
 public final class Spritesheet implements Comparable<Spritesheet> {
   private static final Logger log = Logger.getLogger(Spritesheet.class.getName());
 
@@ -30,15 +28,13 @@ public final class Spritesheet implements Comparable<Spritesheet> {
   private int spriteHeight;
   private int spriteWidth;
 
-  /**
-   * Instantiates a new {@code Spritesheet} instance. Depending on the given {@code spriteWidth} and {@code spriteHeight}, the sub-images will be
-   * cropped from the spritesheet image when accessing individual sprites.
-   *
-   * @param image        the spritesheet image
-   * @param path         the path (or name) of the spritesheet image
-   * @param spriteWidth  the width in pixels of each sprite in the spritesheet.
-   * @param spriteHeight the height in pixels of each sprite in the spritesheet.
-   */
+  /// Instantiates a new `Spritesheet` instance. Depending on the given `spriteWidth` and `spriteHeight`, the sub-images will be
+  /// cropped from the spritesheet image when accessing individual sprites.
+  ///
+  /// @param image        the spritesheet image
+  /// @param path         the path (or name) of the spritesheet image
+  /// @param spriteWidth  the width in pixels of each sprite in the spritesheet.
+  /// @param spriteHeight the height in pixels of each sprite in the spritesheet.
   public Spritesheet(
     final BufferedImage image, final String path, final int spriteWidth, final int spriteHeight) {
     checkImage(image, path);
@@ -70,22 +66,18 @@ public final class Spritesheet implements Comparable<Spritesheet> {
     return AlphanumComparator.compareTo(this.getName(), obj.getName());
   }
 
-  /**
-   * Gets the sprites per row.
-   *
-   * @return the sprites per row
-   */
+  /// Gets the sprites per row.
+  ///
+  /// @return the sprites per row
   public int getColumns() {
     return this.columns;
   }
 
-  /**
-   * Returns a square preview image of the first sprite, scaled to the requested dimension. The scaled image is cached in the global image resource
-   * registry so subsequent calls with the same dimension are cheap.
-   *
-   * @param dimension the side length of the preview image, in pixels
-   * @return the preview image
-   */
+  /// Returns a square preview image of the first sprite, scaled to the requested dimension. The scaled image is cached in the global image resource
+  /// registry so subsequent calls with the same dimension are cheap.
+  ///
+  /// @param dimension the side length of the preview image, in pixels
+  /// @return the preview image
   public BufferedImage getPreview(int dimension) {
     final BufferedImage img = this.getSprite(0);
     BufferedImage scaled;
@@ -106,69 +98,55 @@ public final class Spritesheet implements Comparable<Spritesheet> {
     return scaled;
   }
 
-  /**
-   * Gets the full underlying spritesheet image.
-   *
-   * @return the spritesheet image
-   */
+  /// Gets the full underlying spritesheet image.
+  ///
+  /// @return the spritesheet image
   public BufferedImage getImage() {
     return this.image;
   }
 
-  /**
-   * Gets the image format the spritesheet was loaded from.
-   *
-   * @return the image format
-   */
+  /// Gets the image format the spritesheet was loaded from.
+  ///
+  /// @return the image format
   public ImageFormat getImageFormat() {
     return this.imageFormat;
   }
 
-  /**
-   * The unique name of this spritesheet. A spritesheet can always be identified by this name within a game project.
-   *
-   * @return The name of the spritesheet.
-   */
+  /// The unique name of this spritesheet. A spritesheet can always be identified by this name within a game project.
+  ///
+  /// @return The name of the spritesheet.
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Gets the number of sprite rows in this spritesheet.
-   *
-   * @return the row count
-   */
+  /// Gets the number of sprite rows in this spritesheet.
+  ///
+  /// @return the row count
   public int getRows() {
     return this.rows;
   }
 
-  /**
-   * Returns a randomly chosen sprite from the cached sprite array.
-   *
-   * @return a random sprite, or {@code null} if no sprites are cached
-   */
+  /// Returns a randomly chosen sprite from the cached sprite array.
+  ///
+  /// @return a random sprite, or `null` if no sprites are cached
   public BufferedImage getRandomSprite() {
     return Game.random().choose(this.sprites);
   }
 
-  /**
-   * Returns the sprite at the supplied index.
-   *
-   * @param index the sprite index
-   * @return the sprite image, or {@code null} if the index is invalid or the sprite is empty
-   */
+  /// Returns the sprite at the supplied index.
+  ///
+  /// @param index the sprite index
+  /// @return the sprite image, or `null` if the index is invalid or the sprite is empty
   public BufferedImage getSprite(final int index) {
     return this.getSprite(index, 0, 0);
   }
 
-  /**
-   * Returns the sprite at the supplied index, accounting for the supplied margin/spacing.
-   *
-   * @param index   the sprite index
-   * @param margin  the outer margin of the spritesheet image, in pixels
-   * @param spacing the spacing between adjacent sprites, in pixels
-   * @return the sprite image, or {@code null} if the index is invalid, the sprite is empty, or the sub-image could not be extracted
-   */
+  /// Returns the sprite at the supplied index, accounting for the supplied margin/spacing.
+  ///
+  /// @param index   the sprite index
+  /// @param margin  the outer margin of the spritesheet image, in pixels
+  /// @param spacing the spacing between adjacent sprites, in pixels
+  /// @return the sprite image, or `null` if the index is invalid, the sprite is empty, or the sub-image could not be extracted
   public BufferedImage getSprite(final int index, final int margin, final int spacing) {
     if (index < 0 || index >= this.sprites.length || this.emptySprites[index]) {
       return null;
@@ -211,48 +189,38 @@ public final class Spritesheet implements Comparable<Spritesheet> {
     }
   }
 
-  /**
-   * Gets the sprite height.
-   *
-   * @return the sprite height
-   */
+  /// Gets the sprite height.
+  ///
+  /// @return the sprite height
   public int getSpriteHeight() {
     return this.spriteHeight;
   }
 
-  /**
-   * Gets the sprite width.
-   *
-   * @return the sprite width
-   */
+  /// Gets the sprite width.
+  ///
+  /// @return the sprite width
   public int getSpriteWidth() {
     return this.spriteWidth;
   }
 
-  /**
-   * Gets the total sprites.
-   *
-   * @return the total sprites
-   */
+  /// Gets the total sprites.
+  ///
+  /// @return the total sprites
   public int getTotalNumberOfSprites() {
     return this.getRows() * this.getColumns();
   }
 
-  /**
-   * Returns whether this spritesheet is currently registered with the global spritesheet resources.
-   *
-   * @return {@code true} if loaded
-   */
+  /// Returns whether this spritesheet is currently registered with the global spritesheet resources.
+  ///
+  /// @return `true` if loaded
   public boolean isLoaded() {
     return Resources.spritesheets().contains(this.getName())
       && Resources.spritesheets().get(this.getName()).equals(this);
   }
 
-  /**
-   * Sets the sprite height (in pixels) and rebuilds the row/column counts.
-   *
-   * @param spriteHeight the new sprite height
-   */
+  /// Sets the sprite height (in pixels) and rebuilds the row/column counts.
+  ///
+  /// @param spriteHeight the new sprite height
   public void setSpriteHeight(final int spriteHeight) {
     this.checkHeight(spriteHeight);
 
@@ -260,11 +228,9 @@ public final class Spritesheet implements Comparable<Spritesheet> {
     this.updateRowsAndCols();
   }
 
-  /**
-   * Sets the sprite width (in pixels) and rebuilds the row/column counts.
-   *
-   * @param spriteWidth the new sprite width
-   */
+  /// Sets the sprite width (in pixels) and rebuilds the row/column counts.
+  ///
+  /// @param spriteWidth the new sprite width
   public void setSpriteWidth(final int spriteWidth) {
     this.checkWidth(spriteWidth);
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/StaticShadowLayer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/StaticShadowLayer.java
@@ -10,12 +10,10 @@ import java.awt.geom.Rectangle2D;
 
 public class StaticShadowLayer extends ColorLayer {
 
-  /**
-   * Instantiates a new {@code StaticShadowLayer} instance.
-   *
-   * @param environment The environment to which this instance is assigned.
-   * @param color       The color of this instance.
-   */
+  /// Instantiates a new `StaticShadowLayer` instance.
+  ///
+  /// @param environment The environment to which this instance is assigned.
+  /// @param color       The color of this instance.
   public StaticShadowLayer(Environment environment, Color color) {
     super(environment, color);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/StaticShadowType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/StaticShadowType.java
@@ -1,43 +1,35 @@
 package de.gurkenlabs.litiengine.graphics;
 
-/**
- * Enumerates the offset directions used when rendering a static (baked) shadow. Each value describes the offset of the shadow shape relative to the
- * source map object.
- */
+/// Enumerates the offset directions used when rendering a static (baked) shadow. Each value describes the offset of the shadow shape relative to the
+/// source map object.
 public enum StaticShadowType {
-  /**
-   * Shadow offset downward.
-   */
+  /// Shadow offset downward.
   DOWN,
-  /**
-   * Shadow offset down and to the left.
-   */
+  /// Shadow offset down and to the left.
   DOWNLEFT,
-  /** Shadow offset down and to the right. */
+  /// Shadow offset down and to the right.
   DOWNRIGHT,
-  /** Shadow offset to the left. */
+  /// Shadow offset to the left.
   LEFT,
-  /** Shadow offset to the left and downward. */
+  /// Shadow offset to the left and downward.
   LEFTDOWN,
-  /** Shadow offset to the left and the right. */
+  /// Shadow offset to the left and the right.
   LEFTRIGHT,
-  /** No shadow is rendered. */
+  /// No shadow is rendered.
   NONE,
-  /** Shadow is rendered without any offset. */
+  /// Shadow is rendered without any offset.
   NOOFFSET,
-  /** Shadow offset to the right. */
+  /// Shadow offset to the right.
   RIGHT,
-  /** Shadow offset to the right and downward. */
+  /// Shadow offset to the right and downward.
   RIGHTDOWN,
-  /** Shadow offset to the right and the left. */
+  /// Shadow offset to the right and the left.
   RIGHTLEFT;
 
-  /**
-   * Returns the enum value matching the supplied name, or {@link #NOOFFSET} if the name is blank or does not match any known value.
-   *
-   * @param mapObjectType the type name
-   * @return the matching enum value, or {@link #NOOFFSET}
-   */
+  /// Returns the enum value matching the supplied name, or [#NOOFFSET] if the name is blank or does not match any known value.
+  ///
+  /// @param mapObjectType the type name
+  /// @return the matching enum value, or [#NOOFFSET]
   public static StaticShadowType get(final String mapObjectType) {
     if (mapObjectType == null || mapObjectType.isEmpty()) {
       return StaticShadowType.NOOFFSET;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TextRenderer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TextRenderer.java
@@ -23,83 +23,71 @@ import java.text.AttributedString;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * This class provides static methods for rendering text with various options such as alignment, scaling, rotation, and anti-aliasing. It cannot be
- * instantiated.
- */
+/// This class provides static methods for rendering text with various options such as alignment, scaling, rotation, and anti-aliasing. It cannot be
+/// instantiated.
 public final class TextRenderer {
   private TextRenderer() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Draw text at the given coordinates. This variant of drawText() uses RenderingHints.VALUE_TEXT_ANTIALIAS_OFF as Anti-Aliasing method by standard.
-   * For other Anti-Aliasing options, please use the drawText()-variant with five parameters.
-   *
-   * @param g    the Graphics2D object to draw on
-   * @param text the String to be distributed over all generated lines
-   * @param x    the min x coordinate
-   * @param y    the min y coordinate
-   */
+  /// Draw text at the given coordinates. This variant of drawText() uses RenderingHints.VALUE_TEXT_ANTIALIAS_OFF as Anti-Aliasing method by standard.
+  /// For other Anti-Aliasing options, please use the drawText()-variant with five parameters.
+  ///
+  /// @param g    the Graphics2D object to draw on
+  /// @param text the String to be distributed over all generated lines
+  /// @param x    the min x coordinate
+  /// @param y    the min y coordinate
   public static void render(final Graphics2D g, final String text, final double x, final double y) {
     render(g, text, x, y, true);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object at the specified location.
-   *
-   * @param g        The graphics object to draw on.
-   * @param text     The text to be drawn.
-   * @param location The location where the text will be drawn.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object at the specified location.
+  ///
+  /// @param g        The graphics object to draw on.
+  /// @param text     The text to be drawn.
+  /// @param location The location where the text will be drawn.
   public static void render(final Graphics2D g, final String text, Point2D location) {
     render(g, text, location.getX(), location.getY());
   }
 
-  /**
-   * Draws text with the specified alignment.
-   *
-   * @param g       the Graphics2D object to draw on
-   * @param text    the String to be distributed over all generated lines
-   * @param align   The horizontal alignment.
-   * @param valign  The vertical alignment.
-   * @param offsetX The horizontal offset that is added to the alignment.
-   * @param offsetY The vertical offset that is added to the alignment.
-   */
+  /// Draws text with the specified alignment.
+  ///
+  /// @param g       the Graphics2D object to draw on
+  /// @param text    the String to be distributed over all generated lines
+  /// @param align   The horizontal alignment.
+  /// @param valign  The vertical alignment.
+  /// @param offsetX The horizontal offset that is added to the alignment.
+  /// @param offsetY The vertical offset that is added to the alignment.
   public static void render(final Graphics2D g, final String text, Align align, Valign valign, double offsetX, double offsetY) {
     final Rectangle2D bounds = g.getClipBounds();
     render(g, text, bounds, align, valign, offsetX, offsetY, false);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object within the specified bounds using the specified alignment and scaling
-   * options.
-   *
-   * @param g                 The graphics object to draw on.
-   * @param text              The text to be drawn.
-   * @param bounds            The rectangle defining the boundaries used for alignment and scaling.
-   * @param alignment         The horizontal alignment.
-   * @param verticalAlignment The vertical alignment.
-   * @param scaleFont         If true, scale the font so that the text will fit inside the given rectangle. If not, use the Graphics context's
-   *                          previous font size.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object within the specified bounds using the specified alignment and scaling
+  /// options.
+  ///
+  /// @param g                 The graphics object to draw on.
+  /// @param text              The text to be drawn.
+  /// @param bounds            The rectangle defining the boundaries used for alignment and scaling.
+  /// @param alignment         The horizontal alignment.
+  /// @param verticalAlignment The vertical alignment.
+  /// @param scaleFont         If true, scale the font so that the text will fit inside the given rectangle. If not, use the Graphics context's
+  /// previous font size.
   public static void render(final Graphics2D g, final String text, Rectangle2D bounds, Align alignment, Valign verticalAlignment, boolean scaleFont) {
     render(g, text, bounds, alignment, verticalAlignment, 0, 0, scaleFont);
   }
 
-  /**
-   * Draws text within the given boundaries using the specified alignment and scales the font size, if desired.
-   *
-   * @param g         the Graphics2D object to draw on
-   * @param text      the String to be distributed over all generated lines
-   * @param bounds    the Rectangle defining the boundaries used for alignment and scaling.
-   * @param align     The horizontal alignment.
-   * @param valign    The vertical alignment.
-   * @param offsetX   The horizontal offset that is added to the alignment.
-   * @param offsetY   The vertical offset that is added to the alignment.
-   * @param scaleFont if true, scale the font so that the text will fit inside the given rectangle. If not, use the Graphics context's previous font
-   *                  size.
-   */
+  /// Draws text within the given boundaries using the specified alignment and scales the font size, if desired.
+  ///
+  /// @param g         the Graphics2D object to draw on
+  /// @param text      the String to be distributed over all generated lines
+  /// @param bounds    the Rectangle defining the boundaries used for alignment and scaling.
+  /// @param align     The horizontal alignment.
+  /// @param valign    The vertical alignment.
+  /// @param offsetX   The horizontal offset that is added to the alignment.
+  /// @param offsetY   The vertical offset that is added to the alignment.
+  /// @param scaleFont if true, scale the font so that the text will fit inside the given rectangle. If not, use the Graphics context's previous font
+  /// size.
   public static void render(final Graphics2D g, final String text, Rectangle2D bounds, Align align, Valign valign, double offsetX, double offsetY,
     boolean scaleFont) {
     if (bounds == null) {
@@ -119,16 +107,14 @@ public final class TextRenderer {
     g.setFont(g.getFont().deriveFont(previousFontSize));
   }
 
-  /**
-   * Draw text at the given coordinates. This variant of drawText() uses a provided AntiAliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param x            the min x coordinate
-   * @param y            the min y coordinate
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates. This variant of drawText() uses a provided AntiAliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param x            the min x coordinate
+  /// @param y            the min y coordinate
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
+  /// @see RenderingHints
   public static void render(final Graphics2D g, final String text, final double x, final double y, boolean antiAliasing) {
     if (text == null || text.isEmpty()) {
       return;
@@ -144,29 +130,25 @@ public final class TextRenderer {
     g.setRenderingHints(originalHints);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object at the specified location with optional anti-aliasing.
-   *
-   * @param g            The graphics object to draw on.
-   * @param text         The text to be drawn.
-   * @param location     The location where the text will be drawn.
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object at the specified location with optional anti-aliasing.
+  ///
+  /// @param g            The graphics object to draw on.
+  /// @param text         The text to be drawn.
+  /// @param location     The location where the text will be drawn.
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
   public static void render(final Graphics2D g, final String text, Point2D location, boolean antiAliasing) {
     render(g, text, location.getX(), location.getY(), antiAliasing);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object at the specified coordinates with rotation and optional
-   * anti-aliasing.
-   *
-   * @param g            The graphics object to draw on.
-   * @param text         The text to be drawn.
-   * @param x            The x-coordinate of the text.
-   * @param y            The y-coordinate of the text.
-   * @param angle        The angle by which the text will be rotated.
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object at the specified coordinates with rotation and optional
+  /// anti-aliasing.
+  ///
+  /// @param g            The graphics object to draw on.
+  /// @param text         The text to be drawn.
+  /// @param x            The x-coordinate of the text.
+  /// @param y            The y-coordinate of the text.
+  /// @param angle        The angle by which the text will be rotated.
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
   public static void renderRotated(final Graphics2D g, final String text, final double x, final double y, final double angle, boolean antiAliasing) {
     RenderingHints originalHints = g.getRenderingHints();
 
@@ -178,15 +160,13 @@ public final class TextRenderer {
     g.setRenderingHints(originalHints);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object at the specified coordinates with rotation.
-   *
-   * @param g     The graphics object to draw on.
-   * @param text  The text to be drawn.
-   * @param x     The x-coordinate of the text.
-   * @param y     The y-coordinate of the text.
-   * @param angle The angle by which the text will be rotated.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object at the specified coordinates with rotation.
+  ///
+  /// @param g     The graphics object to draw on.
+  /// @param text  The text to be drawn.
+  /// @param x     The x-coordinate of the text.
+  /// @param y     The y-coordinate of the text.
+  /// @param angle The angle by which the text will be rotated.
   public static void renderRotated(final Graphics2D g, final String text, final double x, final double y, final double angle) {
     AffineTransform oldTx = g.getTransform();
     g.rotate(Math.toRadians(angle), x, y);
@@ -194,88 +174,76 @@ public final class TextRenderer {
     g.setTransform(oldTx);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object at the specified location with rotation.
-   *
-   * @param g        The graphics object to draw on.
-   * @param text     The text to be drawn.
-   * @param location The location where the text will be drawn.
-   * @param angle    The angle by which the text will be rotated.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object at the specified location with rotation.
+  ///
+  /// @param g        The graphics object to draw on.
+  /// @param text     The text to be drawn.
+  /// @param location The location where the text will be drawn.
+  /// @param angle    The angle by which the text will be rotated.
   public static void renderRotated(final Graphics2D g, final String text, Point2D location, final double angle) {
     renderRotated(g, text, location.getX(), location.getY(), angle);
   }
 
-  /**
-   * Renders the specified {@code String} to the given {@code Graphics2D} object at the specified location with rotation and optional anti-aliasing.
-   *
-   * @param g            The graphics object to draw on.
-   * @param text         The text to be drawn.
-   * @param location     The location where the text will be drawn.
-   * @param angle        The angle by which the text will be rotated.
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   */
+  /// Renders the specified `String` to the given `Graphics2D` object at the specified location with rotation and optional anti-aliasing.
+  ///
+  /// @param g            The graphics object to draw on.
+  /// @param text         The text to be drawn.
+  /// @param location     The location where the text will be drawn.
+  /// @param angle        The angle by which the text will be rotated.
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
   public static void renderRotated(final Graphics2D g, final String text, Point2D location, final double angle, boolean antiAliasing) {
     renderRotated(g, text, location.getX(), location.getY(), angle, antiAliasing);
   }
 
-  /**
-   * Draw text at the given coordinates with a maximum line width for automatic line breaks. This variant of drawTextWithAutomaticLinebreaks() uses
-   * RenderingHints.VALUE_TEXT_ANTIALIAS_OFF as Anti-Aliasing method by standard. For other Anti-Aliasing options, please use the
-   * drawTextWithAutomaticLinebreaks()-variant with six parameters.
-   *
-   * @param g         the Graphics2D object to draw on
-   * @param text      the String to be distributed over all generated lines
-   * @param x         the min x coordinate
-   * @param y         the min y coordinate
-   * @param lineWidth the max line width
-   */
+  /// Draw text at the given coordinates with a maximum line width for automatic line breaks. This variant of drawTextWithAutomaticLinebreaks() uses
+  /// RenderingHints.VALUE_TEXT_ANTIALIAS_OFF as Anti-Aliasing method by standard. For other Anti-Aliasing options, please use the
+  /// drawTextWithAutomaticLinebreaks()-variant with six parameters.
+  ///
+  /// @param g         the Graphics2D object to draw on
+  /// @param text      the String to be distributed over all generated lines
+  /// @param x         the min x coordinate
+  /// @param y         the min y coordinate
+  /// @param lineWidth the max line width
   public static void renderWithLinebreaks(final Graphics2D g, final String text, final double x, final double y, final double lineWidth) {
     renderWithLinebreaks(g, text, x, y, lineWidth, true);
   }
 
-  /**
-   * Draw text at the given coordinates with a maximum line width for automatic line breaks.
-   *
-   * @param g         The Graphics2D object to draw on.
-   * @param text      The String to be distributed over all generated lines.
-   * @param location  The location where the text will be drawn.
-   * @param lineWidth The max line width.
-   */
+  /// Draw text at the given coordinates with a maximum line width for automatic line breaks.
+  ///
+  /// @param g         The Graphics2D object to draw on.
+  /// @param text      The String to be distributed over all generated lines.
+  /// @param location  The location where the text will be drawn.
+  /// @param lineWidth The max line width.
   public static void renderWithLinebreaks(final Graphics2D g, final String text, Point2D location, final double lineWidth) {
     renderWithLinebreaks(g, text, location.getX(), location.getY(), lineWidth);
   }
 
-  /**
-   * Draw text at the given coordinates with a maximum line width for automatic line breaks and a provided Anti-Aliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param x            the min x coordinate
-   * @param y            the min y coordinate
-   * @param lineWidth    the max line width
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates with a maximum line width for automatic line breaks and a provided Anti-Aliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param x            the min x coordinate
+  /// @param y            the min y coordinate
+  /// @param lineWidth    the max line width
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
+  /// @see RenderingHints
   public static void renderWithLinebreaks(final Graphics2D g, final String text, final double x, final double y, final double lineWidth,
     final boolean antiAliasing) {
     renderWithLinebreaks(g, text, Align.LEFT, Valign.TOP, x, y, lineWidth, 0.0, antiAliasing);
   }
 
-  /**
-   * Draw text at the given coordinates with a maximum line width for automatic line breaks and a provided Anti-Aliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param align        The horizontal alignment.
-   * @param valign       The vertical alignment.
-   * @param x            the min x coordinate
-   * @param y            the min y coordinate
-   * @param height       the line height.
-   * @param width        the line width
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates with a maximum line width for automatic line breaks and a provided Anti-Aliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param align        The horizontal alignment.
+  /// @param valign       The vertical alignment.
+  /// @param x            the min x coordinate
+  /// @param y            the min y coordinate
+  /// @param height       the line height.
+  /// @param width        the line width
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
+  /// @see RenderingHints
   public static void renderWithLinebreaks(final Graphics2D g, final String text, Align align, Valign valign, final double x, final double y,
     final double width, final double height, final boolean antiAliasing) {
     if (text == null || text.isEmpty()) {
@@ -314,43 +282,37 @@ public final class TextRenderer {
     g.setRenderingHints(originalHints);
   }
 
-  /**
-   * Draw text at the given coordinates with a maximum line width for automatic line breaks and a provided Anti-Aliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param location     The location where the text will be drawn.
-   * @param lineWidth    the max line width
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates with a maximum line width for automatic line breaks and a provided Anti-Aliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param location     The location where the text will be drawn.
+  /// @param lineWidth    the max line width
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
+  /// @see RenderingHints
   public static void renderWithLinebreaks(final Graphics2D g, final String text, Point2D location, final double lineWidth,
     final boolean antiAliasing) {
     renderWithLinebreaks(g, text, location.getX(), location.getY(), lineWidth, antiAliasing);
   }
 
-  /**
-   * Draw text at the given coordinates with an outline in the provided color. This variant of drawTextWithShadow() doesn't use Anti-Aliasing. For
-   * other Anti-Aliasing options, please specify the boolean value that controls it.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param x            the min x coordinate
-   * @param y            the min y coordinate
-   * @param outlineColor the outline color
-   */
+  /// Draw text at the given coordinates with an outline in the provided color. This variant of drawTextWithShadow() doesn't use Anti-Aliasing. For
+  /// other Anti-Aliasing options, please specify the boolean value that controls it.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param x            the min x coordinate
+  /// @param y            the min y coordinate
+  /// @param outlineColor the outline color
   public static void renderWithOutline(final Graphics2D g, final String text, final double x, final double y, final Color outlineColor) {
     renderWithOutline(g, text, x, y, outlineColor, false);
   }
 
-  /**
-   * Draw text at the given coordinates with an outline in the provided color.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param location     The location where the text will be drawn.
-   * @param outlineColor the outline color
-   */
+  /// Draw text at the given coordinates with an outline in the provided color.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param location     The location where the text will be drawn.
+  /// @param outlineColor the outline color
   public static void renderWithOutline(final Graphics2D g, final String text, Point2D location, final Color outlineColor) {
     renderWithOutline(g, text, location.getX(), location.getY(), outlineColor);
   }
@@ -361,39 +323,35 @@ public final class TextRenderer {
     renderWithOutline(g, text, x, y, outlineColor, stroke, antiAliasing);
   }
 
-  /**
-   * Draw text at the given coordinates with an outline in the provided color and a provided Anti-Aliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param x            the min x coordinate
-   * @param y            the min y coordinate
-   * @param outlineColor the outline color
-   * @param stroke       the width of the outline
-   * @param antiAliasing the Anti-Aliasing object (e.g. RenderingHints.VALUE_TEXT_ANTIALIAS_OFF)
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates with an outline in the provided color and a provided Anti-Aliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param x            the min x coordinate
+  /// @param y            the min y coordinate
+  /// @param outlineColor the outline color
+  /// @param stroke       the width of the outline
+  /// @param antiAliasing the Anti-Aliasing object (e.g. RenderingHints.VALUE_TEXT_ANTIALIAS_OFF)
+  /// @see RenderingHints
   public static void renderWithOutline(final Graphics2D g, final String text, final double x, final double y, final Color outlineColor,
     final float stroke, final boolean antiAliasing) {
     renderWithOutline(g, text, x, y, 0.0, 0.0, outlineColor, stroke, Align.LEFT, Valign.TOP, antiAliasing);
   }
 
-  /**
-   * Draw text at the given coordinates with an outline in the provided color and a provided Anti-Aliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param x            the min x coordinate
-   * @param y            the min y coordinate
-   * @param width        the width of the bounding box in which the text will be aligned
-   * @param height       the height of the bounding box in which the text will be aligned
-   * @param outlineColor the outline color
-   * @param stroke       the thickness of the outline
-   * @param align        The horizontal alignment.
-   * @param valign       The vertical alignment.
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates with an outline in the provided color and a provided Anti-Aliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param x            the min x coordinate
+  /// @param y            the min y coordinate
+  /// @param width        the width of the bounding box in which the text will be aligned
+  /// @param height       the height of the bounding box in which the text will be aligned
+  /// @param outlineColor the outline color
+  /// @param stroke       the thickness of the outline
+  /// @param align        The horizontal alignment.
+  /// @param valign       The vertical alignment.
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
+  /// @see RenderingHints
   public static void renderWithOutline(final Graphics2D g, final String text, final double x, final double y, double width, double height,
     final Color outlineColor, final float stroke, Align align, Valign valign, final boolean antiAliasing) {
     if (text == null || text.isEmpty()) {
@@ -435,60 +393,50 @@ public final class TextRenderer {
     g.setRenderingHints(originalHints);
   }
 
-  /**
-   * Draw text at the given coordinates with an outline in the provided color and a provided Anti-Aliasing parameter.
-   *
-   * @param g            the Graphics2D object to draw on
-   * @param text         the String to be distributed over all generated lines
-   * @param location     The location where the text will be drawn.
-   * @param outlineColor the outline color
-   * @param antiAliasing Configure whether or not to render the text with antialiasing.
-   * @see RenderingHints
-   */
+  /// Draw text at the given coordinates with an outline in the provided color and a provided Anti-Aliasing parameter.
+  ///
+  /// @param g            the Graphics2D object to draw on
+  /// @param text         the String to be distributed over all generated lines
+  /// @param location     The location where the text will be drawn.
+  /// @param outlineColor the outline color
+  /// @param antiAliasing Configure whether or not to render the text with antialiasing.
+  /// @see RenderingHints
   public static void renderWithOutline(final Graphics2D g, final String text, Point2D location, final Color outlineColor,
     final boolean antiAliasing) {
     renderWithOutline(g, text, location.getX(), location.getY(), outlineColor, antiAliasing);
   }
 
-  /**
-   * Retrieve the bounds of some text if it was to be drawn on the specified Graphics2D
-   *
-   * @param g    The Graphics2D object to be drawn on
-   * @param text The string to calculate the bounds of
-   * @return The bounds of the specified String in the specified Graphics context.
-   * @see java.awt.FontMetrics#getStringBounds(String str, Graphics context)
-   */
+  /// Retrieve the bounds of some text if it was to be drawn on the specified Graphics2D
+  ///
+  /// @param g    The Graphics2D object to be drawn on
+  /// @param text The string to calculate the bounds of
+  /// @return The bounds of the specified String in the specified Graphics context.
+  /// @see java.awt.FontMetrics#getStringBounds(String str, Graphics context)
   public static Rectangle2D getBounds(final Graphics2D g, final String text) {
     return g.getFontMetrics().getStringBounds(text, g);
   }
 
-  /**
-   * Retrieve the width of some text if it was to be drawn on the specified Graphics2D
-   *
-   * @param g    The Graphics2D object to be drawn on
-   * @param text The string to retrieve the width of
-   * @return The width of the specified text
-   */
+  /// Retrieve the width of some text if it was to be drawn on the specified Graphics2D
+  ///
+  /// @param g    The Graphics2D object to be drawn on
+  /// @param text The string to retrieve the width of
+  /// @return The width of the specified text
   public static double getWidth(final Graphics2D g, final String text) {
     return getBounds(g, text).getWidth();
   }
 
-  /**
-   * Retrieve the height of some text if it was to be drawn on the specified Graphics2D
-   *
-   * @param g    The Graphics2D object to be drawn on
-   * @param text The string to retrieve the height of
-   * @return The height of the specified text
-   */
+  /// Retrieve the height of some text if it was to be drawn on the specified Graphics2D
+  ///
+  /// @param g    The Graphics2D object to be drawn on
+  /// @param text The string to retrieve the height of
+  /// @return The height of the specified text
   public static double getHeight(final Graphics2D g, final String text) {
     return getBounds(g, text).getHeight();
   }
 
-  /**
-   * Enables text anti-aliasing on the provided {@code Graphics2D} object.
-   *
-   * @param g The Graphics2D object on which to enable text anti-aliasing.
-   */
+  /// Enables text anti-aliasing on the provided `Graphics2D` object.
+  ///
+  /// @param g The Graphics2D object on which to enable text anti-aliasing.
   public static void enableTextAntiAliasing(final Graphics2D g) {
     g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
     g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TransparencyImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TransparencyImageEffect.java
@@ -8,13 +8,11 @@ import java.awt.image.BufferedImage;
 public class TransparencyImageEffect extends ImageEffect {
   private final float alpha;
 
-  /**
-   * Initializes a new instance of the {@code TransparencyImageEffect}.
-   *
-   * @param ttl The time to live of this effect.
-   * @param alpha the constant alpha to be multiplied with the alpha of the source. alpha must be a floating point number in the inclusive range [0.0,
-   *              1.0].
-   */
+  /// Initializes a new instance of the `TransparencyImageEffect`.
+  ///
+  /// @param ttl The time to live of this effect.
+  /// @param alpha the constant alpha to be multiplied with the alpha of the source. alpha must be a floating point number in the inclusive range [0.0,
+  /// 1.0].
   public TransparencyImageEffect(final int ttl, final float alpha) {
     super(ttl, "Transparency_" + alpha);
     this.alpha = alpha;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TransparencyImageEffect.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/TransparencyImageEffect.java
@@ -5,6 +5,9 @@ import de.gurkenlabs.litiengine.util.Imaging;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 
+/// Applies a constant alpha multiplier to every pixel of an image for the effect's lifetime.
+///
+/// @see Imaging#setAlpha(BufferedImage, float)
 public class TransparencyImageEffect extends ImageEffect {
   private final float alpha;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ZoomChangedEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/ZoomChangedEvent.java
@@ -2,6 +2,9 @@ package de.gurkenlabs.litiengine.graphics;
 
 import java.io.Serial;
 
+/// Event emitted after a camera's zoom factor changes.
+///
+/// @see ICamera#onZoom(ZoomChangedListener)
 public class ZoomChangedEvent extends CameraEvent {
   @Serial private static final long serialVersionUID = -427566098748292912L;
   private final double zoom;
@@ -11,6 +14,9 @@ public class ZoomChangedEvent extends CameraEvent {
     this.zoom = zoom;
   }
 
+  /// Returns the new zoom factor.
+  ///
+  /// @return The new camera zoom.
   public double getZoom() {
     return this.zoom;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/Animation.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/Animation.java
@@ -11,17 +11,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The {@code Animation} class keeps track of the current keyframe which is used to animate a visual element. It iterates over all defined keyframes
- * with respect to their duration and provides information for the related {@code AnimationController} which keyframe should currently be rendered.
- *
- * @see IAnimationController#getCurrent()
- */
+/// The `Animation` class keeps track of the current keyframe which is used to animate a visual element. It iterates over all defined keyframes
+/// with respect to their duration and provides information for the related `AnimationController` which keyframe should currently be rendered.
+///
+/// @see IAnimationController#getCurrent()
 public class Animation implements IUpdateable, ILaunchable {
   private final List<KeyFrameListener> listeners;
-  /**
-   * The default frame duration in milliseconds.
-   */
+  /// The default frame duration in milliseconds.
   public static final int DEFAULT_FRAME_DURATION = 120;
 
   private static final Logger log = Logger.getLogger(Animation.class.getName());
@@ -39,50 +35,42 @@ public class Animation implements IUpdateable, ILaunchable {
   private boolean paused;
   private boolean playing;
 
-  /**
-   * Initializes a new instance of the {@code Animation} class.
-   *
-   * @param spriteSheetName   The name of the spritesheet used by this animation.
-   * @param loop              A flag indicating whether the animation should be looped or played only once.
-   * @param randomizeStart    A flag indicating whether this animation should choose a random keyframe to start.
-   * @param keyFrameDurations The duration of each keyframe.
-   */
+  /// Initializes a new instance of the `Animation` class.
+  ///
+  /// @param spriteSheetName   The name of the spritesheet used by this animation.
+  /// @param loop              A flag indicating whether the animation should be looped or played only once.
+  /// @param randomizeStart    A flag indicating whether this animation should choose a random keyframe to start.
+  /// @param keyFrameDurations The duration of each keyframe.
   public Animation(final String spriteSheetName, final boolean loop, final boolean randomizeStart, final int... keyFrameDurations) {
     this(Resources.spritesheets().get(spriteSheetName), loop, randomizeStart, keyFrameDurations);
   }
 
-  /**
-   * Initializes a new instance of the {@code Animation} class.
-   *
-   * @param spritesheet       The spritesheet used by this animation.
-   * @param loop              A flag indicating whether the animation should be looped or played only once.
-   * @param randomizeStart    A flag indicating whether this animation should choose a random keyframe to start.
-   * @param keyFrameDurations The duration of each keyframe.
-   */
+  /// Initializes a new instance of the `Animation` class.
+  ///
+  /// @param spritesheet       The spritesheet used by this animation.
+  /// @param loop              A flag indicating whether the animation should be looped or played only once.
+  /// @param randomizeStart    A flag indicating whether this animation should choose a random keyframe to start.
+  /// @param keyFrameDurations The duration of each keyframe.
   public Animation(final Spritesheet spritesheet, final boolean loop, final boolean randomizeStart, final int... keyFrameDurations) {
     this(spritesheet.getName(), spritesheet, loop, randomizeStart, keyFrameDurations);
   }
 
-  /**
-   * Initializes a new instance of the {@code Animation} class.
-   *
-   * @param spritesheet       The spritesheet used by this animation.
-   * @param loop              A flag indicating whether the animation should be looped or played only once.
-   * @param keyFrameDurations The duration of each keyframe.
-   */
+  /// Initializes a new instance of the `Animation` class.
+  ///
+  /// @param spritesheet       The spritesheet used by this animation.
+  /// @param loop              A flag indicating whether the animation should be looped or played only once.
+  /// @param keyFrameDurations The duration of each keyframe.
   public Animation(final Spritesheet spritesheet, final boolean loop, final int... keyFrameDurations) {
     this(spritesheet.getName(), spritesheet, loop, keyFrameDurations);
   }
 
-  /**
-   * Initializes a new instance of the {@code Animation} class.
-   *
-   * @param name              The name of this animation.
-   * @param spritesheet       The spritesheet used by this animation.
-   * @param loop              A flag indicating whether the animation should be looped or played only once.
-   * @param randomizeStart    A flag indicating whether this animation should choose a random keyframe to start.
-   * @param keyFrameDurations The duration of each keyframe.
-   */
+  /// Initializes a new instance of the `Animation` class.
+  ///
+  /// @param name              The name of this animation.
+  /// @param spritesheet       The spritesheet used by this animation.
+  /// @param loop              A flag indicating whether the animation should be looped or played only once.
+  /// @param randomizeStart    A flag indicating whether this animation should choose a random keyframe to start.
+  /// @param keyFrameDurations The duration of each keyframe.
   public Animation(final String name, final Spritesheet spritesheet, final boolean loop, final boolean randomizeStart,
     final int... keyFrameDurations) {
     this(name, spritesheet, loop, keyFrameDurations);
@@ -92,14 +80,12 @@ public class Animation implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Initializes a new instance of the {@code Animation} class.
-   *
-   * @param name              The name of this animation.
-   * @param spritesheet       The spritesheet used by this animation.
-   * @param loop              A flag indicating whether the animation should be looped or played only once.
-   * @param keyFrameDurations The duration of each keyframe.
-   */
+  /// Initializes a new instance of the `Animation` class.
+  ///
+  /// @param name              The name of this animation.
+  /// @param spritesheet       The spritesheet used by this animation.
+  /// @param loop              A flag indicating whether the animation should be looped or played only once.
+  /// @param keyFrameDurations The duration of each keyframe.
   public Animation(final String name, final Spritesheet spritesheet, final boolean loop, final int... keyFrameDurations) {
     this.name = name;
     this.spritesheet = spritesheet;
@@ -118,11 +104,9 @@ public class Animation implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Gets to aggregated duration of all {@link KeyFrame}s in this animation.
-   *
-   * @return The total duration of a single playback.
-   */
+  /// Gets to aggregated duration of all [KeyFrame]s in this animation.
+  ///
+  /// @return The total duration of a single playback.
   public int getTotalDuration() {
     int duration = 0;
     for (KeyFrame keyFrame : getKeyframes()) {
@@ -132,22 +116,18 @@ public class Animation implements IUpdateable, ILaunchable {
     return duration;
   }
 
-  /**
-   * Gets the name of this animation.
-   *
-   * @return The name of this animation.
-   */
+  /// Gets the name of this animation.
+  ///
+  /// @return The name of this animation.
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Gets the spritesheet used by this animation.
-   *
-   * <p>If the previously used spritesheet was unloaded, this method attempts to reload it by its name.</p>
-   *
-   * @return The spritesheet used by this animation.
-   */
+  /// Gets the spritesheet used by this animation.
+  ///
+  /// If the previously used spritesheet was unloaded, this method attempts to reload it by its name.
+  ///
+  /// @return The spritesheet used by this animation.
   public Spritesheet getSpritesheet() {
     // in case the previously sprite sheet was unloaded (removed from the loaded sprite sheets),
     // try to find an updated one by the name of the previously used sprite
@@ -160,58 +140,46 @@ public class Animation implements IUpdateable, ILaunchable {
     return this.spritesheet;
   }
 
-  /**
-   * Gets a value indicating whether this animation intended to loop.
-   *
-   * @return True if this animation will loop; otherwise false.
-   */
+  /// Gets a value indicating whether this animation intended to loop.
+  ///
+  /// @return True if this animation will loop; otherwise false.
   public boolean isLooping() {
     return this.loop;
   }
 
-  /**
-   * Gets a value indicating whether this animation is currently paused.
-   *
-   * @return True if this animation is currently pause; otherwise false.
-   */
+  /// Gets a value indicating whether this animation is currently paused.
+  ///
+  /// @return True if this animation is currently pause; otherwise false.
   public boolean isPaused() {
     return this.paused;
   }
 
-  /**
-   * Gets a value indicating whether this animation is currently playing.
-   *
-   * @return True if this animation is currently playing; otherwise false.
-   */
+  /// Gets a value indicating whether this animation is currently playing.
+  ///
+  /// @return True if this animation is currently playing; otherwise false.
   public boolean isPlaying() {
     return !this.paused && !this.keyframes.isEmpty() && this.playing;
   }
 
-  /**
-   * Pauses the playback of this animation.
-   *
-   * @see #isPaused()
-   * @see #unpause()
-   */
+  /// Pauses the playback of this animation.
+  ///
+  /// @see #isPaused()
+  /// @see #unpause()
   public void pause() {
     this.paused = true;
   }
 
-  /**
-   * Un-pauses the playback of this animation.
-   *
-   * @see #isPaused()
-   * @see #pause()
-   */
+  /// Un-pauses the playback of this animation.
+  ///
+  /// @see #isPaused()
+  /// @see #pause()
   public void unpause() {
     this.paused = false;
   }
 
-  /**
-   * Sets the frame duration for all keyframes in this animation to the specified value.
-   *
-   * @param frameDuration The frameduration for all keyframes.
-   */
+  /// Sets the frame duration for all keyframes in this animation to the specified value.
+  ///
+  /// @param frameDuration The frameduration for all keyframes.
   public void setDurationForAllKeyFrames(final int frameDuration) {
     this.frameDuration = frameDuration;
 
@@ -220,14 +188,11 @@ public class Animation implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Sets the specified durations for the keyframes at the index of the defined arguments.
-   *
-   * <p>
-   * e.g.: If this animation defines 5 keyframes, the caller of this method can provide 5 individual durations for each keyframe.
-   *
-   * @param keyFrameDurations The durations to be set on the keyframes of this animation.
-   */
+  /// Sets the specified durations for the keyframes at the index of the defined arguments.
+  ///
+  /// e.g.: If this animation defines 5 keyframes, the caller of this method can provide 5 individual durations for each keyframe.
+  ///
+  /// @param keyFrameDurations The durations to be set on the keyframes of this animation.
   public void setKeyFrameDurations(final int... keyFrameDurations) {
     if (keyFrameDurations.length == 0) {
       return;
@@ -238,38 +203,30 @@ public class Animation implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Gets an array of this animation's keyframe durations by streaming the keyframe list and mapping the durations to an int array.
-   *
-   * @return An array of this animation's keyframe durations.
-   */
+  /// Gets an array of this animation's keyframe durations by streaming the keyframe list and mapping the durations to an int array.
+  ///
+  /// @return An array of this animation's keyframe durations.
   public int[] getKeyFrameDurations() {
     return getKeyframes().stream().mapToInt(KeyFrame::getDuration).toArray();
   }
 
-  /**
-   * Sets the looping behavior for this animation.
-   *
-   * @param loop if true, restart the animation infinitely after its last frame.
-   */
+  /// Sets the looping behavior for this animation.
+  ///
+  /// @param loop if true, restart the animation infinitely after its last frame.
   public void setLooping(boolean loop) {
     this.loop = loop;
   }
 
-  /**
-   * Adds a listener that will be notified when the current keyframe changes.
-   *
-   * @param listener the listener to be added
-   */
+  /// Adds a listener that will be notified when the current keyframe changes.
+  ///
+  /// @param listener the listener to be added
   public void onKeyFrameChanged(KeyFrameListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes a listener that was previously added to be notified when the current keyframe changes.
-   *
-   * @param listener the listener to be removed
-   */
+  /// Removes a listener that was previously added to be notified when the current keyframe changes.
+  ///
+  /// @param listener the listener to be removed
   public void removeKeyFrameListener(final KeyFrameListener listener) {
     this.listeners.remove(listener);
   }
@@ -282,9 +239,7 @@ public class Animation implements IUpdateable, ILaunchable {
     this.restart();
   }
 
-  /**
-   * Restarts this animation at its first frame.
-   */
+  /// Restarts this animation at its first frame.
   public void restart() {
     this.currentFrame = this.firstFrame;
     this.lastFrameUpdate = Game.loop().getTicks();
@@ -323,36 +278,28 @@ public class Animation implements IUpdateable, ILaunchable {
     this.lastFrameUpdate = Game.loop().getTicks();
   }
 
-  /**
-   * Gets the current keyframe of the animation.
-   *
-   * @return The current keyframe of the animation.
-   */
+  /// Gets the current keyframe of the animation.
+  ///
+  /// @return The current keyframe of the animation.
   public KeyFrame getCurrentKeyFrame() {
     return this.currentFrame;
   }
 
-  /**
-   * Gets the list of keyframes in the animation.
-   *
-   * @return The list of keyframes in the animation.
-   */
+  /// Gets the list of keyframes in the animation.
+  ///
+  /// @return The list of keyframes in the animation.
   public List<KeyFrame> getKeyframes() {
     return this.keyframes;
   }
 
-  /**
-   * Initializes the animation key frames by the specified durations.
-   *
-   * <p>
-   * The amount of keyframes is defined by the available sprites of the assigned {@code Spritesheet}. For each sprite, a new keyframe will be
-   * initialized.
-   *
-   * <p>
-   * If no custom durations are specified, the {@link #DEFAULT_FRAME_DURATION} will be used for each frame.
-   *
-   * @param durations The custom durations for each keyframe.
-   */
+  /// Initializes the animation key frames by the specified durations.
+  ///
+  /// The amount of keyframes is defined by the available sprites of the assigned `Spritesheet`. For each sprite, a new keyframe will be
+  /// initialized.
+  ///
+  /// If no custom durations are specified, the [#DEFAULT_FRAME_DURATION] will be used for each frame.
+  ///
+  /// @param durations The custom durations for each keyframe.
   private void initKeyFrames(final int... durations) {
     if (this.getSpritesheet() == null) {
       return;
@@ -382,11 +329,9 @@ public class Animation implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Checks if the current keyframe is the last keyframe in the animation.
-   *
-   * @return True if the current keyframe is the last keyframe; otherwise false.
-   */
+  /// Checks if the current keyframe is the last keyframe in the animation.
+  ///
+  /// @return True if the current keyframe is the last keyframe; otherwise false.
   public boolean isLastKeyFrame() {
     return getKeyframes().indexOf(currentFrame) == getKeyframes().size() - 1;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/AnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/AnimationController.java
@@ -17,10 +17,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * The {@code AnimationController} class implements the {@code IAnimationController} interface. It manages animations and image effects, allowing for
- * the control and playback of animations.
- */
+/// The `AnimationController` class implements the `IAnimationController` interface. It manages animations and image effects, allowing for
+/// the control and playback of animations.
 public class AnimationController implements IAnimationController {
   private static final int MAX_IMAGE_EFFECTS = 20;
   private AffineTransform affineTransform;
@@ -32,9 +30,7 @@ public class AnimationController implements IAnimationController {
   private final List<ImageEffect> imageEffects;
   private final List<AnimationListener> listeners;
 
-  /**
-   * Initializes a new instance of the {@code AnimationController} class.
-   */
+  /// Initializes a new instance of the `AnimationController` class.
   public AnimationController() {
     this.animations = new ConcurrentHashMap<>();
     this.imageEffects = new CopyOnWriteArrayList<>();
@@ -42,25 +38,21 @@ public class AnimationController implements IAnimationController {
     this.enabled = true;
   }
 
-  /**
-   * Initializes a new instance of the {@code AnimationController} class with the specified default animation.
-   *
-   * @param defaultAnimation The default animation for this controller.
-   * @see #getDefault()
-   */
+  /// Initializes a new instance of the `AnimationController` class with the specified default animation.
+  ///
+  /// @param defaultAnimation The default animation for this controller.
+  /// @see #getDefault()
   public AnimationController(final Animation defaultAnimation) {
     this();
     this.setDefault(defaultAnimation);
   }
 
-  /**
-   * Initializes a new instance of the {@code AnimationController} class with the specified default animation.
-   *
-   * @param defaultAnimation The default animation for this controller.
-   * @param animations       Additional animations that are managed by this controller instance.
-   * @see #getDefault()
-   * @see #getAll()
-   */
+  /// Initializes a new instance of the `AnimationController` class with the specified default animation.
+  ///
+  /// @param defaultAnimation The default animation for this controller.
+  /// @param animations       Additional animations that are managed by this controller instance.
+  /// @see #getDefault()
+  /// @see #getAll()
   public AnimationController(final Animation defaultAnimation, final Animation... animations) {
     this(defaultAnimation);
 
@@ -73,33 +65,27 @@ public class AnimationController implements IAnimationController {
     }
   }
 
-  /**
-   * Initializes a new instance of the {@code AnimationController} class with the specified default animation.
-   *
-   * @param sprite The sprite sheet used by the default animation of this controller.
-   */
+  /// Initializes a new instance of the `AnimationController` class with the specified default animation.
+  ///
+  /// @param sprite The sprite sheet used by the default animation of this controller.
   public AnimationController(final Spritesheet sprite) {
     this(sprite, true);
   }
 
-  /**
-   * Initializes a new instance of the {@code AnimationController} class with the specified default animation.
-   *
-   * @param sprite The sprite sheet used by the default animation of this controller.
-   * @param loop   A flag indicating whether the default animation should be looped or only played once.
-   */
+  /// Initializes a new instance of the `AnimationController` class with the specified default animation.
+  ///
+  /// @param sprite The sprite sheet used by the default animation of this controller.
+  /// @param loop   A flag indicating whether the default animation should be looped or only played once.
   public AnimationController(final Spritesheet sprite, final boolean loop) {
     this(new Animation(sprite, loop, Resources.spritesheets().getCustomKeyFrameDurations(sprite)));
   }
 
-  /**
-   * Creates a new animation with the sprites flipped either vertically or horizontally.
-   *
-   * @param anim          The original animation to be flipped.
-   * @param newSpriteName The name for the new flipped spritesheet.
-   * @param vertical      A boolean flag indicating whether to flip the sprites vertically. If false, the sprites will be flipped horizontally.
-   * @return A new Animation object with the flipped sprites.
-   */
+  /// Creates a new animation with the sprites flipped either vertically or horizontally.
+  ///
+  /// @param anim          The original animation to be flipped.
+  /// @param newSpriteName The name for the new flipped spritesheet.
+  /// @param vertical      A boolean flag indicating whether to flip the sprites vertically. If false, the sprites will be flipped horizontally.
+  /// @return A new Animation object with the flipped sprites.
   public static Animation flippedAnimation(Animation anim, String newSpriteName, boolean vertical) {
     final BufferedImage flippedImage =
       vertical ? Imaging.flipSpritesVertically(anim.getSpritesheet()) : Imaging.flipSpritesHorizontally(anim.getSpritesheet());
@@ -134,11 +120,9 @@ public class AnimationController implements IAnimationController {
     this.listeners.add(listener);
   }
 
-  /**
-   * Attach the {@code AnimationController}, as well as all its {@code Animation}s to the Game loop.
-   *
-   * @see ILoop
-   */
+  /// Attach the `AnimationController`, as well as all its `Animation`s to the Game loop.
+  ///
+  /// @see ILoop
   public void attach() {
     Game.loop().attach(this);
   }
@@ -147,11 +131,9 @@ public class AnimationController implements IAnimationController {
     this.animations.clear();
   }
 
-  /**
-   * Detach the {@code AnimationController}, as well as all its {@code Animation}s from the Game loop.
-   *
-   * @see ILoop
-   */
+  /// Detach the `AnimationController`, as well as all its `Animation`s from the Game loop.
+  ///
+  /// @see ILoop
   public void detach() {
     Game.loop().detach(this);
   }
@@ -346,12 +328,10 @@ public class AnimationController implements IAnimationController {
     }
   }
 
-  /**
-   * Build a unique cache key for the current frame. The spritesheet's {@code hashCode}, the current keyframe's sprite index, as well as all applied
-   * {@code ImageEffect}s' names, are considered when determining the current cache key.
-   *
-   * @return the unique cache key for the current key frame
-   */
+  /// Build a unique cache key for the current frame. The spritesheet's `hashCode`, the current keyframe's sprite index, as well as all applied
+  /// `ImageEffect`s' names, are considered when determining the current cache key.
+  ///
+  /// @return the unique cache key for the current key frame
   protected String buildCurrentCacheKey() {
     if (this.getCurrent() == null || this.getCurrent().getCurrentKeyFrame() == null || this.getCurrent().getSpritesheet() == null) {
       return null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/AnimationListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/AnimationListener.java
@@ -2,23 +2,17 @@ package de.gurkenlabs.litiengine.graphics.animation;
 
 import java.util.EventListener;
 
-/**
- * This listener provides call-backs for when an {@code Animation} is played or the play back was finished.
- */
+/// This listener provides call-backs for when an `Animation` is played or the play back was finished.
 public interface AnimationListener extends EventListener {
-  /**
-   * Called when the specified animation has started playing.
-   *
-   * @param animation
-   *          The animation that is now played.
-   */
+  /// Called when the specified animation has started playing.
+  ///
+  /// @param animation
+  /// The animation that is now played.
   public default void played(Animation animation) {}
 
-  /**
-   * Called when the specified animation has finished playing.
-   *
-   * @param animation
-   *          The animation that has just finished playing.
-   */
+  /// Called when the specified animation has finished playing.
+  ///
+  /// @param animation
+  /// The animation that has just finished playing.
   public default void finished(Animation animation) {}
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/CreatureAnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/CreatureAnimationController.java
@@ -12,95 +12,80 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * This {@link AnimationController} implementation provides animation rules that use naming conventions to provide {@link Animation}s for
- * {@link Creature} implementations.
- *
- * <p>
- * The spritesheet images need to be named according to the following conventions in order to be automatically used by this controller:
- *
- * <ul>
- * <li>{@link #getSpritePrefix()}-idle-{DIRECTION}.{EXTENSION}
- * <li>{@link #getSpritePrefix()}-move-{DIRECTION}.{EXTENSION}
- * </ul>
- * <p>
- * Where {DIRECTION} refers to a value of the {@link Direction} enum and {@link #getSpritePrefix()} refers to the
- * current sprite prefix of the entity. {EXTENSION} refers to a value of the
- * {@link de.gurkenlabs.litiengine.resources.ImageFormat} enum.
- *
- * @param <T> The type of the creature for which animations are managed by this controller.
- * @see de.gurkenlabs.litiengine.entities.Creature
- * @see de.gurkenlabs.litiengine.Direction
- * @see de.gurkenlabs.litiengine.entities.IEntity#getName()
- */
+/// This [AnimationController] implementation provides animation rules that use naming conventions to provide [Animation]s for
+/// [Creature] implementations.
+///
+/// The spritesheet images need to be named according to the following conventions in order to be automatically used by this controller:
+///
+/// - [#getSpritePrefix()]-idle-{DIRECTION}.{EXTENSION}
+/// - [#getSpritePrefix()]-move-{DIRECTION}.{EXTENSION}
+///
+/// Where {DIRECTION} refers to a value of the [Direction] enum and [#getSpritePrefix()] refers to the
+/// current sprite prefix of the entity. {EXTENSION} refers to a value of the
+/// [de.gurkenlabs.litiengine.resources.ImageFormat] enum.
+///
+/// @param <T> The type of the creature for which animations are managed by this controller.
+/// @see de.gurkenlabs.litiengine.entities.Creature
+/// @see de.gurkenlabs.litiengine.Direction
+/// @see de.gurkenlabs.litiengine.entities.IEntity#getName()
 public class CreatureAnimationController<T extends Creature> extends EntityAnimationController<T> {
   private static final String WALK_STATE = "walk";
   private String[] customDeathAnimations;
   private String randomDeathSprite;
 
-  /**
-   * Initializes a new instance of the {@code CreatureAnimationController} class.
-   *
-   * @param creature                    The creature related to this controller.
-   * @param useFlippedSpritesAsFallback A flag indicating whether this controller should flip the provided spritesheet horizontally to provide a
-   *                                    fallback animation for left or right directions.
-   * @see #getEntity()
-   */
+  /// Initializes a new instance of the `CreatureAnimationController` class.
+  ///
+  /// @param creature                    The creature related to this controller.
+  /// @param useFlippedSpritesAsFallback A flag indicating whether this controller should flip the provided spritesheet horizontally to provide a
+  /// fallback animation for left or right directions.
+  /// @see #getEntity()
   public CreatureAnimationController(T creature, boolean useFlippedSpritesAsFallback) {
     super(creature);
     this.init(useFlippedSpritesAsFallback);
   }
 
-  /**
-   * Initializes a new instance of the {@code CreatureAnimationController} class.
-   *
-   * @param creature         The creature related to this controller.
-   * @param defaultAnimation The default animation for this controller.
-   * @see #getEntity()
-   * @see #getDefault()
-   */
+  /// Initializes a new instance of the `CreatureAnimationController` class.
+  ///
+  /// @param creature         The creature related to this controller.
+  /// @param defaultAnimation The default animation for this controller.
+  /// @see #getEntity()
+  /// @see #getDefault()
   public CreatureAnimationController(T creature, Animation defaultAnimation) {
     this(creature, true, defaultAnimation);
   }
 
-  /**
-   * Initializes a new instance of the {@code CreatureAnimationController} class.
-   *
-   * @param creature                    The creature related to this controller.
-   * @param useFlippedSpritesAsFallback A flag indicating whether this controller should flip the provided spritesheet horizontally to provide a
-   *                                    fallback animation for left or right directions.
-   * @param defaultAnimation            The default animation for this controller.
-   * @param animations                  Additional animations that are managed by this controller instance.
-   * @see #getEntity()
-   * @see #getDefault()
-   * @see #getAll()
-   */
+  /// Initializes a new instance of the `CreatureAnimationController` class.
+  ///
+  /// @param creature                    The creature related to this controller.
+  /// @param useFlippedSpritesAsFallback A flag indicating whether this controller should flip the provided spritesheet horizontally to provide a
+  /// fallback animation for left or right directions.
+  /// @param defaultAnimation            The default animation for this controller.
+  /// @param animations                  Additional animations that are managed by this controller instance.
+  /// @see #getEntity()
+  /// @see #getDefault()
+  /// @see #getAll()
   public CreatureAnimationController(T creature, boolean useFlippedSpritesAsFallback, Animation defaultAnimation, final Animation... animations) {
     super(creature, defaultAnimation, animations);
     this.init(useFlippedSpritesAsFallback);
   }
 
-  /**
-   * Gets the sprite name for the specified creature and animation state.
-   *
-   * @param creature The creature to retrieve the sprite name for.
-   * @param state    The current animation state.
-   * @return A string representing the sprite name for the specified creature in the defined animation state.
-   * @see Creature#getSpritesheetName()
-   */
+  /// Gets the sprite name for the specified creature and animation state.
+  ///
+  /// @param creature The creature to retrieve the sprite name for.
+  /// @param state    The current animation state.
+  /// @return A string representing the sprite name for the specified creature in the defined animation state.
+  /// @see Creature#getSpritesheetName()
   public static String getSpriteName(Creature creature, CreatureAnimationState state) {
     return creature.getSpritesheetName() + "-" + state.spriteString();
   }
 
-  /**
-   * Gets the sprite name for the specified creature, animation state.and direction.
-   *
-   * @param creature  The creature to retrieve the sprite name for.
-   * @param state     The current animation state.
-   * @param direction The direction in which the creature is facing.
-   * @return A string representing the sprite name for the specified creature, animation state and facing direction.
-   * @see Creature#getSpritesheetName()
-   */
+  /// Gets the sprite name for the specified creature, animation state.and direction.
+  ///
+  /// @param creature  The creature to retrieve the sprite name for.
+  /// @param state     The current animation state.
+  /// @param direction The direction in which the creature is facing.
+  /// @return A string representing the sprite name for the specified creature, animation state and facing direction.
+  /// @see Creature#getSpritesheetName()
   public static String getSpriteName(Creature creature, CreatureAnimationState state, Direction direction) {
     return getSpriteName(creature, state) + "-" + direction.name().toLowerCase(Locale.ROOT);
   }
@@ -113,12 +98,10 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
     return this.getEntity().getSpritesheetName();
   }
 
-  /**
-   * This method evaluates the current animation name that depends on certain properties of the {@link #getEntity()}. Overwriting this method allows
-   * to specify more sophisticated animations.
-   *
-   * @return The name of the current animation that should be played
-   */
+  /// This method evaluates the current animation name that depends on certain properties of the [#getEntity()]. Overwriting this method allows
+  /// to specify more sophisticated animations.
+  ///
+  /// @return The name of the current animation that should be played
   protected String getCurrentAnimationName() {
     Creature entity = getEntity();
     Direction direction = entity.getFacingDirection();
@@ -135,11 +118,9 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
     }
   }
 
-  /**
-   * Chooses a random death animation from the available custom death animations.
-   *
-   * @return The name of the chosen random death animation, or null if no custom death animations are available.
-   */
+  /// Chooses a random death animation from the available custom death animations.
+  ///
+  /// @return The name of the chosen random death animation, or null if no custom death animations are available.
   private String chooseRandomDeathAnimation() {
     if (customDeathAnimations.length == 0) {
       return null;
@@ -153,9 +134,7 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
     return randomDeathSprite;
   }
 
-  /**
-   * Initializes the available animations for the creature. This method sets up moving, idle, and dead animations for all directions.
-   */
+  /// Initializes the available animations for the creature. This method sets up moving, idle, and dead animations for all directions.
 
   private void initializeAvailableAnimations() {
     for (CreatureAnimationState state : CreatureAnimationState.values()) {
@@ -179,10 +158,8 @@ public class CreatureAnimationController<T extends Creature> extends EntityAnima
     }
   }
 
-  /**
-   * Initializes flipped animations for the creature. This method creates a map of animations for the left and right directions, and if an animation
-   * is missing for one direction, it uses the flipped version of the animation from the opposite direction.
-   */
+  /// Initializes flipped animations for the creature. This method creates a map of animations for the left and right directions, and if an animation
+  /// is missing for one direction, it uses the flipped version of the animation from the opposite direction.
   private void initializeFlippedAnimations() {
     Map<String, Optional<Animation>> animations = new HashMap<>();
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/EntityAnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/EntityAnimationController.java
@@ -18,12 +18,10 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
   private String spritePrefix;
   private boolean autoScaling;
 
-  /**
-   * Initializes a new instance of the {@code EntityAnimationController} class.
-   *
-   * @param entity The entity related to this animation controller.
-   * @see #getEntity()
-   */
+  /// Initializes a new instance of the `EntityAnimationController` class.
+  ///
+  /// @param entity The entity related to this animation controller.
+  /// @see #getEntity()
   public EntityAnimationController(final T entity) {
     super();
     this.entity = entity;
@@ -33,16 +31,14 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
     }
   }
 
-  /**
-   * Initializes a new instance of the {@code EntityAnimationController} class.
-   *
-   * @param entity           The entity related to this animation controller.
-   * @param defaultAnimation The default animation for this controller.
-   * @param animations       Additional animations that are managed by this controller instance.
-   * @see #getEntity()
-   * @see #getDefault()
-   * @see #getAll()
-   */
+  /// Initializes a new instance of the `EntityAnimationController` class.
+  ///
+  /// @param entity           The entity related to this animation controller.
+  /// @param defaultAnimation The default animation for this controller.
+  /// @param animations       Additional animations that are managed by this controller instance.
+  /// @see #getEntity()
+  /// @see #getDefault()
+  /// @see #getAll()
   public EntityAnimationController(
     final T entity, final Animation defaultAnimation, final Animation... animations) {
     super(defaultAnimation, animations);
@@ -51,23 +47,19 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
     this.spritePrefix = Game.random().choose(getDefaultSpritePrefixes(entity.getClass()));
   }
 
-  /**
-   * Initializes a new instance of the {@code EntityAnimationController} class.
-   *
-   * @param entity The entity related to this animation controller.
-   * @param sprite The sprite sheet used by the default animation of this controller.
-   */
+  /// Initializes a new instance of the `EntityAnimationController` class.
+  ///
+  /// @param entity The entity related to this animation controller.
+  /// @param sprite The sprite sheet used by the default animation of this controller.
   public EntityAnimationController(final T entity, final Spritesheet sprite) {
     this(entity, sprite, true);
   }
 
-  /**
-   * Initializes a new instance of the {@code EntityAnimationController} class.
-   *
-   * @param entity The entity related to this animation controller.
-   * @param sprite The sprite sheet used by the default animation of this controller.
-   * @param loop   A flag indicating whether the default animation should be looped or only played once.
-   */
+  /// Initializes a new instance of the `EntityAnimationController` class.
+  ///
+  /// @param entity The entity related to this animation controller.
+  /// @param sprite The sprite sheet used by the default animation of this controller.
+  /// @param loop   A flag indicating whether the default animation should be looped or only played once.
   public EntityAnimationController(final T entity, final Spritesheet sprite, boolean loop) {
     this(
       entity,
@@ -144,26 +136,22 @@ public class EntityAnimationController<T extends IEntity> extends AnimationContr
     }
   }
 
-  /**
-   * Retrieves the sprite prefix associated with this animation controller.
-   *
-   * <p>The sprite prefix is used to determine the default sprite for the entity
-   * managed by this animation controller.
-   *
-   * @return the sprite prefix as a {@code String}
-   */
+  /// Retrieves the sprite prefix associated with this animation controller.
+  ///
+  /// The sprite prefix is used to determine the default sprite for the entity
+  /// managed by this animation controller.
+  ///
+  /// @return the sprite prefix as a `String`
   protected String getSpritePrefix() {
     return this.spritePrefix;
   }
 
-  /**
-   * Sets the sprite prefix for this animation controller.
-   *
-   * <p>The sprite prefix is used to determine the default sprite for the entity
-   * managed by this animation controller.
-   *
-   * @param prefix the new sprite prefix to set
-   */
+  /// Sets the sprite prefix for this animation controller.
+  ///
+  /// The sprite prefix is used to determine the default sprite for the entity
+  /// managed by this animation controller.
+  ///
+  /// @param prefix the new sprite prefix to set
   protected void setSpritePrefix(String prefix) {
     this.spritePrefix = prefix;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/IAnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/IAnimationController.java
@@ -11,245 +11,193 @@ import java.util.List;
 
 public interface IAnimationController extends IUpdateable {
 
-  /**
-   * Adds the specified animation listener to receive events and callbacks when animation playbacks are started and
-   * finished.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified animation listener to receive events and callbacks when animation playbacks are started and
+  /// finished.
+  ///
+  /// @param listener
+  /// The listener to add.
   public void addListener(AnimationListener listener);
 
-  /**
-   * Removes the specified animation listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Removes the specified animation listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   public void removeListener(AnimationListener listener);
 
-  /**
-   * Add the specified {@code Animation} to this controller instance.
-   *
-   * <p>
-   * Animations with the same name will be replaced by this method.
-   *
-   * @param animation
-   *          The animation to add.
-   * @see #remove(Animation)
-   * @see #hasAnimation(String)
-   * @see #clear()
-   */
+  /// Add the specified `Animation` to this controller instance.
+  ///
+  /// Animations with the same name will be replaced by this method.
+  ///
+  /// @param animation
+  /// The animation to add.
+  /// @see #remove(Animation)
+  /// @see #hasAnimation(String)
+  /// @see #clear()
   public void add(Animation animation);
 
-  /**
-   * Removes the specified {@code Animation} from this controller instance.
-   *
-   * @param animation
-   *          The animation to remove.
-   * @see #add(Animation)
-   * @see #hasAnimation(String)
-   * @see #clear()
-   */
+  /// Removes the specified `Animation` from this controller instance.
+  ///
+  /// @param animation
+  /// The animation to remove.
+  /// @see #add(Animation)
+  /// @see #hasAnimation(String)
+  /// @see #clear()
   public void remove(Animation animation);
 
-  /** Remove all {@code Animation}s from the {@code AnimationController}. */
+  /// Remove all `Animation`s from the `AnimationController`.
   public void clear();
 
-  /**
-   * Gets all {@code Animation} instances managed by this controller.
-   *
-   * @return All {@code Animation} instances.
-   */
+  /// Gets all `Animation` instances managed by this controller.
+  ///
+  /// @return All `Animation` instances.
   public Collection<Animation> getAll();
 
-  /**
-   * Gets the {@code Animation} instance with the specified name from this controller.
-   *
-   * <p>
-   * The name of an {@code Animation} is case sensitive.
-   *
-   * @param animationName
-   *          The name of the animation.
-   * @return The animation with the specified name or null if no such animation is managed by this controller.
-   * @see #getCurrent()
-   * @see #getDefault()
-   * @see #hasAnimation(String)
-   */
+  /// Gets the `Animation` instance with the specified name from this controller.
+  ///
+  /// The name of an `Animation` is case sensitive.
+  ///
+  /// @param animationName
+  /// The name of the animation.
+  /// @return The animation with the specified name or null if no such animation is managed by this controller.
+  /// @see #getCurrent()
+  /// @see #getDefault()
+  /// @see #hasAnimation(String)
   public Animation get(String animationName);
 
-  /**
-   * Gets the currently active {@code Animation} of this controller.
-   *
-   * <p>
-   * The current active animation provides the current image that is being rendered by consumers of this controller (e.g.
-   * the render engine or any explicit, custom render mechanism).
-   *
-   * @return The currently active animation.
-   * @see #getDefault()
-   * @see #get(String)
-   * @see RenderEngine#renderEntity(java.awt.Graphics2D, de.gurkenlabs.litiengine.entities.IEntity)
-   */
+  /// Gets the currently active `Animation` of this controller.
+  ///
+  /// The current active animation provides the current image that is being rendered by consumers of this controller (e.g.
+  /// the render engine or any explicit, custom render mechanism).
+  ///
+  /// @return The currently active animation.
+  /// @see #getDefault()
+  /// @see #get(String)
+  /// @see RenderEngine#renderEntity(java.awt.Graphics2D, de.gurkenlabs.litiengine.entities.IEntity)
   public Animation getCurrent();
 
-  /**
-   * Gets the default {@code Animation} of this controller.
-   *
-   * <p>
-   * This animation is played when no other animation is currently active.
-   *
-   * @return The default animation of this controller.
-   * @see #getCurrent()
-   * @see #get(String)
-   * @see #setDefault(Animation)
-   */
+  /// Gets the default `Animation` of this controller.
+  ///
+  /// This animation is played when no other animation is currently active.
+  ///
+  /// @return The default animation of this controller.
+  /// @see #getCurrent()
+  /// @see #get(String)
+  /// @see #setDefault(Animation)
   public Animation getDefault();
 
-  /**
-   * Determines whether this controller has an {@code Animation} with the specified name.
-   *
-   * <p>
-   * The name of an {@code Animation} is case sensitive.
-   *
-   * @param animationName
-   *          The name of the animation.
-   * @return True if this controller contains an {@code Animation} with the specified name; otherwise false.
-   * @see #add(Animation)
-   * @see #remove(Animation)
-   */
+  /// Determines whether this controller has an `Animation` with the specified name.
+  ///
+  /// The name of an `Animation` is case sensitive.
+  ///
+  /// @param animationName
+  /// The name of the animation.
+  /// @return True if this controller contains an `Animation` with the specified name; otherwise false.
+  /// @see #add(Animation)
+  /// @see #remove(Animation)
   public boolean hasAnimation(String animationName);
 
-  /**
-   * Determines whether this controller is currently playing an {@code Animation} with the specified name.
-   *
-   * <p>
-   * The name of an {@code Animation} is case sensitive.
-   *
-   * @param animationName
-   *          The name of the animation.
-   * @return True if this controller is currently playing the {@code Animation} with the specified name.
-   * @see #getCurrent()
-   */
+  /// Determines whether this controller is currently playing an `Animation` with the specified name.
+  ///
+  /// The name of an `Animation` is case sensitive.
+  ///
+  /// @param animationName
+  /// The name of the animation.
+  /// @return True if this controller is currently playing the `Animation` with the specified name.
+  /// @see #getCurrent()
   public boolean isPlaying(String animationName);
 
-  /**
-   * Plays the {@code Animation} with the specified name.
-   *
-   * <p>
-   * Does nothing if this controller doesn't contain an {@code Animation} with the specified name.
-   *
-   * <p>
-   * This method also publishes the "played" event to all subscribed {@code AnimationListener} instances.
-   *
-   * @param animationName
-   *          The name of the {@code Animation} to be played.
-   * @see AnimationListener#played(Animation)
-   * @see #getCurrent()
-   */
+  /// Plays the `Animation` with the specified name.
+  ///
+  /// Does nothing if this controller doesn't contain an `Animation` with the specified name.
+  ///
+  /// This method also publishes the "played" event to all subscribed `AnimationListener` instances.
+  ///
+  /// @param animationName
+  /// The name of the `Animation` to be played.
+  /// @see AnimationListener#played(Animation)
+  /// @see #getCurrent()
   public void play(final String animationName);
 
-  /**
-   * Sets the specified {@code Animation} as default for this controller.
-   *
-   * @param animation
-   *          The animation to be set as default.
-   * @see #getDefault()
-   */
+  /// Sets the specified `Animation` as default for this controller.
+  ///
+  /// @param animation
+  /// The animation to be set as default.
+  /// @see #getDefault()
   public void setDefault(Animation animation);
 
-  /**
-   * Gets the current sprite (keyframe) of the currently active animation of this controller.
-   *
-   * <p>
-   * The implementation of this method applies all registered {@code ImageEffects}.
-   *
-   * @return The current sprite of the current animation with applied effects; or null, if this controller is currently
-   *         disabled.
-   * @see #getCurrent()
-   * @see Animation#getCurrentKeyFrame()
-   * @see #isEnabled()
-   */
+  /// Gets the current sprite (keyframe) of the currently active animation of this controller.
+  ///
+  /// The implementation of this method applies all registered `ImageEffects`.
+  ///
+  /// @return The current sprite of the current animation with applied effects; or null, if this controller is currently
+  /// disabled.
+  /// @see #getCurrent()
+  /// @see Animation#getCurrentKeyFrame()
+  /// @see #isEnabled()
   public BufferedImage getCurrentImage();
 
-  /**
-   * Gets the current sprite scaled by the specified dimensions of the currently active animation of this controller.
-   *
-   * <p>
-   * The implementation of this method applies all registered {@code ImageEffects}.
-   *
-   * @param width
-   *          The width of the image.
-   * @param height
-   *          The height of the image.
-   * @return The current sprite of the current animation scaled by the defined dimensions with applied effects; or null,
-   *         if this controller is currently disabled.
-   * @see #getCurrent()
-   * @see #getCurrentImage()
-   * @see Animation#getCurrentKeyFrame()
-   * @see #isEnabled()
-   */
+  /// Gets the current sprite scaled by the specified dimensions of the currently active animation of this controller.
+  ///
+  /// The implementation of this method applies all registered `ImageEffects`.
+  ///
+  /// @param width
+  /// The width of the image.
+  /// @param height
+  /// The height of the image.
+  /// @return The current sprite of the current animation scaled by the defined dimensions with applied effects; or null,
+  /// if this controller is currently disabled.
+  /// @see #getCurrent()
+  /// @see #getCurrentImage()
+  /// @see Animation#getCurrentKeyFrame()
+  /// @see #isEnabled()
   public BufferedImage getCurrentImage(int width, int height);
 
-  /**
-   * Gets the {@code AffineTransform} instance assigned to this controller that can be used to externally transform the
-   * current image when rendering it with the {@code ImageRenderer}.
-   *
-   * @return The {@code AffineTransform} instance assigned to this controller or null.
-   * @see AffineTransform
-   * @see ImageRenderer#renderTransformed(java.awt.Graphics2D, java.awt.Image, AffineTransform)
-   * @see #setAffineTransform(AffineTransform)
-   * @see #getCurrentImage()
-   */
+  /// Gets the `AffineTransform` instance assigned to this controller that can be used to externally transform the
+  /// current image when rendering it with the `ImageRenderer`.
+  ///
+  /// @return The `AffineTransform` instance assigned to this controller or null.
+  /// @see AffineTransform
+  /// @see ImageRenderer#renderTransformed(java.awt.Graphics2D, java.awt.Image, AffineTransform)
+  /// @see #setAffineTransform(AffineTransform)
+  /// @see #getCurrentImage()
   public AffineTransform getAffineTransform();
 
-  /**
-   * Sets the {@code AffineTransform} instance for this controller that can be used to externally transform the current
-   * image when rendering it with the {@code ImageRenderer}.
-   *
-   * @param affineTransform
-   *          The {@code AffineTransform} instance for this controller.
-   * @see AffineTransform
-   * @see #getAffineTransform()
-   */
+  /// Sets the `AffineTransform` instance for this controller that can be used to externally transform the current
+  /// image when rendering it with the `ImageRenderer`.
+  ///
+  /// @param affineTransform
+  /// The `AffineTransform` instance for this controller.
+  /// @see AffineTransform
+  /// @see #getAffineTransform()
   public void setAffineTransform(AffineTransform affineTransform);
 
-  /**
-   * Adds the specified {@code ImageEffect} to be applied when the current image is retrieved from this controller.
-   *
-   * @param effect
-   *          The image effect to be added.
-   */
+  /// Adds the specified `ImageEffect` to be applied when the current image is retrieved from this controller.
+  ///
+  /// @param effect
+  /// The image effect to be added.
   public void add(ImageEffect effect);
 
-  /**
-   * Removes the specified {@code ImageEffect} from this controller.
-   *
-   * @param effect
-   *          The image effect to be removed.
-   */
+  /// Removes the specified `ImageEffect` from this controller.
+  ///
+  /// @param effect
+  /// The image effect to be removed.
   public void remove(ImageEffect effect);
 
-  /**
-   * Gets all image effects assigned to this controller.
-   *
-   * @return All image effects of this controller.
-   * @see #add(ImageEffect)
-   * @see #remove(ImageEffect)
-   */
+  /// Gets all image effects assigned to this controller.
+  ///
+  /// @return All image effects of this controller.
+  /// @see #add(ImageEffect)
+  /// @see #remove(ImageEffect)
   public List<ImageEffect> getImageEffects();
 
-  /**
-   * Determines whether this controller is currently enabled.
-   *
-   * @return True if this controller is enabled; otherwise false.
-   */
+  /// Determines whether this controller is currently enabled.
+  ///
+  /// @return True if this controller is enabled; otherwise false.
   public boolean isEnabled();
 
-  /**
-   * Sets a flag that defines whether this controller is enabled or not.
-   *
-   * @param enabled
-   *          True if the controller should be enabled; otherwise false.
-   */
+  /// Sets a flag that defines whether this controller is enabled or not.
+  ///
+  /// @param enabled
+  /// True if the controller should be enabled; otherwise false.
   public void setEnabled(boolean enabled);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/IEntityAnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/IEntityAnimationController.java
@@ -7,64 +7,52 @@ import java.util.function.Predicate;
 
 public interface IEntityAnimationController<T extends IEntity>
     extends IAnimationController, IEntityController {
-  /**
-   * Registers an animation rule that will be evaluated if there is currently no animation playing that is defined to
-   * loop. This allows to specify animations that should be applied under certain conditions.
-   *
-   * @param rule
-   *          The rule that must be fulfilled for the animation to be applied
-   * @param animationName
-   *          The callback that evaluates the actual animation name that will be applied
-   */
+  /// Registers an animation rule that will be evaluated if there is currently no animation playing that is defined to
+  /// loop. This allows to specify animations that should be applied under certain conditions.
+  ///
+  /// @param rule
+  /// The rule that must be fulfilled for the animation to be applied
+  /// @param animationName
+  /// The callback that evaluates the actual animation name that will be applied
   public void addRule(Predicate<? super T> rule, Function<? super T, String> animationName);
 
-  /**
-   * Registers an animation rule that will be evaluated if there is currently no animation playing that is defined to
-   * loop. This allows to specify animations that should be applied under certain conditions.
-   *
-   * @param rule
-   *          The rule that must be fulfilled for the animation to be applied
-   * @param animationName
-   *          The callback that evaluates the actual animation name that will be applied
-   * @param priority
-   *          The priority that defines the order in which the rule will be processed. Rules with higher priorities will
-   *          be processed first.
-   */
+  /// Registers an animation rule that will be evaluated if there is currently no animation playing that is defined to
+  /// loop. This allows to specify animations that should be applied under certain conditions.
+  ///
+  /// @param rule
+  /// The rule that must be fulfilled for the animation to be applied
+  /// @param animationName
+  /// The callback that evaluates the actual animation name that will be applied
+  /// @param priority
+  /// The priority that defines the order in which the rule will be processed. Rules with higher priorities will
+  /// be processed first.
   public void addRule(
       Predicate<? super T> rule, Function<? super T, String> animationName, int priority);
 
-  /**
-   * Gets a flag indicating whether this controller instance is auto scaling its animations by the dimensions of the
-   * entity.
-   *
-   * @return True if this instance is automatically scaling to the dimensions of the entity; otherwise false.
-   */
+  /// Gets a flag indicating whether this controller instance is auto scaling its animations by the dimensions of the
+  /// entity.
+  ///
+  /// @return True if this instance is automatically scaling to the dimensions of the entity; otherwise false.
   public boolean isAutoScaling();
 
-  /**
-   * Sets a value indicating whether this controller instance is auto scaling its animations by the dimensions of the
-   * entity
-   *
-   * @param scaling
-   *          True if this instance is automatically scaling to the dimensions of the entity; otherwise false.
-   */
+  /// Sets a value indicating whether this controller instance is auto scaling its animations by the dimensions of the
+  /// entity
+  ///
+  /// @param scaling
+  /// True if this instance is automatically scaling to the dimensions of the entity; otherwise false.
   public void setAutoScaling(boolean scaling);
 
-  /**
-   * Sets the dimensions used to scale the animations of this controller instance.
-   *
-   * @param ratioX
-   *          The x-ratio to scale the animation with.
-   * @param ratioY
-   *          The y-ratio to scale the animation with.
-   */
+  /// Sets the dimensions used to scale the animations of this controller instance.
+  ///
+  /// @param ratioX
+  /// The x-ratio to scale the animation with.
+  /// @param ratioY
+  /// The y-ratio to scale the animation with.
   public void scaleSprite(float ratioX, float ratioY);
 
-  /**
-   * Sets the ratio used to scale the animations of this controller instance.
-   *
-   * @param ratio
-   *          The ratio to scale the animation with.
-   */
+  /// Sets the ratio used to scale the animations of this controller instance.
+  ///
+  /// @param ratio
+  /// The ratio to scale the animation with.
   public void scaleSprite(float ratio);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/KeyFrame.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/KeyFrame.java
@@ -1,8 +1,6 @@
 package de.gurkenlabs.litiengine.graphics.animation;
 
-/**
- * The {@code Keyframe} class defines the relation between a particular sprite index and its animation duration.
- */
+/// The `Keyframe` class defines the relation between a particular sprite index and its animation duration.
 public class KeyFrame {
   private int duration;
   private int sprite;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/PropAnimationController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/animation/PropAnimationController.java
@@ -12,12 +12,10 @@ import java.util.Optional;
 public class PropAnimationController<T extends Prop> extends EntityAnimationController<T> {
   public static final String PROP_IDENTIFIER = "prop-";
 
-  /**
-   * Initializes a new instance of the {@code PropAnimationController} class.
-   *
-   * @param prop
-   *          The prop related to this controller.
-   */
+  /// Initializes a new instance of the `PropAnimationController` class.
+  ///
+  /// @param prop
+  /// The prop related to this controller.
   public PropAnimationController(final T prop) {
     super(prop);
 
@@ -26,34 +24,30 @@ public class PropAnimationController<T extends Prop> extends EntityAnimationCont
     this.add(createAnimation(this.getEntity(), PropState.DESTROYED));
   }
 
-  /**
-   * Gets the sprite name for the specified prop and state.
-   *
-   * @param prop
-   *          The prop to retrieve the sprite name for.
-   * @param appendState
-   *          A flag indicating whether the state should be appended to the name.
-   * @return A string representing the sprite name for the specified prop in its state.
-   * @see Prop#getSpritesheetName()
-   * @see Prop#getState()
-   */
+  /// Gets the sprite name for the specified prop and state.
+  ///
+  /// @param prop
+  /// The prop to retrieve the sprite name for.
+  /// @param appendState
+  /// A flag indicating whether the state should be appended to the name.
+  /// @return A string representing the sprite name for the specified prop in its state.
+  /// @see Prop#getSpritesheetName()
+  /// @see Prop#getState()
   public static String getSpriteName(final Prop prop, boolean appendState) {
     return getSpriteName(prop, prop.getState(), appendState);
   }
 
-  /**
-   * Gets the sprite name for the specified prop and state.
-   *
-   * @param prop
-   *          The prop to retrieve the sprite name for.
-   * @param state
-   *          The state of the prop.
-   * @param appendState
-   *          A flag indicating whether the state should be appended to the name.
-   * @return A string representing the sprite name for the specified prop in its state.
-   * @see Prop#getSpritesheetName()
-   * @see Prop#getState()
-   */
+  /// Gets the sprite name for the specified prop and state.
+  ///
+  /// @param prop
+  /// The prop to retrieve the sprite name for.
+  /// @param state
+  /// The state of the prop.
+  /// @param appendState
+  /// A flag indicating whether the state should be appended to the name.
+  /// @return A string representing the sprite name for the specified prop in its state.
+  /// @see Prop#getSpritesheetName()
+  /// @see Prop#getState()
   public static String getSpriteName(final Prop prop, PropState state, boolean appendState) {
     StringBuilder sb = new StringBuilder(PROP_IDENTIFIER);
     sb.append(prop.getSpritesheetName());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/Emitter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/Emitter.java
@@ -33,13 +33,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * Represents an emitter that provides particle effects in the game.
- *
- * <p>The {@code Emitter} class extends {@link Entity} and implements the
- * {@link IUpdateable}, {@link ITimeToLive}, and {@link IRenderable} interfaces. It manages the lifecycle, rendering, and behavior of particles,
- * allowing for dynamic visual effects.
- */
+/// Represents an emitter that provides particle effects in the game.
+///
+/// The `Emitter` class extends [Entity] and implements the
+/// [IUpdateable], [ITimeToLive], and [IRenderable] interfaces. It manages the lifecycle, rendering, and behavior of particles,
+/// allowing for dynamic visual effects.
 @CollisionInfo(collision = false) @EmitterInfo @TmxType(MapObjectType.EMITTER) public class Emitter extends Entity
   implements IUpdateable, ITimeToLive, IRenderable {
 
@@ -56,13 +54,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
   private long lastSpawn;
   private Point2D origin;
 
-  /**
-   * Constructs a new {@code Emitter} instance.
-   *
-   * <p>Initializes the emitter with default settings, including particle collections,
-   * renderable mappings, and emitter data. If the {@link EmitterInfo} annotation is present on the class, its values are used to configure the
-   * emitter's properties.
-   */
+  /// Constructs a new `Emitter` instance.
+  ///
+  /// Initializes the emitter with default settings, including particle collections,
+  /// renderable mappings, and emitter data. If the [EmitterInfo] annotation is present on the class, its values are used to configure the
+  /// emitter's properties.
   public Emitter() {
     this.finishedListeners = ConcurrentHashMap.newKeySet();
     this.particles = new CopyOnWriteArrayList<>();
@@ -95,108 +91,92 @@ import java.util.concurrent.CopyOnWriteArrayList;
     }
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified emitter data.
-   *
-   * <p>Initializes the emitter using the provided {@link EmitterAttributes}, which
-   * contains configuration details such as particle type, spawn rate, and emitter duration.
-   *
-   * @param emitterData the data used to configure this emitter
-   */
+  /// Constructs a new `Emitter` instance with the specified emitter data.
+  ///
+  /// Initializes the emitter using the provided [EmitterAttributes], which
+  /// contains configuration details such as particle type, spawn rate, and emitter duration.
+  ///
+  /// @param emitterData the data used to configure this emitter
   public Emitter(EmitterAttributes emitterData) {
     this();
     setEmitterData(emitterData);
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified origin and emitter data.
-   *
-   * <p>Initializes the emitter at the given origin point and configures it using the provided
-   * {@link EmitterAttributes}, which contains details such as particle type, spawn rate, and emitter duration.
-   *
-   * @param origin      the origin point where the emitter is located
-   * @param emitterData the data used to configure this emitter
-   */
+  /// Constructs a new `Emitter` instance with the specified origin and emitter data.
+  ///
+  /// Initializes the emitter at the given origin point and configures it using the provided
+  /// [EmitterAttributes], which contains details such as particle type, spawn rate, and emitter duration.
+  ///
+  /// @param origin      the origin point where the emitter is located
+  /// @param emitterData the data used to configure this emitter
   public Emitter(final Point2D origin, EmitterAttributes emitterData) {
     this(origin);
     setEmitterData(emitterData);
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified coordinates and emitter data.
-   *
-   * <p>Initializes the emitter at the given x and y coordinates and configures it using the provided
-   * {@link EmitterAttributes}, which contains details such as particle type, spawn rate, and emitter duration.
-   *
-   * @param x           the x-coordinate of the emitter's origin
-   * @param y           the y-coordinate of the emitter's origin
-   * @param emitterData the data used to configure this emitter
-   */
+  /// Constructs a new `Emitter` instance with the specified coordinates and emitter data.
+  ///
+  /// Initializes the emitter at the given x and y coordinates and configures it using the provided
+  /// [EmitterAttributes], which contains details such as particle type, spawn rate, and emitter duration.
+  ///
+  /// @param x           the x-coordinate of the emitter's origin
+  /// @param y           the y-coordinate of the emitter's origin
+  /// @param emitterData the data used to configure this emitter
   public Emitter(final double x, final double y, EmitterAttributes emitterData) {
     this(x, y);
     setEmitterData(emitterData);
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified coordinates and emitter XML configuration.
-   *
-   * <p>Initializes the emitter at the given x and y coordinates and configures it using the provided
-   * XML file, which contains emitter settings such as particle type, spawn rate, and emitter duration.
-   *
-   * @param x          the x-coordinate of the emitter's origin
-   * @param y          the y-coordinate of the emitter's origin
-   * @param emitterXml the path to the XML file used to configure this emitter
-   */
+  /// Constructs a new `Emitter` instance with the specified coordinates and emitter XML configuration.
+  ///
+  /// Initializes the emitter at the given x and y coordinates and configures it using the provided
+  /// XML file, which contains emitter settings such as particle type, spawn rate, and emitter duration.
+  ///
+  /// @param x          the x-coordinate of the emitter's origin
+  /// @param y          the y-coordinate of the emitter's origin
+  /// @param emitterXml the path to the XML file used to configure this emitter
   public Emitter(final double x, final double y, final String emitterXml) {
     this(x, y);
     setEmitterData(emitterXml);
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified origin and emitter XML configuration.
-   *
-   * <p>Initializes the emitter at the given origin point and configures it using the provided
-   * XML file, which contains emitter settings such as particle type, spawn rate, and emitter duration.
-   *
-   * @param origin     the origin point where the emitter is located
-   * @param emitterXml the path to the XML file used to configure this emitter
-   */
+  /// Constructs a new `Emitter` instance with the specified origin and emitter XML configuration.
+  ///
+  /// Initializes the emitter at the given origin point and configures it using the provided
+  /// XML file, which contains emitter settings such as particle type, spawn rate, and emitter duration.
+  ///
+  /// @param origin     the origin point where the emitter is located
+  /// @param emitterXml the path to the XML file used to configure this emitter
   public Emitter(final Point2D origin, final String emitterXml) {
     this(origin);
     setEmitterData(emitterXml);
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified origin coordinates.
-   *
-   * <p>Initializes the emitter at the given x and y coordinates, represented as a {@link Point2D.Double}.
-   *
-   * @param originX the x-coordinate of the emitter's origin
-   * @param originY the y-coordinate of the emitter's origin
-   */
+  /// Constructs a new `Emitter` instance with the specified origin coordinates.
+  ///
+  /// Initializes the emitter at the given x and y coordinates, represented as a [Point2D.Double].
+  ///
+  /// @param originX the x-coordinate of the emitter's origin
+  /// @param originY the y-coordinate of the emitter's origin
   public Emitter(final double originX, final double originY) {
     this(new Point2D.Double(originX, originY));
   }
 
-  /**
-   * Constructs a new {@code Emitter} instance with the specified origin.
-   *
-   * <p>Initializes the emitter at the given origin point, setting its location
-   * and preparing it for further configuration or activation.
-   *
-   * @param origin the origin point where the emitter is located
-   */
+  /// Constructs a new `Emitter` instance with the specified origin.
+  ///
+  /// Initializes the emitter at the given origin point, setting its location
+  /// and preparing it for further configuration or activation.
+  ///
+  /// @param origin the origin point where the emitter is located
   public Emitter(final Point2D origin) {
     this();
     this.setLocation(origin);
   }
 
-  /**
-   * Activates the emitter.
-   *
-   * <p>Marks the emitter as activated, sets the activation tick to the current game time,
-   * and attaches the emitter to the game loop for updates. If the emitter is already activated, this method does nothing.
-   */
+  /// Activates the emitter.
+  ///
+  /// Marks the emitter as activated, sets the activation tick to the current game time,
+  /// and attaches the emitter to the game loop for updates. If the emitter is already activated, this method does nothing.
   public void activate() {
     if (this.activated) {
       return;
@@ -207,14 +187,12 @@ import java.util.concurrent.CopyOnWriteArrayList;
     Game.loop().attach(this);
   }
 
-  /**
-   * Adds a particle to this emitter's list of particles.
-   *
-   * <p>If the emitter is stopped, this method does nothing. Otherwise, the specified particle
-   * is added to the internal particle collection for rendering and updates.
-   *
-   * @param particle the particle to be added to the emitter
-   */
+  /// Adds a particle to this emitter's list of particles.
+  ///
+  /// If the emitter is stopped, this method does nothing. Otherwise, the specified particle
+  /// is added to the internal particle collection for rendering and updates.
+  ///
+  /// @param particle the particle to be added to the emitter
   public void addParticle(final Particle particle) {
     if (this.isStopped()) {
       return;
@@ -222,13 +200,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
     this.particles.add(particle);
   }
 
-  /**
-   * Deactivates the emitter.
-   *
-   * <p>This method stops the emitter's activity and resets its state. It clears all particles,
-   * resets the alive time, activation tick, and last spawn time, and detaches the emitter from the game loop. If the emitter is not currently
-   * activated, this method does nothing.
-   */
+  /// Deactivates the emitter.
+  ///
+  /// This method stops the emitter's activity and resets its state. It clears all particles,
+  /// resets the alive time, activation tick, and last spawn time, and detaches the emitter from the game loop. If the emitter is not currently
+  /// activated, this method does nothing.
   public void deactivate() {
     if (!this.activated) {
       return;
@@ -242,12 +218,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
     Game.loop().detach(this);
   }
 
-  /**
-   * Deletes this emitter from the game world.
-   *
-   * <p>Deactivates the emitter, clears its particles, and removes it from the current environment
-   * if one exists. This method ensures that the emitter is no longer active or present in the game.
-   */
+  /// Deletes this emitter from the game world.
+  ///
+  /// Deactivates the emitter, clears its particles, and removes it from the current environment
+  /// if one exists. This method ensures that the emitter is no longer active or present in the game.
   public void delete() {
     this.deactivate();
     if (Game.world().environment() != null) {
@@ -256,39 +230,33 @@ import java.util.concurrent.CopyOnWriteArrayList;
   }
 
 
-  /**
-   * Retrieves the total alive time of the emitter.
-   *
-   * <p>This method returns the amount of time, in milliseconds, that the emitter
-   * has been active since its activation.
-   *
-   * @return the alive time of the emitter in milliseconds
-   */
+  /// Retrieves the total alive time of the emitter.
+  ///
+  /// This method returns the amount of time, in milliseconds, that the emitter
+  /// has been active since its activation.
+  ///
+  /// @return the alive time of the emitter in milliseconds
   @Override
   public long getAliveTime() {
     return this.aliveTime;
   }
 
-  /**
-   * Retrieves the emitter data associated with this emitter.
-   *
-   * <p>The emitter data contains configuration details such as particle type,
-   * spawn rate, and other properties that define the emitter's behavior.
-   *
-   * @return the {@link EmitterAttributes} object for this emitter
-   */
+  /// Retrieves the emitter data associated with this emitter.
+  ///
+  /// The emitter data contains configuration details such as particle type,
+  /// spawn rate, and other properties that define the emitter's behavior.
+  ///
+  /// @return the [EmitterAttributes] object for this emitter
   public EmitterAttributes data() {
     return this.emitterData;
   }
 
-  /**
-   * Retrieves the origin point of the emitter.
-   *
-   * <p>If the origin has not been calculated yet, this method updates the origin
-   * based on the emitter's current position and alignment settings.
-   *
-   * @return the origin point of the emitter as a {@link Point2D} object
-   */
+  /// Retrieves the origin point of the emitter.
+  ///
+  /// If the origin has not been calculated yet, this method updates the origin
+  /// based on the emitter's current position and alignment settings.
+  ///
+  /// @return the origin point of the emitter as a [Point2D] object
   public Point2D getOrigin() {
     if (this.origin == null) {
       this.updateOrigin();
@@ -296,12 +264,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
     return this.origin;
   }
 
-  /**
-   * Updates the origin point of the emitter.
-   *
-   * <p>This method recalculates the origin based on the emitter's current position,
-   * width, height, and alignment settings defined in the emitter data.
-   */
+  /// Updates the origin point of the emitter.
+  ///
+  /// This method recalculates the origin based on the emitter's current position,
+  /// width, height, and alignment settings defined in the emitter data.
   protected void updateOrigin() {
     this.origin = new Point2D.Double(
       getX() + data().getOriginAlign().getValue(getWidth()),
@@ -309,15 +275,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
     );
   }
 
-  /**
-   * Retrieves the renderable object associated with the specified render type.
-   *
-   * <p>If the provided render type is {@link RenderType#NONE}, this method returns {@code null}.
-   * Otherwise, it returns the {@link IRenderable} instance mapped to the given render type.
-   *
-   * @param type the render type for which the renderable object is requested
-   * @return the renderable object associated with the specified render type, or {@code null} if the type is {@link RenderType#NONE}
-   */
+  /// Retrieves the renderable object associated with the specified render type.
+  ///
+  /// If the provided render type is [RenderType#NONE], this method returns `null`.
+  /// Otherwise, it returns the [IRenderable] instance mapped to the given render type.
+  ///
+  /// @param type the render type for which the renderable object is requested
+  /// @return the renderable object associated with the specified render type, or `null` if the type is [RenderType#NONE]
   public IRenderable getRenderable(RenderType type) {
     if (type == RenderType.NONE) {
       return null;
@@ -326,119 +290,99 @@ import java.util.concurrent.CopyOnWriteArrayList;
     return this.renderables.get(type);
   }
 
-  /**
-   * Retrieves the list of particles managed by this emitter.
-   *
-   * <p>Returns a list containing all particles currently associated with this emitter.
-   * These particles are used for rendering and updates during the emitter's lifecycle.
-   *
-   * @return a list of particles managed by this emitter
-   */
+  /// Retrieves the list of particles managed by this emitter.
+  ///
+  /// Returns a list containing all particles currently associated with this emitter.
+  /// These particles are used for rendering and updates during the emitter's lifecycle.
+  ///
+  /// @return a list of particles managed by this emitter
   public List<Particle> getParticles() {
     return this.particles;
   }
 
-  /**
-   * Checks if the emitter is set to activate on initialization.
-   *
-   * <p>Returns a boolean indicating whether the emitter should automatically activate
-   * when it is initialized.
-   *
-   * @return {@code true} if the emitter activates on initialization, {@code false} otherwise
-   */
+  /// Checks if the emitter is set to activate on initialization.
+  ///
+  /// Returns a boolean indicating whether the emitter should automatically activate
+  /// when it is initialized.
+  ///
+  /// @return `true` if the emitter activates on initialization, `false` otherwise
   public boolean isActivateOnInit() {
     return this.activateOnInit;
   }
 
-  /**
-   * Checks if the emitter is currently activated.
-   *
-   * <p>Returns a boolean indicating whether the emitter is in an active state.
-   *
-   * @return {@code true} if the emitter is activated, {@code false} otherwise
-   */
+  /// Checks if the emitter is currently activated.
+  ///
+  /// Returns a boolean indicating whether the emitter is in an active state.
+  ///
+  /// @return `true` if the emitter is activated, `false` otherwise
   public boolean isActivated() {
     return this.activated;
   }
 
-  /**
-   * Determines if the emitter has finished its duration.
-   *
-   * <p>This method checks whether the emitter's time-to-live (TTL) is greater than zero
-   * and if the TTL has been reached. If both conditions are true, the emitter is considered finished.
-   *
-   * @return {@code true} if the emitter's duration is complete, {@code false} otherwise
-   */
+  /// Determines if the emitter has finished its duration.
+  ///
+  /// This method checks whether the emitter's time-to-live (TTL) is greater than zero
+  /// and if the TTL has been reached. If both conditions are true, the emitter is considered finished.
+  ///
+  /// @return `true` if the emitter's duration is complete, `false` otherwise
   public boolean isFinished() {
     return this.getTimeToLive() > 0 && this.timeToLiveReached();
   }
 
-  /**
-   * Checks whether the emitter is currently paused.
-   *
-   * <p>Returns a boolean indicating if the emitter is in a paused state.
-   *
-   * @return {@code true} if the emitter is paused, {@code false} otherwise
-   */
+  /// Checks whether the emitter is currently paused.
+  ///
+  /// Returns a boolean indicating if the emitter is in a paused state.
+  ///
+  /// @return `true` if the emitter is paused, `false` otherwise
   public boolean isPaused() {
     return this.paused;
   }
 
-  /**
-   * Sets the paused state of the emitter.
-   *
-   * <p>This method updates the emitter's paused status to the specified value.
-   * When paused, the emitter stops updating its particles and other behaviors.
-   *
-   * @param paused {@code true} to pause the emitter, {@code false} to resume it
-   */
+  /// Sets the paused state of the emitter.
+  ///
+  /// This method updates the emitter's paused status to the specified value.
+  /// When paused, the emitter stops updating its particles and other behaviors.
+  ///
+  /// @param paused `true` to pause the emitter, `false` to resume it
   public void setPaused(final boolean paused) {
     this.paused = paused;
   }
 
-  /**
-   * Checks if the emitter is currently stopped.
-   *
-   * <p>Returns a boolean indicating whether the emitter is in a stopped state.
-   *
-   * @return {@code true} if the emitter is stopped, {@code false} otherwise
-   */
+  /// Checks if the emitter is currently stopped.
+  ///
+  /// Returns a boolean indicating whether the emitter is in a stopped state.
+  ///
+  /// @return `true` if the emitter is stopped, `false` otherwise
   public boolean isStopped() {
     return this.stopped;
   }
 
-  /**
-   * Sets the stopped state of the emitter.
-   *
-   * <p>This method updates the emitter's stopped status to the specified value.
-   * When stopped, the emitter ceases all activity and updates.
-   *
-   * @param stopped {@code true} to stop the emitter, {@code false} to resume it
-   */
+  /// Sets the stopped state of the emitter.
+  ///
+  /// This method updates the emitter's stopped status to the specified value.
+  /// When stopped, the emitter ceases all activity and updates.
+  ///
+  /// @param stopped `true` to stop the emitter, `false` to resume it
   public void setStopped(final boolean stopped) {
     this.stopped = stopped;
   }
 
-  /**
-   * Registers a listener to be notified when the emitter finishes.
-   *
-   * <p>The specified {@link EmitterFinishedListener} is added to the list of listeners
-   * that will be invoked when the emitter completes its lifecycle.
-   *
-   * @param listener the listener to be notified when the emitter finishes
-   */
+  /// Registers a listener to be notified when the emitter finishes.
+  ///
+  /// The specified [EmitterFinishedListener] is added to the list of listeners
+  /// that will be invoked when the emitter completes its lifecycle.
+  ///
+  /// @param listener the listener to be notified when the emitter finishes
   public void onFinished(EmitterFinishedListener listener) {
     this.finishedListeners.add(listener);
   }
 
-  /**
-   * Removes a previously registered finished listener.
-   *
-   * <p>The specified {@link EmitterFinishedListener} is removed from the list of listeners
-   * that are notified when the emitter finishes.
-   *
-   * @param listener the listener to be removed
-   */
+  /// Removes a previously registered finished listener.
+  ///
+  /// The specified [EmitterFinishedListener] is removed from the list of listeners
+  /// that are notified when the emitter finishes.
+  ///
+  /// @param listener the listener to be removed
   public void removeFinishedListener(EmitterFinishedListener listener) {
     this.finishedListeners.remove(listener);
   }
@@ -447,14 +391,12 @@ import java.util.concurrent.CopyOnWriteArrayList;
     this.renderParticles(g, RenderType.NONE);
   }
 
-  /**
-   * Sets the emitter data for this emitter.
-   *
-   * <p>This method updates the emitter's configuration using the provided {@link EmitterAttributes}.
-   * If the provided data is null, the method does nothing.
-   *
-   * @param emitterData the data used to configure this emitter
-   */
+  /// Sets the emitter data for this emitter.
+  ///
+  /// This method updates the emitter's configuration using the provided [EmitterAttributes].
+  /// If the provided data is null, the method does nothing.
+  ///
+  /// @param emitterData the data used to configure this emitter
   public void setEmitterData(final EmitterAttributes emitterData) {
     if (emitterData == null) {
       return;
@@ -462,44 +404,36 @@ import java.util.concurrent.CopyOnWriteArrayList;
     this.emitterData = emitterData;
   }
 
-  /**
-   * Sets the emitter data for this emitter using an XML configuration file.
-   *
-   * <p>This method loads the emitter data from the specified XML file and updates the emitter's
-   * configuration accordingly.
-   *
-   * @param emitterXmlPath the path to the XML file containing the emitter data
-   */
+  /// Sets the emitter data for this emitter using an XML configuration file.
+  ///
+  /// This method loads the emitter data from the specified XML file and updates the emitter's
+  /// configuration accordingly.
+  ///
+  /// @param emitterXmlPath the path to the XML file containing the emitter data
   public void setEmitterData(final String emitterXmlPath) {
     EmitterAttributes loaded = EmitterLoader.load(emitterXmlPath);
     setEmitterData(loaded);
   }
 
-  /**
-   * Time to live reached.
-   *
-   * @return true, if successful
-   */
+  /// Time to live reached.
+  ///
+  /// @return true, if successful
   @Override public boolean timeToLiveReached() {
     return this.activated && this.getTimeToLive() > 0 && this.getAliveTime() >= this.getTimeToLive();
   }
 
-  /**
-   * Toggles the paused state of the emitter.
-   *
-   * <p>This method switches the emitter's paused status between {@code true} and {@code false}.
-   * When paused, the emitter stops updating its particles and other behaviors.
-   */
+  /// Toggles the paused state of the emitter.
+  ///
+  /// This method switches the emitter's paused status between `true` and `false`.
+  /// When paused, the emitter stops updating its particles and other behaviors.
   public void togglePaused() {
     this.paused = !this.paused;
   }
 
-  /**
-   * Toggles the stopped state of the emitter.
-   *
-   * <p>This method switches the emitter's stopped status between {@code true} and {@code false}.
-   * When stopped, the emitter ceases all activity and updates.
-   */
+  /// Toggles the stopped state of the emitter.
+  ///
+  /// This method switches the emitter's stopped status between `true` and `false`.
+  /// When stopped, the emitter ceases all activity and updates.
   public void toggleStopped() {
     this.stopped = !this.stopped;
   }
@@ -544,27 +478,23 @@ import java.util.concurrent.CopyOnWriteArrayList;
   }
 
 
-  /**
-   * Checks if the emitter can accept new particles.
-   *
-   * <p>This method determines whether the current number of particles is less than
-   * the maximum allowed particles as defined in the emitter data configuration.
-   *
-   * @return {@code true} if the emitter can accept new particles, {@code false} otherwise
-   */
+  /// Checks if the emitter can accept new particles.
+  ///
+  /// This method determines whether the current number of particles is less than
+  /// the maximum allowed particles as defined in the emitter data configuration.
+  ///
+  /// @return `true` if the emitter can accept new particles, `false` otherwise
   protected boolean canTakeNewParticles() {
     return this.particles.size() < this.data().getMaxParticles();
   }
 
-  /**
-   * Creates a new particle based on the emitter's configuration.
-   *
-   * <p>This method generates a particle of the type specified in the emitter's data.
-   * The particle's dimensions are determined by the configured width and height. If the particle type is {@code SPRITE}, the method ensures the
-   * spritesheet is valid before creating the particle. If no specific type is defined, a rectangle particle is created by default.
-   *
-   * @return the newly created particle, or {@code null} if the particle type is {@code SPRITE} and the spritesheet is invalid
-   */
+  /// Creates a new particle based on the emitter's configuration.
+  ///
+  /// This method generates a particle of the type specified in the emitter's data.
+  /// The particle's dimensions are determined by the configured width and height. If the particle type is `SPRITE`, the method ensures the
+  /// spritesheet is valid before creating the particle. If no specific type is defined, a rectangle particle is created by default.
+  ///
+  /// @return the newly created particle, or `null` if the particle type is `SPRITE` and the spritesheet is invalid
   protected Particle createNewParticle() {
 
     float width = data().getParticleWidth().getRandomNumber().floatValue();
@@ -600,26 +530,22 @@ import java.util.concurrent.CopyOnWriteArrayList;
     }
   }
 
-  /**
-   * Determines if a particle can be removed from the emitter.
-   *
-   * <p>This method checks whether the specified particle has reached its time-to-live (TTL).
-   * If the particle's TTL is reached, it is considered eligible for removal.
-   *
-   * @param particle the particle to check
-   * @return {@code true} if the particle's TTL is reached, {@code false} otherwise
-   */
+  /// Determines if a particle can be removed from the emitter.
+  ///
+  /// This method checks whether the specified particle has reached its time-to-live (TTL).
+  /// If the particle's TTL is reached, it is considered eligible for removal.
+  ///
+  /// @param particle the particle to check
+  /// @return `true` if the particle's TTL is reached, `false` otherwise
   protected boolean particleCanBeRemoved(final Particle particle) {
     return particle.timeToLiveReached();
   }
 
-  /**
-   * Spawns new particles for the emitter.
-   *
-   * <p>This method generates a number of particles based on the emitter's spawn amount
-   * configuration. It ensures that the emitter does not exceed its maximum allowed particles. If a new particle is successfully created, it is added
-   * to the emitter's particle list.
-   */
+  /// Spawns new particles for the emitter.
+  ///
+  /// This method generates a number of particles based on the emitter's spawn amount
+  /// configuration. It ensures that the emitter does not exceed its maximum allowed particles. If a new particle is successfully created, it is added
+  /// to the emitter's particle list.
   protected void spawnParticle() {
     for (short i = 0; i < this.data().getSpawnAmount(); i++) {
       if (!this.canTakeNewParticles()) {
@@ -633,13 +559,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
     }
   }
 
-  /**
-   * Render particles of this effect. The particles are always rendered relatively to this effects render location. A particle doesn't have an own map
-   * location. It is always relative to the effect it is assigned to.
-   *
-   * @param g          The graphics object to draw on.
-   * @param renderType The render type.
-   */
+  /// Render particles of this effect. The particles are always rendered relatively to this effects render location. A particle doesn't have an own map
+  /// location. It is always relative to the effect it is assigned to.
+  ///
+  /// @param g          The graphics object to draw on.
+  /// @param renderType The render type.
   private void renderParticles(final Graphics2D g, final RenderType renderType) {
     if (Game.config().graphics().getGraphicQuality().getValue() < this.data().getRequiredQuality().getValue()) {
       return;
@@ -654,19 +578,15 @@ import java.util.concurrent.CopyOnWriteArrayList;
     }
   }
 
-  /**
-   * Listener interface for handling emitter completion events.
-   *
-   * <p>Implementations of this interface can be registered to an emitter to be notified
-   * when the emitter finishes its lifecycle.
-   */
+  /// Listener interface for handling emitter completion events.
+  ///
+  /// Implementations of this interface can be registered to an emitter to be notified
+  /// when the emitter finishes its lifecycle.
   @FunctionalInterface public interface EmitterFinishedListener extends EventListener {
 
-    /**
-     * Called when the emitter has finished its lifecycle.
-     *
-     * @param emitter the emitter that has finished
-     */
+    /// Called when the emitter has finished its lifecycle.
+    ///
+    /// @param emitter the emitter that has finished
     void finished(Emitter emitter);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/EntityEmitter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/EntityEmitter.java
@@ -4,82 +4,68 @@ import de.gurkenlabs.litiengine.entities.IEntity;
 import de.gurkenlabs.litiengine.graphics.emitters.xml.EmitterAttributes;
 import java.awt.geom.Point2D;
 
-/**
- * A standard implementation for emitters that are bound to {@code IEntity.getLocation()}.
- *
- * @see IEntity#getLocation()
- */
+/// A standard implementation for emitters that are bound to `IEntity.getLocation()`.
+///
+/// @see IEntity#getLocation()
 public class EntityEmitter extends Emitter {
 
   private final IEntity entity;
 
   private boolean dynamicLocation;
 
-  /**
-   * Constructs a new EntityEmitter from a given emitter resource that follows an entity's location.
-   *
-   * @param entity              The IEntity to which this emitter is bound.
-   * @param emitterResourceName The name of the configuration for this emitter. If the Emitter has been added to the game resource file, it is loaded
-   *                            from there by name. Otherwise, the EmitterLoader will search the Resource folders for a file with the
-   *                            emitterResourceName.
-   * @param dynamicLocation     If true, the emitter follows the entity's location; if false, it remains at the location where it has been created.
-   */
+  /// Constructs a new EntityEmitter from a given emitter resource that follows an entity's location.
+  ///
+  /// @param entity              The IEntity to which this emitter is bound.
+  /// @param emitterResourceName The name of the configuration for this emitter. If the Emitter has been added to the game resource file, it is loaded
+  /// from there by name. Otherwise, the EmitterLoader will search the Resource folders for a file with the
+  /// emitterResourceName.
+  /// @param dynamicLocation     If true, the emitter follows the entity's location; if false, it remains at the location where it has been created.
   public EntityEmitter(
     final IEntity entity, final String emitterResourceName, final boolean dynamicLocation) {
     this(entity, dynamicLocation);
     setEmitterData(emitterResourceName);
   }
 
-  /**
-   * Constructs a new EntityEmitter from a given emitter resource that remains at the location where it has been created.
-   *
-   * @param entity              The IEntity to which this emitter is bound.
-   * @param emitterResourceName The name of the configuration for this emitter. If the Emitter has been added to the game resource file, it is loaded
-   *                            from there by name. Otherwise, the EmitterLoader will search the Resource folders for a file with the
-   *                            emitterResourceName.
-   */
+  /// Constructs a new EntityEmitter from a given emitter resource that remains at the location where it has been created.
+  ///
+  /// @param entity              The IEntity to which this emitter is bound.
+  /// @param emitterResourceName The name of the configuration for this emitter. If the Emitter has been added to the game resource file, it is loaded
+  /// from there by name. Otherwise, the EmitterLoader will search the Resource folders for a file with the
+  /// emitterResourceName.
   public EntityEmitter(final IEntity entity, final String emitterResourceName) {
     this(entity, emitterResourceName, false);
   }
 
-  /**
-   * Constructs a new EntityEmitter with EmitterAttributes that follows an entity's location.
-   *
-   * @param entity          The IEntity to which this emitter is bound.
-   * @param emitterData     The EmitterAttributes object defining the emitter's behavior.
-   * @param dynamicLocation If true, the emitter follows the entity's location; if false, it remains at the location where it has been created.
-   */
+  /// Constructs a new EntityEmitter with EmitterAttributes that follows an entity's location.
+  ///
+  /// @param entity          The IEntity to which this emitter is bound.
+  /// @param emitterData     The EmitterAttributes object defining the emitter's behavior.
+  /// @param dynamicLocation If true, the emitter follows the entity's location; if false, it remains at the location where it has been created.
   public EntityEmitter(
     final IEntity entity, final EmitterAttributes emitterData, final boolean dynamicLocation) {
     this(entity, dynamicLocation);
     setEmitterData(emitterData);
   }
 
-  /**
-   * Constructs a new EntityEmitter with EmitterAttributes that remains at the location where it has been created.
-   *
-   * @param entity      The IEntity to which this emitter is bound.
-   * @param emitterData The EmitterAttributes object defining the emitter's behavior.
-   */
+  /// Constructs a new EntityEmitter with EmitterAttributes that remains at the location where it has been created.
+  ///
+  /// @param entity      The IEntity to which this emitter is bound.
+  /// @param emitterData The EmitterAttributes object defining the emitter's behavior.
   public EntityEmitter(final IEntity entity, final EmitterAttributes emitterData) {
     this(entity, emitterData, false);
   }
 
-  /**
-   * Instantiates a new entity emitter that remains at the location where it has been created.
-   *
-   * @param entity The IEntity to which this emitter is bound.
-   */
+  /// Instantiates a new entity emitter that remains at the location where it has been created.
+  ///
+  /// @param entity The IEntity to which this emitter is bound.
   public EntityEmitter(final IEntity entity) {
     this(entity, false);
   }
 
-  /**
-   * Instantiates a new entity emitter.
-   *
-   * @param entity          The IEntity to which this emitter is bound.
-   * @param dynamicLocation If true, the emitter follows the entity's location; if false, it remains at the location where it has been created.
-   */
+  /// Instantiates a new entity emitter.
+  ///
+  /// @param entity          The IEntity to which this emitter is bound.
+  /// @param dynamicLocation If true, the emitter follows the entity's location; if false, it remains at the location where it has been created.
   public EntityEmitter(final IEntity entity, boolean dynamicLocation) {
     super();
     this.entity = entity;
@@ -88,30 +74,24 @@ public class EntityEmitter extends Emitter {
     setY(entity.getCenter().getY() - getHeight() / 2d);
   }
 
-  /**
-   * Get the IEntity to which this emitter is bound.
-   *
-   * @return The IEntity to which this emitter is bound.
-   */
+  /// Get the IEntity to which this emitter is bound.
+  ///
+  /// @return The IEntity to which this emitter is bound.
   public IEntity getEntity() {
     return this.entity;
   }
 
-  /**
-   * Check if the emitter has dynamic location tracking enabled. This determines whether this Emitter's location is updated along its entity's
-   * location.
-   *
-   * @return True if dynamic location is enabled, false otherwise.
-   */
+  /// Check if the emitter has dynamic location tracking enabled. This determines whether this Emitter's location is updated along its entity's
+  /// location.
+  ///
+  /// @return True if dynamic location is enabled, false otherwise.
   public boolean hasDynamicLocation() {
     return this.dynamicLocation;
   }
 
-  /**
-   * Toggle dynamic location updates.
-   *
-   * @param dynamicLocation If true, the emitter follows its entity's location; if false, it remains at the location where it has been created.
-   */
+  /// Toggle dynamic location updates.
+  ///
+  /// @param dynamicLocation If true, the emitter follows its entity's location; if false, it remains at the location where it has been created.
   public void setDynamicLocation(boolean dynamicLocation) {
     this.dynamicLocation = dynamicLocation;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/EllipseParticle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/EllipseParticle.java
@@ -5,27 +5,21 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 
-/**
- * Represents a particle in the shape of an ellipse. This class extends the {@code ShapeParticle} to provide specific behavior for elliptical
- * particles.
- */
+/// Represents a particle in the shape of an ellipse. This class extends the `ShapeParticle` to provide specific behavior for elliptical
+/// particles.
 public class EllipseParticle extends ShapeParticle {
-  /**
-   * Initializes a new instance of the {@code EllipseParticle} class with the specified dimensions.
-   *
-   * @param width  The width of the ellipse.
-   * @param height The height of the ellipse.
-   */
+  /// Initializes a new instance of the `EllipseParticle` class with the specified dimensions.
+  ///
+  /// @param width  The width of the ellipse.
+  /// @param height The height of the ellipse.
   public EllipseParticle(final float width, final float height) {
     super(width, height);
   }
 
-  /**
-   * Creates and returns the shape of the ellipse particle, transformed based on the emitter's origin and rotation.
-   *
-   * @param emitterOrigin The origin point of the emitter.
-   * @return A {@code Shape} representing the transformed ellipse.
-   */
+  /// Creates and returns the shape of the ellipse particle, transformed based on the emitter's origin and rotation.
+  ///
+  /// @param emitterOrigin The origin point of the emitter.
+  /// @return A `Shape` representing the transformed ellipse.
   @Override
   protected Shape getShape(final Point2D emitterOrigin) {
     final AffineTransform rotate =

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/Particle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/Particle.java
@@ -12,12 +12,9 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-/**
- * Base class for particles spawned by a {@link Emitter}. A particle has a position, velocity, acceleration, lifetime, color and rendering options.
- * <p>
- * Subclasses are responsible for implementing {@link #render(Graphics2D, Point2D)} which draws the particle relative to the emitter origin.
- * </p>
- */
+/// Base class for particles spawned by a [Emitter]. A particle has a position, velocity, acceleration, lifetime, color and rendering options.
+///
+/// Subclasses are responsible for implementing [Point2D)][#render(Graphics2D,] which draws the particle relative to the emitter origin.
 public abstract class Particle implements ITimeToLive {
 
   private static final Color DEFAULT_COLOR = Color.BLACK;
@@ -30,39 +27,27 @@ public abstract class Particle implements ITimeToLive {
   private Color color = DEFAULT_COLOR;
   private float deltaHeight;
   private float deltaWidth;
-  /**
-   * The horizontal velocity (horizontal movement per update) for this particle.
-   */
+  /// The horizontal velocity (horizontal movement per update) for this particle.
   private float velocityX;
-  /**
-   * The vertical velocity (vertical movement per update) for this particle.
-   */
+  /// The vertical velocity (vertical movement per update) for this particle.
   private float velocityY;
   private float outlineThickness;
   private boolean outlineOnly;
   private boolean antiAliasing;
 
-  /**
-   * The horizontal acceleration (increase / decrease in velocity over time) for this particle.
-   */
+  /// The horizontal acceleration (increase / decrease in velocity over time) for this particle.
   private float accelerationX;
 
-  /**
-   * The vertical acceleration (increase / decrease in velocity over time) for this particle.
-   */
+  /// The vertical acceleration (increase / decrease in velocity over time) for this particle.
   private float accelerationY;
   private float height;
   private int timeToLive;
   private float width;
 
-  /**
-   * The current location of the particle on the X-axis.
-   */
+  /// The current location of the particle on the X-axis.
   private float x;
 
-  /**
-   * The current location of the particle on the Y-axis.
-   */
+  /// The current location of the particle on the Y-axis.
   private float y;
 
   private RenderType customRenderType = RenderType.NONE;
@@ -78,12 +63,10 @@ public abstract class Particle implements ITimeToLive {
 
   private boolean stopOnCollision;
 
-  /**
-   * Constructs a new particle.
-   *
-   * @param width  the particle width in pixels
-   * @param height the particle height in pixels
-   */
+  /// Constructs a new particle.
+  ///
+  /// @param width  the particle width in pixels
+  /// @param height the particle height in pixels
   protected Particle(final float width, final float height) {
     this.setWidth(width);
     this.setHeight(height);
@@ -98,149 +81,117 @@ public abstract class Particle implements ITimeToLive {
     return aliveTime;
   }
 
-  /**
-   * Gets the current bounding box of the particle, depending on its spawn location.
-   *
-   * @param origin the spawn location of this particle
-   * @return The Rectangular particle bounding box.
-   */
+  /// Gets the current bounding box of the particle, depending on its spawn location.
+  ///
+  /// @param origin the spawn location of this particle
+  /// @return The Rectangular particle bounding box.
   public Rectangle2D getBoundingBox(final Point2D origin) {
     return new Rectangle2D.Double(origin.getX() + this.getX(), origin.getY() + this.getY(),
       this.getWidth(), this.getHeight());
   }
 
-  /**
-   * Gets the collision behavior of this particle.
-   *
-   * @return the collision behavior
-   */
+  /// Gets the collision behavior of this particle.
+  ///
+  /// @return the collision behavior
   public Collision getCollisionType() {
     return collisionType;
   }
 
-  /**
-   * Gets the current color of the particle.
-   *
-   * @return the color
-   */
+  /// Gets the current color of the particle.
+  ///
+  /// @return the color
   public Color getColor() {
     return color;
   }
 
-  /**
-   * Gets the per-update height delta applied to the particle.
-   *
-   * @return the height delta
-   */
+  /// Gets the per-update height delta applied to the particle.
+  ///
+  /// @return the height delta
   public float getDeltaHeight() {
     return deltaHeight;
   }
 
-  /**
-   * Gets the per-update width delta applied to the particle.
-   *
-   * @return the width delta
-   */
+  /// Gets the per-update width delta applied to the particle.
+  ///
+  /// @return the width delta
   public float getDeltaWidth() {
     return deltaWidth;
   }
 
-  /**
-   * Gets the horizontal velocity of the particle.
-   *
-   * @return the horizontal velocity
-   */
+  /// Gets the horizontal velocity of the particle.
+  ///
+  /// @return the horizontal velocity
   public float getVelocityX() {
     return velocityX;
   }
 
-  /**
-   * Gets the vertical velocity of the particle.
-   *
-   * @return the vertical velocity
-   */
+  /// Gets the vertical velocity of the particle.
+  ///
+  /// @return the vertical velocity
   public float getVelocityY() {
     return velocityY;
   }
 
-  /**
-   * Gets the horizontal acceleration of the particle.
-   *
-   * @return the horizontal acceleration
-   */
+  /// Gets the horizontal acceleration of the particle.
+  ///
+  /// @return the horizontal acceleration
   public float getAccelerationX() {
     return accelerationX;
   }
 
-  /**
-   * Gets the vertical acceleration of the particle.
-   *
-   * @return the vertical acceleration
-   */
+  /// Gets the vertical acceleration of the particle.
+  ///
+  /// @return the vertical acceleration
   public float getAccelerationY() {
     return accelerationY;
   }
 
-  /**
-   * Gets the current rotation angle of the particle, in degrees.
-   *
-   * @return the current angle
-   */
+  /// Gets the current rotation angle of the particle, in degrees.
+  ///
+  /// @return the current angle
   public float getAngle() {
     return angle;
   }
 
-  /**
-   * Gets the per-update angle delta applied to the particle, in degrees.
-   *
-   * @return the angle delta
-   */
+  /// Gets the per-update angle delta applied to the particle, in degrees.
+  ///
+  /// @return the angle delta
   public float getDeltaAngle() {
     return deltaAngle;
   }
 
-  /**
-   * Gets the current height of the particle, in pixels.
-   *
-   * @return the particle height
-   */
+  /// Gets the current height of the particle, in pixels.
+  ///
+  /// @return the particle height
   public float getHeight() {
     return height;
   }
 
-  /**
-   * Gets the outline thickness used when rendering the particle as an outline.
-   *
-   * @return the outline thickness
-   */
+  /// Gets the outline thickness used when rendering the particle as an outline.
+  ///
+  /// @return the outline thickness
   public float getOutlineThickness() {
     return outlineThickness;
   }
 
-  /**
-   * Returns whether the particle is rendered as an outline only.
-   *
-   * @return {@code true} if outline-only rendering is enabled
-   */
+  /// Returns whether the particle is rendered as an outline only.
+  ///
+  /// @return `true` if outline-only rendering is enabled
   public boolean isOutlineOnly() {
     return outlineOnly;
   }
 
-  /**
-   * Returns whether the particle is rendered with anti-aliasing.
-   *
-   * @return {@code true} if anti-aliasing is enabled
-   */
+  /// Returns whether the particle is rendered with anti-aliasing.
+  ///
+  /// @return `true` if anti-aliasing is enabled
   public boolean isAntiAliased() {
     return antiAliasing;
   }
 
-  /**
-   * Computes the current opacity of the particle. If fading is enabled and the particle has a finite time-to-live, the opacity decreases linearly
-   * from the color's initial alpha towards zero as the particle ages.
-   *
-   * @return the opacity in the range {@code [0, 1]}
-   */
+  /// Computes the current opacity of the particle. If fading is enabled and the particle has a finite time-to-live, the opacity decreases linearly
+  /// from the color's initial alpha towards zero as the particle ages.
+  ///
+  /// @return the opacity in the range `[0, 1]`
   public float getOpacity() {
     if (isFading() && getTimeToLive() > 0) {
       float maxAlpha = getColor().getAlpha() / 255f;
@@ -250,12 +201,10 @@ public abstract class Particle implements ITimeToLive {
     return 1;
   }
 
-  /**
-   * Gets the location relative to the specified effect location.
-   *
-   * @param effectLocation the effect position
-   * @return the location
-   */
+  /// Gets the location relative to the specified effect location.
+  ///
+  /// @param effectLocation the effect position
+  /// @return the location
   public Point2D getRenderLocation(Point2D effectLocation) {
     // if we have a camera, we need to render the particle relative to the
     // viewport
@@ -265,11 +214,9 @@ public abstract class Particle implements ITimeToLive {
     return getAbsoluteLocation(newEffectLocation);
   }
 
-  /**
-   * Gets the custom render type that overrides the emitter's render type, if {@link #usesCustomRenderType()} is {@code true}.
-   *
-   * @return the custom render type
-   */
+  /// Gets the custom render type that overrides the emitter's render type, if [#usesCustomRenderType()] is `true`.
+  ///
+  /// @return the custom render type
   public RenderType getCustomRenderType() {
     return customRenderType;
   }
@@ -279,116 +226,92 @@ public abstract class Particle implements ITimeToLive {
     return timeToLive;
   }
 
-  /**
-   * Gets the current width of the particle, in pixels.
-   *
-   * @return the particle width
-   */
+  /// Gets the current width of the particle, in pixels.
+  ///
+  /// @return the particle width
   public float getWidth() {
     return width;
   }
 
-  /**
-   * Gets the X position of the particle relative to its emitter origin.
-   *
-   * @return the X position
-   */
+  /// Gets the X position of the particle relative to its emitter origin.
+  ///
+  /// @return the X position
   public float getX() {
     return x;
   }
 
-  /**
-   * Gets the Y position of the particle relative to its emitter origin.
-   *
-   * @return the Y position
-   */
+  /// Gets the Y position of the particle relative to its emitter origin.
+  ///
+  /// @return the Y position
   public float getY() {
     return y;
   }
 
-  /**
-   * Returns whether the particle fades out over its lifetime.
-   *
-   * @return {@code true} if fading is enabled
-   */
+  /// Returns whether the particle fades out over its lifetime.
+  ///
+  /// @return `true` if fading is enabled
   public boolean isFading() {
     return fade;
   }
 
-  /**
-   * Returns whether the particle fades upon collision.
-   *
-   * @return {@code true} if fade-on-collision is enabled
-   */
+  /// Returns whether the particle fades upon collision.
+  ///
+  /// @return `true` if fade-on-collision is enabled
   public boolean isFadingOnCollision() {
     return fadeOnCollision;
   }
 
-  /**
-   * Returns whether continuous (ray-cast) collision detection is enabled for this particle.
-   *
-   * @return {@code true} if continuous collision detection is enabled
-   */
+  /// Returns whether continuous (ray-cast) collision detection is enabled for this particle.
+  ///
+  /// @return `true` if continuous collision detection is enabled
   public boolean isContinuousCollisionEnabled() {
     return continuousCollision;
   }
 
-  /**
-   * Returns whether the particle stops moving once a collision occurs.
-   *
-   * @return {@code true} if the particle stops on collision
-   */
+  /// Returns whether the particle stops moving once a collision occurs.
+  ///
+  /// @return `true` if the particle stops on collision
   public boolean isStoppingOnCollision() {
     return stopOnCollision;
   }
 
-  /**
-   * Renders this particle to the given graphics context.
-   *
-   * @param g             the graphics context to draw to
-   * @param emitterOrigin the world location of the owning emitter
-   */
+  /// Renders this particle to the given graphics context.
+  ///
+  /// @param g             the graphics context to draw to
+  /// @param emitterOrigin the world location of the owning emitter
   public abstract void render(final Graphics2D g, final Point2D emitterOrigin);
 
-  /**
-   * Sets the collision behavior of this particle.
-   *
-   * @param collisionType the new collision behavior
-   * @return this particle instance for chaining
-   */
+  /// Sets the collision behavior of this particle.
+  ///
+  /// @param collisionType the new collision behavior
+  /// @return this particle instance for chaining
   public Particle setCollisionType(final Collision collisionType) {
     this.collisionType = collisionType;
     return this;
   }
 
-  /**
-   * Enabling this check can be very performance hungry and should be used with caution and only for a small amount of particles.
-   *
-   * @param ccd If set to true, the collision will be checked continuously by a ray-cast approximation.
-   * @return This particle instance.
-   */
+  /// Enabling this check can be very performance hungry and should be used with caution and only for a small amount of particles.
+  ///
+  /// @param ccd If set to true, the collision will be checked continuously by a ray-cast approximation.
+  /// @return This particle instance.
   public Particle setContinuousCollision(boolean ccd) {
     this.continuousCollision = ccd;
     return this;
   }
 
-  /**
-   * Sets whether the particle stops moving when it collides.
-   *
-   * @param stopOnCollision {@code true} to stop the particle on collision
-   * @return this particle instance for chaining
-   */
+  /// Sets whether the particle stops moving when it collides.
+  ///
+  /// @param stopOnCollision `true` to stop the particle on collision
+  /// @return this particle instance for chaining
   public Particle setStopOnCollision(boolean stopOnCollision) {
     this.stopOnCollision = stopOnCollision;
     return this;
   }
 
-  /**
-   * Sets the color of the particle. {@code null} values are ignored.
-   *
-   * @param color the new color
-   * @return this particle instance for chaining
-   */
+  /// Sets the color of the particle. `null` values are ignored.
+  ///
+  /// @param color the new color
+  /// @return this particle instance for chaining
   public Particle setColor(final Color color) {
     if (color != null) {
       this.color = color;
@@ -396,222 +319,182 @@ public abstract class Particle implements ITimeToLive {
     return this;
   }
 
-  /**
-   * Sets the per-update height delta applied to the particle.
-   *
-   * @param deltaHeight the height delta
-   * @return this particle instance for chaining
-   */
+  /// Sets the per-update height delta applied to the particle.
+  ///
+  /// @param deltaHeight the height delta
+  /// @return this particle instance for chaining
   public Particle setDeltaHeight(final float deltaHeight) {
     this.deltaHeight = deltaHeight;
     return this;
   }
 
-  /**
-   * Sets the horizontal acceleration of the particle.
-   *
-   * @param accelerationX the horizontal acceleration
-   * @return this particle instance for chaining
-   */
+  /// Sets the horizontal acceleration of the particle.
+  ///
+  /// @param accelerationX the horizontal acceleration
+  /// @return this particle instance for chaining
   public Particle setAccelerationX(final float accelerationX) {
     this.accelerationX = accelerationX;
     return this;
   }
 
-  /**
-   * Sets the vertical acceleration of the particle.
-   *
-   * @param accelerationY the vertical acceleration
-   * @return this particle instance for chaining
-   */
+  /// Sets the vertical acceleration of the particle.
+  ///
+  /// @param accelerationY the vertical acceleration
+  /// @return this particle instance for chaining
   public Particle setAccelerationY(final float accelerationY) {
     this.accelerationY = accelerationY;
     return this;
   }
 
-  /**
-   * Sets the current rotation angle of the particle, in degrees.
-   *
-   * @param angle the angle to set
-   * @return this particle instance for chaining
-   */
+  /// Sets the current rotation angle of the particle, in degrees.
+  ///
+  /// @param angle the angle to set
+  /// @return this particle instance for chaining
   public Particle setAngle(final float angle) {
     this.angle = angle;
     return this;
   }
 
-  /**
-   * Sets the per-update angle delta applied to the particle, in degrees.
-   *
-   * @param deltaAngle the angle delta
-   * @return this particle instance for chaining
-   */
+  /// Sets the per-update angle delta applied to the particle, in degrees.
+  ///
+  /// @param deltaAngle the angle delta
+  /// @return this particle instance for chaining
   public Particle setDeltaAngle(final float deltaAngle) {
     this.deltaAngle = deltaAngle;
     return this;
   }
 
-  /**
-   * Sets the per-update width delta applied to the particle.
-   *
-   * @param deltaWidth the width delta
-   * @return this particle instance for chaining
-   */
+  /// Sets the per-update width delta applied to the particle.
+  ///
+  /// @param deltaWidth the width delta
+  /// @return this particle instance for chaining
   public Particle setDeltaWidth(final float deltaWidth) {
     this.deltaWidth = deltaWidth;
     return this;
   }
 
-  /**
-   * Sets the horizontal velocity of the particle.
-   *
-   * @param velocityX the horizontal velocity
-   * @return this particle instance for chaining
-   */
+  /// Sets the horizontal velocity of the particle.
+  ///
+  /// @param velocityX the horizontal velocity
+  /// @return this particle instance for chaining
   public Particle setVelocityX(final float velocityX) {
     this.velocityX = velocityX;
     return this;
   }
 
-  /**
-   * Sets the vertical velocity of the particle.
-   *
-   * @param velocityY the vertical velocity
-   * @return this particle instance for chaining
-   */
+  /// Sets the vertical velocity of the particle.
+  ///
+  /// @param velocityY the vertical velocity
+  /// @return this particle instance for chaining
   public Particle setVelocityY(final float velocityY) {
     this.velocityY = velocityY;
     return this;
   }
 
-  /**
-   * Sets whether the particle fades out over its lifetime.
-   *
-   * @param fade {@code true} to enable fading
-   * @return this particle instance for chaining
-   */
+  /// Sets whether the particle fades out over its lifetime.
+  ///
+  /// @param fade `true` to enable fading
+  /// @return this particle instance for chaining
   public Particle setFade(boolean fade) {
     this.fade = fade;
     return this;
   }
 
-  /**
-   * Sets whether the particle fades upon collision.
-   *
-   * @param fadeOnCollision {@code true} to enable fade-on-collision
-   * @return this particle instance for chaining
-   */
+  /// Sets whether the particle fades upon collision.
+  ///
+  /// @param fadeOnCollision `true` to enable fade-on-collision
+  /// @return this particle instance for chaining
   public Particle setFadeOnCollision(boolean fadeOnCollision) {
     this.fadeOnCollision = fadeOnCollision;
     return this;
   }
 
-  /**
-   * Sets the height of the particle, in pixels.
-   *
-   * @param height the height to set
-   * @return this particle instance for chaining
-   */
+  /// Sets the height of the particle, in pixels.
+  ///
+  /// @param height the height to set
+  /// @return this particle instance for chaining
   public Particle setHeight(final float height) {
     this.height = height;
     return this;
   }
 
-  /**
-   * Sets the outline thickness used when rendering the particle as an outline.
-   *
-   * @param outlineThickness the outline thickness
-   * @return this particle instance for chaining
-   */
+  /// Sets the outline thickness used when rendering the particle as an outline.
+  ///
+  /// @param outlineThickness the outline thickness
+  /// @return this particle instance for chaining
   public Particle setOutlineThickness(final float outlineThickness) {
     this.outlineThickness = outlineThickness;
     return this;
   }
 
-  /**
-   * Sets whether the particle is rendered as an outline only.
-   *
-   * @param outlineOnly {@code true} to enable outline-only rendering
-   * @return this particle instance for chaining
-   */
+  /// Sets whether the particle is rendered as an outline only.
+  ///
+  /// @param outlineOnly `true` to enable outline-only rendering
+  /// @return this particle instance for chaining
   public Particle setOutlineOnly(final boolean outlineOnly) {
     this.outlineOnly = outlineOnly;
     return this;
   }
 
-  /**
-   * Sets whether the particle is rendered with anti-aliasing.
-   *
-   * @param antiAliasing {@code true} to enable anti-aliasing
-   * @return this particle instance for chaining
-   */
+  /// Sets whether the particle is rendered with anti-aliasing.
+  ///
+  /// @param antiAliasing `true` to enable anti-aliasing
+  /// @return this particle instance for chaining
   public Particle setAntiAliasing(final boolean antiAliasing) {
     this.antiAliasing = antiAliasing;
     return this;
   }
 
-  /**
-   * Sets a custom render type that overrides the emitter's render type for this particle.
-   *
-   * @param renderType the render type to use
-   * @return this particle instance for chaining
-   */
+  /// Sets a custom render type that overrides the emitter's render type for this particle.
+  ///
+  /// @param renderType the render type to use
+  /// @return this particle instance for chaining
   public Particle setCustomRenderType(RenderType renderType) {
     this.customRenderType = renderType;
     this.useCustomRenderType = true;
     return this;
   }
 
-  /**
-   * Sets the width of the particle, in pixels.
-   *
-   * @param width the width to set
-   * @return this particle instance for chaining
-   */
+  /// Sets the width of the particle, in pixels.
+  ///
+  /// @param width the width to set
+  /// @return this particle instance for chaining
   public Particle setWidth(final float width) {
     this.width = width;
     return this;
   }
 
-  /**
-   * Sets the X position of the particle relative to its emitter origin.
-   *
-   * @param x the X position
-   * @return this particle instance for chaining
-   */
+  /// Sets the X position of the particle relative to its emitter origin.
+  ///
+  /// @param x the X position
+  /// @return this particle instance for chaining
   public Particle setX(final float x) {
     this.x = x;
     return this;
   }
 
-  /**
-   * Sets the Y position of the particle relative to its emitter origin.
-   *
-   * @param y the Y position
-   * @return this particle instance for chaining
-   */
+  /// Sets the Y position of the particle relative to its emitter origin.
+  ///
+  /// @param y the Y position
+  /// @return this particle instance for chaining
   public Particle setY(final float y) {
     this.y = y;
     return this;
   }
 
-  /**
-   * Sets the time-to-live (TTL) of the particle, in milliseconds.
-   *
-   * @param ttl the TTL to set
-   * @return this particle instance for chaining
-   */
+  /// Sets the time-to-live (TTL) of the particle, in milliseconds.
+  ///
+  /// @param ttl the TTL to set
+  /// @return this particle instance for chaining
   public Particle setTimeToLive(final int ttl) {
     this.timeToLive = ttl;
     return this;
   }
 
-  /**
-   * Initializes this particle's mutable state from the supplied {@link EmitterAttributes}.
-   *
-   * @param data the emitter data providing initial parameter values
-   * @return this particle instance for chaining
-   */
+  /// Initializes this particle's mutable state from the supplied [EmitterAttributes].
+  ///
+  /// @param data the emitter data providing initial parameter values
+  /// @return this particle instance for chaining
   public Particle init(final EmitterAttributes data) {
     this.setX(data.getParticleOffsetX().getRandomNumber().floatValue());
     this.setY(data.getParticleOffsetY().getRandomNumber().floatValue());
@@ -647,12 +530,10 @@ public abstract class Particle implements ITimeToLive {
     return getTimeToLive() > 0 && this.getAliveTime() >= this.getTimeToLive();
   }
 
-  /**
-   * Updates the effect's position, change in xCurrent, change in yCurrent, remaining lifetime, and color.
-   *
-   * @param emitterOrigin The current {@link Emitter} origin
-   * @param updateRatio   The update ratio for this particle.
-   */
+  /// Updates the effect's position, change in xCurrent, change in yCurrent, remaining lifetime, and color.
+  ///
+  /// @param emitterOrigin The current [Emitter] origin
+  /// @param updateRatio   The update ratio for this particle.
   public void update(final Point2D emitterOrigin, final float updateRatio) {
     if (this.aliveTick == 0) {
       this.aliveTick = Game.time().now();
@@ -693,13 +574,11 @@ public abstract class Particle implements ITimeToLive {
   }
 
 
-  /**
-   * Test for ray cast collisions
-   *
-   * @param emitterOrigin The current {@link Emitter} origin
-   * @param updateRatio   The update ratio for this particle.
-   * @return True if ray cast collision occurs
-   */
+  /// Test for ray cast collisions
+  ///
+  /// @param emitterOrigin The current [Emitter] origin
+  /// @param updateRatio   The update ratio for this particle.
+  /// @return True if ray cast collision occurs
   protected boolean hasRayCastCollision(final Point2D emitterOrigin, final float updateRatio) {
     final float targetX = this.x + this.getVelocityX() * updateRatio;
     final float targetY = this.y + this.getVelocityY() * updateRatio;
@@ -756,41 +635,33 @@ public abstract class Particle implements ITimeToLive {
     }
   }
 
-  /**
-   * Computes the absolute world location of this particle given an emitter origin.
-   *
-   * @param effectLocation the emitter origin
-   * @return the absolute world location of the particle
-   */
+  /// Computes the absolute world location of this particle given an emitter origin.
+  ///
+  /// @param effectLocation the emitter origin
+  /// @return the absolute world location of the particle
   public Point2D getAbsoluteLocation(final Point2D effectLocation) {
     return new Point2D.Float(getAbsoluteX(effectLocation), getAbsoluteY(effectLocation));
   }
 
-  /**
-   * Computes the absolute world X coordinate of this particle, accounting for the particle's width.
-   *
-   * @param emitterOrigin the emitter origin
-   * @return the absolute X coordinate
-   */
+  /// Computes the absolute world X coordinate of this particle, accounting for the particle's width.
+  ///
+  /// @param emitterOrigin the emitter origin
+  /// @return the absolute X coordinate
   protected float getAbsoluteX(Point2D emitterOrigin) {
     return (float) (emitterOrigin.getX() + this.getX() - this.getWidth() / 2.0);
   }
 
-  /**
-   * Computes the absolute world Y coordinate of this particle, accounting for the particle's height.
-   *
-   * @param emitterOrigin the emitter origin
-   * @return the absolute Y coordinate
-   */
+  /// Computes the absolute world Y coordinate of this particle, accounting for the particle's height.
+  ///
+  /// @param emitterOrigin the emitter origin
+  /// @return the absolute Y coordinate
   protected float getAbsoluteY(Point2D emitterOrigin) {
     return (float) (emitterOrigin.getY() + this.getY() - this.getHeight() / 2.0);
   }
 
-  /**
-   * Returns whether this particle has a custom render type that overrides the emitter's render type.
-   *
-   * @return {@code true} if a custom render type is set
-   */
+  /// Returns whether this particle has a custom render type that overrides the emitter's render type.
+  ///
+  /// @return `true` if a custom render type is set
   public boolean usesCustomRenderType() {
     return useCustomRenderType;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/ParticleType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/ParticleType.java
@@ -1,25 +1,19 @@
 package de.gurkenlabs.litiengine.graphics.emitters.particles;
 
-/**
- * Enumerates the shape/render types supported by the engine's built-in {@link Particle} implementations.
- */
+/// Enumerates the shape/render types supported by the engine's built-in [Particle] implementations.
 public enum ParticleType {
-  /**
-   * Rectangular particle.
-   */
+  /// Rectangular particle.
   RECTANGLE,
-  /**
-   * Elliptic particle.
-   */
+  /// Elliptic particle.
   ELLIPSE,
-  /** Triangular particle. */
+  /// Triangular particle.
   TRIANGLE,
-  /** Diamond-shaped particle. */
+  /// Diamond-shaped particle.
   DIAMOND,
-  /** Line particle. */
+  /// Line particle.
   LINE,
-  /** Text particle. */
+  /// Text particle.
   TEXT,
-  /** Sprite-based particle. */
+  /// Sprite-based particle.
   SPRITE
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/ShapeParticle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/ShapeParticle.java
@@ -8,59 +8,49 @@ import java.awt.Shape;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-/**
- * Represents a particle with a specific shape.
- *
- * <p>This abstract class defines the behavior and rendering logic for particles
- * that are represented by geometric shapes. Subclasses must implement the {@link #getShape(Point2D)} method to define the specific shape of the
- * particle.
- */
+/// Represents a particle with a specific shape.
+///
+/// This abstract class defines the behavior and rendering logic for particles
+/// that are represented by geometric shapes. Subclasses must implement the [#getShape(Point2D)] method to define the specific shape of the
+/// particle.
 public abstract class ShapeParticle extends Particle {
 
-  /**
-   * Creates a new shape particle with the specified dimensions.
-   *
-   * @param width  the width of the particle
-   * @param height the height of the particle
-   */
+  /// Creates a new shape particle with the specified dimensions.
+  ///
+  /// @param width  the width of the particle
+  /// @param height the height of the particle
   protected ShapeParticle(float width, float height) {
     super(width, height);
   }
 
-  /**
-   * Retrieves the shape of the particle based on the emitter's origin.
-   *
-   * <p>This method must be implemented by subclasses to define the specific
-   * shape of the particle.
-   *
-   * @param emitterOrigin the origin point of the emitter
-   * @return the shape of the particle
-   */
+  /// Retrieves the shape of the particle based on the emitter's origin.
+  ///
+  /// This method must be implemented by subclasses to define the specific
+  /// shape of the particle.
+  ///
+  /// @param emitterOrigin the origin point of the emitter
+  /// @return the shape of the particle
   protected abstract Shape getShape(final Point2D emitterOrigin);
 
-  /**
-   * Retrieves the bounding box of the particle.
-   *
-   * <p>The bounding box is calculated based on the particle's shape and the
-   * specified origin point.
-   *
-   * @param origin the origin point of the emitter
-   * @return the bounding box of the particle as a {@link Rectangle2D}
-   */
+  /// Retrieves the bounding box of the particle.
+  ///
+  /// The bounding box is calculated based on the particle's shape and the
+  /// specified origin point.
+  ///
+  /// @param origin the origin point of the emitter
+  /// @return the bounding box of the particle as a [Rectangle2D]
   @Override
   public Rectangle2D getBoundingBox(Point2D origin) {
     return getShape(origin).getBounds2D();
   }
 
-  /**
-   * Renders the particle on the specified graphics context.
-   *
-   * <p>The rendering behavior depends on whether the particle is outline-only
-   * or a specific subclass such as {@link LineParticle}. The particle's color, opacity, and anti-aliasing settings are applied during rendering.
-   *
-   * @param g             the graphics context to render on
-   * @param emitterOrigin the origin point of the emitter
-   */
+  /// Renders the particle on the specified graphics context.
+  ///
+  /// The rendering behavior depends on whether the particle is outline-only
+  /// or a specific subclass such as [LineParticle]. The particle's color, opacity, and anti-aliasing settings are applied during rendering.
+  ///
+  /// @param g             the graphics context to render on
+  /// @param emitterOrigin the origin point of the emitter
   @Override
   public void render(final Graphics2D g, final Point2D emitterOrigin) {
     g.setColor(

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/TextParticle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/particles/TextParticle.java
@@ -10,47 +10,37 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 
-/**
- * Represents a particle that renders text.
- */
+/// Represents a particle that renders text.
 public class TextParticle extends Particle {
   private Font font;
   private final String text;
 
-  /**
-   * Constructs a TextParticle with the specified text.
-   *
-   * @param text The text to be rendered by this particle.
-   */
+  /// Constructs a TextParticle with the specified text.
+  ///
+  /// @param text The text to be rendered by this particle.
   public TextParticle(final String text) {
     super(1, 1);
     this.text = text;
   }
 
-  /**
-   * Gets the font used by this TextParticle.
-   *
-   * @return The font used by this TextParticle.
-   */
+  /// Gets the font used by this TextParticle.
+  ///
+  /// @return The font used by this TextParticle.
   public Font getFont() {
     return this.font;
   }
 
-  /**
-   * Gets the text rendered by this TextParticle.
-   *
-   * @return The text rendered by this TextParticle.
-   */
+  /// Gets the text rendered by this TextParticle.
+  ///
+  /// @return The text rendered by this TextParticle.
   public String getText() {
     return this.text;
   }
 
-  /**
-   * Renders the text particle.
-   *
-   * @param g             The graphics context.
-   * @param emitterOrigin The origin point of the emitter.
-   */
+  /// Renders the text particle.
+  ///
+  /// @param g             The graphics context.
+  /// @param emitterOrigin The origin point of the emitter.
   @Override
   public void render(final Graphics2D g, final Point2D emitterOrigin) {
     if (getText() == null || getText().isEmpty()) {
@@ -81,21 +71,17 @@ public class TextParticle extends Particle {
     g.setRenderingHints(originalHints);
   }
 
-  /**
-   * Sets the font for this TextParticle.
-   *
-   * @param font The font to set.
-   */
+  /// Sets the font for this TextParticle.
+  ///
+  /// @param font The font to set.
   public void setFont(final Font font) {
     this.font = font;
   }
 
-  /**
-   * Gets the bounding box of the text particle.
-   *
-   * @param origin The origin point.
-   * @return The bounding box of the text particle.
-   */
+  /// Gets the bounding box of the text particle.
+  ///
+  /// @param origin The origin point.
+  /// @return The bounding box of the text particle.
   @Override
   public Rectangle2D getBoundingBox(final Point2D origin) {
     return new Rectangle2D.Double(origin.getX() + getX() - getWidth() / 2, origin.getY() + getY() - getHeight() * 1.5,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/xml/EmitterAttributes.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/emitters/xml/EmitterAttributes.java
@@ -23,288 +23,279 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Represents the data structure for a particle emitter.
- * <p>
- * This class is used to serialize and configure emitter properties such as color, particle movement, rendering options, and particle life cycle. It
- * supports XML binding for persistent configurations.
- * </p>
- */
+/// Represents the data structure for a particle emitter.
+///
+/// This class is used to serialize and configure emitter properties such as color, particle movement, rendering options, and particle life cycle. It
+/// supports XML binding for persistent configurations.
 @XmlRootElement(name = "emitter")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class EmitterAttributes implements Serializable, Resource {
-  /**
-   * Default base color used for emitted particles when no colors are configured.
-   */
+  /// Default base color used for emitted particles when no colors are configured.
   public static final Color DEFAULT_COLOR = new Color(0, 165, 188, 204);
-  /**
-   * Default spritesheet name; empty means no spritesheet is associated.
-   */
+  /// Default spritesheet name; empty means no spritesheet is associated.
   public static final String DEFAULT_SPRITESHEET = "";
-  /** Default display name assigned to a newly created emitter. */
+  /// Default display name assigned to a newly created emitter.
   public static final String DEFAULT_NAME = "Custom Emitter";
-  /** Default text content used by text-rendering particles. */
+  /// Default text content used by text-rendering particles.
   public static final String DEFAULT_TEXT = "LITI";
-  /** Default value controlling whether sprite-based particles are animated. */
+  /// Default value controlling whether sprite-based particles are animated.
   public static final boolean DEFAULT_ANIMATE_SPRITE = true;
-  /** Default value controlling whether sprite-based particle animations are looped. */
+  /// Default value controlling whether sprite-based particle animations are looped.
   public static final boolean DEFAULT_LOOP_SPRITE = true;
-  /** Default value controlling whether particles fade out over their lifetime. */
+  /// Default value controlling whether particles fade out over their lifetime.
   public static final boolean DEFAULT_FADE = true;
-  /** Default value controlling whether particles fade upon collision. */
+  /// Default value controlling whether particles fade upon collision.
   public static final boolean DEFAULT_FADE_ON_COLLISION = false;
-  /** Default value controlling whether shape-based particles are rendered as outlines only. */
+  /// Default value controlling whether shape-based particles are rendered as outlines only.
   public static final boolean DEFAULT_OUTLINE_ONLY = false;
-  /** Default value controlling whether particles are rendered with anti-aliasing. */
+  /// Default value controlling whether particles are rendered with anti-aliasing.
   public static final boolean DEFAULT_ANTIALIASING = false;
-  /** Default collision behavior applied to emitted particles. */
+  /// Default collision behavior applied to emitted particles.
   public static final Collision DEFAULT_COLLISION = Collision.NONE;
-  /** Default particle shape/type used when none is specified. */
+  /// Default particle shape/type used when none is specified.
   public static final ParticleType DEFAULT_PARTICLE_TYPE = ParticleType.RECTANGLE;
-  /** Default minimum graphics quality required for the emitter to be rendered. */
+  /// Default minimum graphics quality required for the emitter to be rendered.
   public static final Quality DEFAULT_REQUIRED_QUALITY = Quality.VERYLOW;
-  /** Default horizontal alignment of the emitter origin. */
+  /// Default horizontal alignment of the emitter origin.
   public static final Align DEFAULT_ORIGIN_ALIGN = Align.CENTER;
-  /** Default vertical alignment of the emitter origin. */
+  /// Default vertical alignment of the emitter origin.
   public static final Valign DEFAULT_ORIGIN_VALIGN = Valign.MIDDLE;
-  /** Default emitter width in pixels. */
+  /// Default emitter width in pixels.
   public static final float DEFAULT_WIDTH = 16f;
-  /** Default emitter height in pixels. */
+  /// Default emitter height in pixels.
   public static final float DEFAULT_HEIGHT = 16f;
-  /** Default color variance (0..1) applied per particle. */
+  /// Default color variance (0..1) applied per particle.
   public static final float DEFAULT_COLOR_VARIANCE = 0f;
-  /** Default alpha variance (0..1) applied per particle. */
+  /// Default alpha variance (0..1) applied per particle.
   public static final float DEFAULT_ALPHA_VARIANCE = 0f;
-  /** Default update rate of the emitter in milliseconds. */
+  /// Default update rate of the emitter in milliseconds.
   public static final int DEFAULT_UPDATERATE = 40;
-  /** Default number of particles spawned per spawn tick. */
+  /// Default number of particles spawned per spawn tick.
   public static final int DEFAULT_SPAWNAMOUNT = 20;
-  /** Default spawn rate in milliseconds between spawn ticks. */
+  /// Default spawn rate in milliseconds between spawn ticks.
   public static final int DEFAULT_SPAWNRATE = 100;
-  /** Default maximum number of concurrently alive particles. */
+  /// Default maximum number of concurrently alive particles.
   public static final int DEFAULT_MAXPARTICLES = 400;
-  /** Default emitter duration in milliseconds; {@code 0} means the emitter runs indefinitely. */
+  /// Default emitter duration in milliseconds; `0` means the emitter runs indefinitely.
   public static final int DEFAULT_DURATION = 0;
-  /** Default minimum time-to-live for a particle in milliseconds. */
+  /// Default minimum time-to-live for a particle in milliseconds.
   public static final int DEFAULT_MIN_PARTICLE_TTL = 400;
-  /** Default maximum time-to-live for a particle in milliseconds. */
+  /// Default maximum time-to-live for a particle in milliseconds.
   public static final int DEFAULT_MAX_PARTICLE_TTL = 1500;
-  /** Default minimum horizontal spawn offset relative to the emitter origin. */
+  /// Default minimum horizontal spawn offset relative to the emitter origin.
   public static final float DEFAULT_MIN_OFFSET_X = -4f;
-  /** Default maximum horizontal spawn offset relative to the emitter origin. */
+  /// Default maximum horizontal spawn offset relative to the emitter origin.
   public static final float DEFAULT_MAX_OFFSET_X = 4f;
-  /** Default minimum vertical spawn offset relative to the emitter origin. */
+  /// Default minimum vertical spawn offset relative to the emitter origin.
   public static final float DEFAULT_MIN_OFFSET_Y = -4f;
-  /** Default maximum vertical spawn offset relative to the emitter origin. */
+  /// Default maximum vertical spawn offset relative to the emitter origin.
   public static final float DEFAULT_MAX_OFFSET_Y = 4f;
-  /** Default minimum width delta applied per update to a particle. */
+  /// Default minimum width delta applied per update to a particle.
   public static final float DEFAULT_MIN_DELTA_WIDTH = -.1f;
-  /** Default maximum width delta applied per update to a particle. */
+  /// Default maximum width delta applied per update to a particle.
   public static final float DEFAULT_MAX_DELTA_WIDTH = .1f;
-  /** Default minimum height delta applied per update to a particle. */
+  /// Default minimum height delta applied per update to a particle.
   public static final float DEFAULT_MIN_DELTA_HEIGHT = -.1f;
-  /** Default maximum height delta applied per update to a particle. */
+  /// Default maximum height delta applied per update to a particle.
   public static final float DEFAULT_MAX_DELTA_HEIGHT = .1f;
-  /** Default minimum horizontal acceleration applied to a particle. */
+  /// Default minimum horizontal acceleration applied to a particle.
   public static final float DEFAULT_MIN_ACCELERATION_X = -.01f;
-  /** Default maximum horizontal acceleration applied to a particle. */
+  /// Default maximum horizontal acceleration applied to a particle.
   public static final float DEFAULT_MAX_ACCELERATION_X = .01f;
-  /** Default minimum vertical acceleration applied to a particle. */
+  /// Default minimum vertical acceleration applied to a particle.
   public static final float DEFAULT_MIN_ACCELERATION_Y = -.01f;
-  /** Default maximum vertical acceleration applied to a particle. */
+  /// Default maximum vertical acceleration applied to a particle.
   public static final float DEFAULT_MAX_ACCELERATION_Y = .01f;
-  /** Default minimum starting angle in degrees of a spawned particle. */
+  /// Default minimum starting angle in degrees of a spawned particle.
   public static final float DEFAULT_MIN_ANGLE = 0;
-  /** Default maximum starting angle in degrees of a spawned particle. */
+  /// Default maximum starting angle in degrees of a spawned particle.
   public static final float DEFAULT_MAX_ROTATION = 360;
-  /** Default minimum angle delta applied per update to a particle. */
+  /// Default minimum angle delta applied per update to a particle.
   public static final float DEFAULT_MIN_DELTA_ANGLE = -1;
-  /** Default maximum angle delta applied per update to a particle. */
+  /// Default maximum angle delta applied per update to a particle.
   public static final float DEFAULT_MAX_DELTA_ANGLE = 1;
-  /** Default minimum horizontal velocity of a spawned particle. */
+  /// Default minimum horizontal velocity of a spawned particle.
   public static final float DEFAULT_MIN_VELOCITY_X = -.1f;
-  /** Default maximum horizontal velocity of a spawned particle. */
+  /// Default maximum horizontal velocity of a spawned particle.
   public static final float DEFAULT_MAX_VELOCITY_X = .1f;
-  /** Default minimum vertical velocity of a spawned particle. */
+  /// Default minimum vertical velocity of a spawned particle.
   public static final float DEFAULT_MIN_VELOCITY_Y = -.1f;
-  /** Default maximum vertical velocity of a spawned particle. */
+  /// Default maximum vertical velocity of a spawned particle.
   public static final float DEFAULT_MAX_VELOCITY_Y = .1f;
-  /** Default minimum outline thickness for outline-rendered particles. */
+  /// Default minimum outline thickness for outline-rendered particles.
   public static final float DEFAULT_MIN_OUTLINETHICKNESS = 1f;
-  /** Default maximum outline thickness for outline-rendered particles. */
+  /// Default maximum outline thickness for outline-rendered particles.
   public static final float DEFAULT_MAX_OUTLINETHICKNESS = 1f;
-  /** Default minimum width of a spawned particle. */
+  /// Default minimum width of a spawned particle.
   public static final float DEFAULT_MIN_WIDTH = 2f;
-  /** Default maximum width of a spawned particle. */
+  /// Default maximum width of a spawned particle.
   public static final float DEFAULT_MAX_WIDTH = 6f;
-  /** Default minimum height of a spawned particle. */
+  /// Default minimum height of a spawned particle.
   public static final float DEFAULT_MIN_HEIGHT = 2f;
-  /** Default maximum height of a spawned particle. */
+  /// Default maximum height of a spawned particle.
   public static final float DEFAULT_MAX_HEIGHT = 6f;
   @Serial
   private static final long serialVersionUID = 50238884097993529L;
-  /** Per-particle alpha variance (0..1). */
+  /// Per-particle alpha variance (0..1).
   @XmlElement
   private float alphaVariance;
 
-  /** Whether sprite-based particles are animated. */
+  /// Whether sprite-based particles are animated.
   @XmlElement
   private boolean animateSprite;
 
-  /** Whether sprite-based particle animations are looped. */
+  /// Whether sprite-based particle animations are looped.
   @XmlElement
   private boolean loopSprite;
 
-  /** Collision behavior applied to emitted particles. */
+  /// Collision behavior applied to emitted particles.
   @XmlElement
   private Collision collision;
 
-  /** Minimum graphics quality required for this emitter to be rendered. */
+  /// Minimum graphics quality required for this emitter to be rendered.
   @XmlElement
   private Quality requiredQuality;
 
-  /** Per-particle color variance (0..1). */
+  /// Per-particle color variance (0..1).
   @XmlElement
   private float colorVariance;
 
-  /** Configured list of encoded color strings used when spawning particles. */
+  /// Configured list of encoded color strings used when spawning particles.
   @XmlElementWrapper
   @XmlElement(name = "color")
   private List<String> colors;
 
-  /** Cached list of decoded colors derived from {@link #colors}. */
+  /// Cached list of decoded colors derived from [#colors].
   @XmlTransient
   private List<Color> decodedColors;
 
-  /** Per-particle height delta parameter. */
+  /// Per-particle height delta parameter.
   @XmlElement
   private RangeAttribute<Float> deltaHeight;
 
-  /** Per-particle width delta parameter. */
+  /// Per-particle width delta parameter.
   @XmlElement
   private RangeAttribute<Float> deltaWidth;
 
-  /** Horizontal velocity parameter of spawned particles. */
+  /// Horizontal velocity parameter of spawned particles.
   @XmlElement
   private RangeAttribute<Float> velocityX;
 
-  /** Vertical velocity parameter of spawned particles. */
+  /// Vertical velocity parameter of spawned particles.
   @XmlElement
   private RangeAttribute<Float> velocityY;
 
-  /** Emitter duration in milliseconds; {@code 0} means the emitter runs indefinitely. */
+  /// Emitter duration in milliseconds; `0` means the emitter runs indefinitely.
   @XmlAttribute
   private int emitterDuration;
 
-  /** Whether particles fade out over their lifetime. */
+  /// Whether particles fade out over their lifetime.
   @XmlElement
   private boolean fade;
 
-  /** Whether particles fade upon collision. */
+  /// Whether particles fade upon collision.
   @XmlElement
   private boolean fadeOnCollision;
 
-  /** Whether shape-based particles are rendered as outlines only. */
+  /// Whether shape-based particles are rendered as outlines only.
   @XmlElement
   private boolean outlineOnly;
 
-  /** Whether particles are rendered with anti-aliasing. */
+  /// Whether particles are rendered with anti-aliasing.
   @XmlElement
   private boolean antiAliasing;
 
-  /** Horizontal acceleration parameter of spawned particles. */
+  /// Horizontal acceleration parameter of spawned particles.
   @XmlElement
   private RangeAttribute<Float> accelerationX;
 
-  /** Vertical acceleration parameter of spawned particles. */
+  /// Vertical acceleration parameter of spawned particles.
   @XmlElement
   private RangeAttribute<Float> accelerationY;
 
-  /** Starting angle parameter for spawned particles, in degrees. */
+  /// Starting angle parameter for spawned particles, in degrees.
   @XmlElement
   private RangeAttribute<Float> angle;
 
-  /** Per-particle angle delta parameter, in degrees per update. */
+  /// Per-particle angle delta parameter, in degrees per update.
   @XmlElement
   private RangeAttribute<Float> deltaAngle;
 
-  /** Outline thickness parameter applied to outline-rendered particles. */
+  /// Outline thickness parameter applied to outline-rendered particles.
   @XmlElement
   private RangeAttribute<Float> outlineThickness;
 
-  /** Height of the emitter in pixels. */
+  /// Height of the emitter in pixels.
   @XmlAttribute
   private float height;
 
-  /** Maximum number of concurrently alive particles allowed. */
+  /// Maximum number of concurrently alive particles allowed.
   @XmlAttribute
   private int maxParticles;
 
-  /** Display name of the emitter. */
+  /// Display name of the emitter.
   @XmlAttribute
   private String name;
 
-  /** Horizontal alignment of the emitter origin. */
+  /// Horizontal alignment of the emitter origin.
   @XmlElement
   private Align originAlign;
 
-  /** Vertical alignment of the emitter origin. */
+  /// Vertical alignment of the emitter origin.
   @XmlElement
   private Valign originValign;
 
-  /** Per-particle height parameter. */
+  /// Per-particle height parameter.
   @XmlElement
   private RangeAttribute<Float> particleHeight;
 
-  /** Particle time-to-live (TTL) parameter in milliseconds. */
+  /// Particle time-to-live (TTL) parameter in milliseconds.
   @XmlElement
   private RangeAttribute<Long> particleTTL;
 
-  /** List of texts used by text-rendering particles. */
+  /// List of texts used by text-rendering particles.
   @XmlElementWrapper
   @XmlElement(name = "text")
   private List<String> texts;
 
-  /** Particle shape/type used when spawning particles. */
+  /// Particle shape/type used when spawning particles.
   @XmlAttribute
   private ParticleType particleType;
 
-  /** Per-particle width parameter. */
+  /// Per-particle width parameter.
   @XmlElement
   private RangeAttribute<Float> particleWidth;
 
-  /** Number of particles spawned per spawn tick. */
+  /// Number of particles spawned per spawn tick.
   @XmlAttribute
   private int spawnAmount;
 
-  /** Spawn rate in milliseconds between spawn ticks. */
+  /// Spawn rate in milliseconds between spawn ticks.
   @XmlAttribute
   private int spawnRate;
 
-  /** Name of the spritesheet used by sprite-based particles. */
+  /// Name of the spritesheet used by sprite-based particles.
   @XmlElement
   private String spritesheet;
 
-  /** Update rate of the emitter in milliseconds. */
+  /// Update rate of the emitter in milliseconds.
   @XmlAttribute
   private int updateRate;
 
-  /** Width of the emitter in pixels. */
+  /// Width of the emitter in pixels.
   @XmlAttribute
   private float width;
 
-  /** Horizontal spawn offset parameter relative to the emitter origin. */
+  /// Horizontal spawn offset parameter relative to the emitter origin.
   @XmlElement
   private RangeAttribute<Float> offsetX;
 
-  /** Vertical spawn offset parameter relative to the emitter origin. */
+  /// Vertical spawn offset parameter relative to the emitter origin.
   @XmlElement
   private RangeAttribute<Float> offsetY;
 
-  /**
-   * Creates a new {@code EmitterAttributes} instance and initializes all {@link RangeAttribute} fields and other defaults required for the emitter to be
-   * rendered and updated correctly.
-   */
+  /// Creates a new `EmitterAttributes` instance and initializes all [RangeAttribute] fields and other defaults required for the emitter to be
+  /// rendered and updated correctly.
   public EmitterAttributes() {
     // initialize fields required for rendering and updating properly.
     this.requiredQuality = DEFAULT_REQUIRED_QUALITY;
@@ -329,97 +320,77 @@ public class EmitterAttributes implements Serializable, Resource {
     this.setColor(DEFAULT_COLOR);
   }
 
-  /**
-   * Gets the per-particle alpha variance.
-   *
-   * @return the alpha variance in the range {@code [0, 1]}
-   */
+  /// Gets the per-particle alpha variance.
+  ///
+  /// @return the alpha variance in the range `[0, 1]`
   @XmlTransient
   public float getAlphaVariance() {
     return this.alphaVariance;
   }
 
-  /**
-   * Sets the per-particle alpha variance. The value is clamped to the range {@code [0, 1]}.
-   *
-   * @param alphaVariance the alpha variance to set
-   */
+  /// Sets the per-particle alpha variance. The value is clamped to the range `[0, 1]`.
+  ///
+  /// @param alphaVariance the alpha variance to set
   public void setAlphaVariance(final float alphaVariance) {
     this.alphaVariance = Math.clamp(alphaVariance, 0, 1);
   }
 
-  /**
-   * Gets the collision behavior of emitted particles.
-   *
-   * @return the configured {@link Collision} behavior
-   */
+  /// Gets the collision behavior of emitted particles.
+  ///
+  /// @return the configured [Collision] behavior
   @XmlTransient
   public Collision getCollision() {
     return this.collision;
   }
 
-  /**
-   * Sets the collision behavior of emitted particles.
-   *
-   * @param collision the {@link Collision} behavior to apply
-   */
+  /// Sets the collision behavior of emitted particles.
+  ///
+  /// @param collision the [Collision] behavior to apply
   public void setCollision(final Collision collision) {
     this.collision = collision;
   }
 
-  /**
-   * Gets the minimum graphics {@link Quality} required for this emitter to be rendered.
-   *
-   * @return the required quality
-   */
+  /// Gets the minimum graphics [Quality] required for this emitter to be rendered.
+  ///
+  /// @return the required quality
   @XmlTransient
   public Quality getRequiredQuality() {
     return this.requiredQuality;
   }
 
-  /**
-   * Sets the minimum graphics {@link Quality} required for this emitter to be rendered.
-   *
-   * @param minQuality the minimum required quality
-   */
+  /// Sets the minimum graphics [Quality] required for this emitter to be rendered.
+  ///
+  /// @param minQuality the minimum required quality
   public void setRequiredQuality(final Quality minQuality) {
     this.requiredQuality = minQuality;
   }
 
-  /**
-   * Gets the per-particle color variance.
-   *
-   * @return the color variance in the range {@code [0, 1]}
-   */
+  /// Gets the per-particle color variance.
+  ///
+  /// @return the color variance in the range `[0, 1]`
   @XmlTransient
   public float getColorVariance() {
     return this.colorVariance;
   }
 
-  /**
-   * Sets the per-particle color variance. The value is clamped to the range {@code [0, 1]}.
-   *
-   * @param colorVariance the color variance to set
-   */
+  /// Sets the per-particle color variance. The value is clamped to the range `[0, 1]`.
+  ///
+  /// @param colorVariance the color variance to set
   public void setColorVariance(final float colorVariance) {
     this.colorVariance = Math.clamp(colorVariance, 0, 1);
   }
 
-  /**
-   * Gets the configured list of color strings used when spawning particles.
-   *
-   * @return the list of encoded color strings
-   */
+  /// Gets the configured list of color strings used when spawning particles.
+  ///
+  /// @return the list of encoded color strings
   @XmlTransient
   public List<String> getColors() {
     return this.colors;
   }
 
-  /**
-   * Gets the decoded {@link Color} list derived from the configured color strings. The result is cached after the first call.
-   *
-   * @return the decoded colors, falling back to {@link #DEFAULT_COLOR} for entries that cannot be decoded
-   */
+  /// Gets the decoded [Color] list derived from the configured color strings. The result is cached after the first call.
+  ///
+  /// @return the decoded colors, falling back to [#DEFAULT_COLOR] for entries that cannot be decoded
   public List<Color> getDecodedColors() {
     if (this.decodedColors != null) {
       return this.decodedColors;
@@ -435,240 +406,190 @@ public class EmitterAttributes implements Serializable, Resource {
     return this.decodedColors;
   }
 
-  /**
-   * Sets the list of color strings used when spawning particles and invalidates the decoded color cache.
-   *
-   * @param colors the list of encoded color strings
-   */
+  /// Sets the list of color strings used when spawning particles and invalidates the decoded color cache.
+  ///
+  /// @param colors the list of encoded color strings
   public void setColors(final List<String> colors) {
     this.colors = colors;
     this.decodedColors = null;
   }
 
-  /**
-   * Sets the colors used when spawning particles by encoding the given AWT colors.
-   *
-   * @param colors the colors to apply
-   */
+  /// Sets the colors used when spawning particles by encoding the given AWT colors.
+  ///
+  /// @param colors the colors to apply
   public void setColors(final Color... colors) {
     this.colors = Arrays.stream(colors).map(ColorHelper::encode).toList();
   }
 
-  /**
-   * Gets the per-particle height delta parameter.
-   *
-   * @return the height delta {@link RangeAttribute}
-   */
+  /// Gets the per-particle height delta parameter.
+  ///
+  /// @return the height delta [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getDeltaHeight() {
     return this.deltaHeight;
   }
 
-  /**
-   * Sets the per-particle height delta parameter.
-   *
-   * @param deltaHeight the height delta parameter to set
-   */
+  /// Sets the per-particle height delta parameter.
+  ///
+  /// @param deltaHeight the height delta parameter to set
   public void setDeltaHeight(final RangeAttribute<Float> deltaHeight) {
     this.deltaHeight = deltaHeight;
   }
 
-  /**
-   * Gets the per-particle width delta parameter.
-   *
-   * @return the width delta {@link RangeAttribute}
-   */
+  /// Gets the per-particle width delta parameter.
+  ///
+  /// @return the width delta [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getDeltaWidth() {
     return this.deltaWidth;
   }
 
-  /**
-   * Sets the per-particle width delta parameter.
-   *
-   * @param deltaWidth the width delta parameter to set
-   */
+  /// Sets the per-particle width delta parameter.
+  ///
+  /// @param deltaWidth the width delta parameter to set
   public void setDeltaWidth(final RangeAttribute<Float> deltaWidth) {
     this.deltaWidth = deltaWidth;
   }
 
-  /**
-   * Gets the starting angle parameter for spawned particles.
-   *
-   * @return the angle {@link RangeAttribute}
-   */
+  /// Gets the starting angle parameter for spawned particles.
+  ///
+  /// @return the angle [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getAngle() {
     return this.angle;
   }
 
-  /**
-   * Sets the starting angle parameter for spawned particles.
-   *
-   * @param angle the angle parameter to set
-   */
+  /// Sets the starting angle parameter for spawned particles.
+  ///
+  /// @param angle the angle parameter to set
   public void setAngle(final RangeAttribute<Float> angle) {
     this.angle = angle;
   }
 
-  /**
-   * Gets the per-particle angle delta parameter.
-   *
-   * @return the angle delta {@link RangeAttribute}
-   */
+  /// Gets the per-particle angle delta parameter.
+  ///
+  /// @return the angle delta [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getDeltaAngle() {
     return this.deltaAngle;
   }
 
-  /**
-   * Gets the horizontal velocity parameter of spawned particles.
-   *
-   * @return the horizontal velocity {@link RangeAttribute}
-   */
+  /// Gets the horizontal velocity parameter of spawned particles.
+  ///
+  /// @return the horizontal velocity [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getVelocityX() {
     return this.velocityX;
   }
 
-  /**
-   * Sets the horizontal velocity parameter of spawned particles.
-   *
-   * @param velocityX the horizontal velocity parameter to set
-   */
+  /// Sets the horizontal velocity parameter of spawned particles.
+  ///
+  /// @param velocityX the horizontal velocity parameter to set
   public void setVelocityX(final RangeAttribute<Float> velocityX) {
     this.velocityX = velocityX;
   }
 
-  /**
-   * Gets the vertical velocity parameter of spawned particles.
-   *
-   * @return the vertical velocity {@link RangeAttribute}
-   */
+  /// Gets the vertical velocity parameter of spawned particles.
+  ///
+  /// @return the vertical velocity [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getVelocityY() {
     return this.velocityY;
   }
 
-  /**
-   * Sets the vertical velocity parameter of spawned particles.
-   *
-   * @param velocityY the vertical velocity parameter to set
-   */
+  /// Sets the vertical velocity parameter of spawned particles.
+  ///
+  /// @param velocityY the vertical velocity parameter to set
   public void setVelocityY(final RangeAttribute<Float> velocityY) {
     this.velocityY = velocityY;
   }
 
-  /**
-   * Gets the emitter duration in milliseconds. A value of {@code 0} means the emitter runs indefinitely.
-   *
-   * @return the emitter duration in milliseconds
-   */
+  /// Gets the emitter duration in milliseconds. A value of `0` means the emitter runs indefinitely.
+  ///
+  /// @return the emitter duration in milliseconds
   @XmlTransient
   public int getEmitterDuration() {
     return this.emitterDuration;
   }
 
-  /**
-   * Sets the emitter duration in milliseconds. A value of {@code 0} means the emitter runs indefinitely.
-   *
-   * @param emitterDuration the emitter duration in milliseconds
-   */
+  /// Sets the emitter duration in milliseconds. A value of `0` means the emitter runs indefinitely.
+  ///
+  /// @param emitterDuration the emitter duration in milliseconds
   public void setEmitterDuration(final int emitterDuration) {
     this.emitterDuration = emitterDuration;
   }
 
-  /**
-   * Gets the horizontal acceleration parameter of spawned particles.
-   *
-   * @return the horizontal acceleration {@link RangeAttribute}
-   */
+  /// Gets the horizontal acceleration parameter of spawned particles.
+  ///
+  /// @return the horizontal acceleration [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getAccelerationX() {
     return this.accelerationX;
   }
 
-  /**
-   * Sets the horizontal acceleration parameter of spawned particles.
-   *
-   * @param accelerationX the horizontal acceleration parameter to set
-   */
+  /// Sets the horizontal acceleration parameter of spawned particles.
+  ///
+  /// @param accelerationX the horizontal acceleration parameter to set
   public void setAccelerationX(final RangeAttribute<Float> accelerationX) {
     this.accelerationX = accelerationX;
   }
 
-  /**
-   * Gets the vertical acceleration parameter of spawned particles.
-   *
-   * @return the vertical acceleration {@link RangeAttribute}
-   */
+  /// Gets the vertical acceleration parameter of spawned particles.
+  ///
+  /// @return the vertical acceleration [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getAccelerationY() {
     return this.accelerationY;
   }
 
-  /**
-   * Sets the vertical acceleration parameter of spawned particles.
-   *
-   * @param accelerationY the vertical acceleration parameter to set
-   */
+  /// Sets the vertical acceleration parameter of spawned particles.
+  ///
+  /// @param accelerationY the vertical acceleration parameter to set
   public void setAccelerationY(final RangeAttribute<Float> accelerationY) {
     this.accelerationY = accelerationY;
   }
 
-  /**
-   * Gets the outline thickness parameter applied to outline-rendered particles.
-   *
-   * @return the outline thickness {@link RangeAttribute}
-   */
+  /// Gets the outline thickness parameter applied to outline-rendered particles.
+  ///
+  /// @return the outline thickness [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getOutlineThickness() {
     return this.outlineThickness;
   }
 
-  /**
-   * Sets the outline thickness parameter applied to outline-rendered particles.
-   *
-   * @param outlineThickness the outline thickness parameter to set
-   */
+  /// Sets the outline thickness parameter applied to outline-rendered particles.
+  ///
+  /// @param outlineThickness the outline thickness parameter to set
   public void setOutlineThickness(final RangeAttribute<Float> outlineThickness) {
     this.outlineThickness = outlineThickness;
   }
 
-  /**
-   * Gets the height of the emitter in pixels.
-   *
-   * @return the emitter height
-   */
+  /// Gets the height of the emitter in pixels.
+  ///
+  /// @return the emitter height
   @XmlTransient
   public float getHeight() {
     return this.height;
   }
 
-  /**
-   * Sets the height of the emitter in pixels.
-   *
-   * @param height the emitter height to set
-   */
+  /// Sets the height of the emitter in pixels.
+  ///
+  /// @param height the emitter height to set
   public void setHeight(final float height) {
     this.height = height;
   }
 
-  /**
-   * Gets the maximum number of concurrently alive particles allowed for this emitter.
-   *
-   * @return the maximum number of particles
-   */
+  /// Gets the maximum number of concurrently alive particles allowed for this emitter.
+  ///
+  /// @return the maximum number of particles
   @XmlTransient
   public int getMaxParticles() {
     return this.maxParticles;
   }
 
-  /**
-   * Sets the maximum number of concurrently alive particles allowed for this emitter.
-   *
-   * @param maxParticles the maximum number of particles
-   */
+  /// Sets the maximum number of concurrently alive particles allowed for this emitter.
+  ///
+  /// @param maxParticles the maximum number of particles
   public void setMaxParticles(final int maxParticles) {
     this.maxParticles = maxParticles;
   }
@@ -684,258 +605,204 @@ public class EmitterAttributes implements Serializable, Resource {
     this.name = name;
   }
 
-  /**
-   * Gets the horizontal alignment of the emitter origin.
-   *
-   * @return the horizontal origin alignment
-   */
+  /// Gets the horizontal alignment of the emitter origin.
+  ///
+  /// @return the horizontal origin alignment
   @XmlTransient
   public Align getOriginAlign() {
     return this.originAlign;
   }
 
-  /**
-   * Sets the horizontal alignment of the emitter origin.
-   *
-   * @param align the horizontal origin alignment to set
-   */
+  /// Sets the horizontal alignment of the emitter origin.
+  ///
+  /// @param align the horizontal origin alignment to set
   public void setOriginAlign(final Align align) {
     this.originAlign = align;
   }
 
-  /**
-   * Gets the vertical alignment of the emitter origin.
-   *
-   * @return the vertical origin alignment
-   */
+  /// Gets the vertical alignment of the emitter origin.
+  ///
+  /// @return the vertical origin alignment
   @XmlTransient
   public Valign getOriginValign() {
     return this.originValign;
   }
 
-  /**
-   * Sets the vertical alignment of the emitter origin.
-   *
-   * @param valign the vertical origin alignment to set
-   */
+  /// Sets the vertical alignment of the emitter origin.
+  ///
+  /// @param valign the vertical origin alignment to set
   public void setOriginValign(final Valign valign) {
     this.originValign = valign;
   }
 
-  /**
-   * Gets the per-particle height parameter.
-   *
-   * @return the particle height {@link RangeAttribute}
-   */
+  /// Gets the per-particle height parameter.
+  ///
+  /// @return the particle height [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getParticleHeight() {
     return this.particleHeight;
   }
 
-  /**
-   * Sets the per-particle height parameter.
-   *
-   * @param particleHeight the particle height parameter to set
-   */
+  /// Sets the per-particle height parameter.
+  ///
+  /// @param particleHeight the particle height parameter to set
   public void setParticleHeight(final RangeAttribute<Float> particleHeight) {
     this.particleHeight = particleHeight;
   }
 
-  /**
-   * Gets the particle time-to-live (TTL) parameter, in milliseconds.
-   *
-   * @return the particle TTL {@link RangeAttribute}
-   */
+  /// Gets the particle time-to-live (TTL) parameter, in milliseconds.
+  ///
+  /// @return the particle TTL [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Long> getParticleTTL() {
     return this.particleTTL;
   }
 
-  /**
-   * Sets the particle time-to-live (TTL) parameter, in milliseconds.
-   *
-   * @param particleTTL the particle TTL parameter to set
-   */
+  /// Sets the particle time-to-live (TTL) parameter, in milliseconds.
+  ///
+  /// @param particleTTL the particle TTL parameter to set
   public void setParticleTTL(final RangeAttribute<Long> particleTTL) {
     this.particleTTL = particleTTL;
   }
 
-  /**
-   * Gets the list of text strings used by text-rendering particles.
-   *
-   * @return the list of texts
-   */
+  /// Gets the list of text strings used by text-rendering particles.
+  ///
+  /// @return the list of texts
   @XmlTransient
   public List<String> getTexts() {
     return this.texts;
   }
 
-  /**
-   * Sets the list of text strings used by text-rendering particles.
-   *
-   * @param texts the list of texts
-   */
+  /// Sets the list of text strings used by text-rendering particles.
+  ///
+  /// @param texts the list of texts
   public void setTexts(final List<String> texts) {
     this.texts = texts;
   }
 
-  /**
-   * Gets the particle type (shape) used when spawning particles.
-   *
-   * @return the particle type
-   */
+  /// Gets the particle type (shape) used when spawning particles.
+  ///
+  /// @return the particle type
   @XmlTransient
   public ParticleType getParticleType() {
     return this.particleType;
   }
 
-  /**
-   * Sets the particle type (shape) used when spawning particles.
-   *
-   * @param particleType the particle type to set
-   */
+  /// Sets the particle type (shape) used when spawning particles.
+  ///
+  /// @param particleType the particle type to set
   public void setParticleType(final ParticleType particleType) {
     this.particleType = particleType;
   }
 
-  /**
-   * Gets the per-particle width parameter.
-   *
-   * @return the particle width {@link RangeAttribute}
-   */
+  /// Gets the per-particle width parameter.
+  ///
+  /// @return the particle width [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getParticleWidth() {
     return this.particleWidth;
   }
 
-  /**
-   * Sets the per-particle width parameter.
-   *
-   * @param particleWidth the particle width parameter to set
-   */
+  /// Sets the per-particle width parameter.
+  ///
+  /// @param particleWidth the particle width parameter to set
   public void setParticleWidth(final RangeAttribute<Float> particleWidth) {
     this.particleWidth = particleWidth;
   }
 
-  /**
-   * Gets the horizontal spawn offset parameter relative to the emitter origin.
-   *
-   * @return the horizontal offset {@link RangeAttribute}
-   */
+  /// Gets the horizontal spawn offset parameter relative to the emitter origin.
+  ///
+  /// @return the horizontal offset [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getParticleOffsetX() {
     return this.offsetX;
   }
 
-  /**
-   * Sets the horizontal spawn offset parameter relative to the emitter origin.
-   *
-   * @param x the horizontal offset parameter to set
-   */
+  /// Sets the horizontal spawn offset parameter relative to the emitter origin.
+  ///
+  /// @param x the horizontal offset parameter to set
   public void setParticleOffsetX(final RangeAttribute<Float> x) {
     this.offsetX = x;
   }
 
-  /**
-   * Gets the vertical spawn offset parameter relative to the emitter origin.
-   *
-   * @return the vertical offset {@link RangeAttribute}
-   */
+  /// Gets the vertical spawn offset parameter relative to the emitter origin.
+  ///
+  /// @return the vertical offset [RangeAttribute]
   @XmlTransient
   public RangeAttribute<Float> getParticleOffsetY() {
     return this.offsetY;
   }
 
-  /**
-   * Sets the vertical spawn offset parameter relative to the emitter origin.
-   *
-   * @param y the vertical offset parameter to set
-   */
+  /// Sets the vertical spawn offset parameter relative to the emitter origin.
+  ///
+  /// @param y the vertical offset parameter to set
   public void setParticleOffsetY(final RangeAttribute<Float> y) {
     this.offsetY = y;
   }
 
-  /**
-   * Gets the number of particles that are spawned per spawn tick.
-   *
-   * @return the spawn amount
-   */
+  /// Gets the number of particles that are spawned per spawn tick.
+  ///
+  /// @return the spawn amount
   @XmlTransient
   public int getSpawnAmount() {
     return this.spawnAmount;
   }
 
-  /**
-   * Sets the number of particles that are spawned per spawn tick.
-   *
-   * @param spawnAmount the spawn amount to set
-   */
+  /// Sets the number of particles that are spawned per spawn tick.
+  ///
+  /// @param spawnAmount the spawn amount to set
   public void setSpawnAmount(final int spawnAmount) {
     this.spawnAmount = spawnAmount;
   }
 
-  /**
-   * Gets the spawn rate in milliseconds between spawn ticks.
-   *
-   * @return the spawn rate
-   */
+  /// Gets the spawn rate in milliseconds between spawn ticks.
+  ///
+  /// @return the spawn rate
   @XmlTransient
   public int getSpawnRate() {
     return this.spawnRate;
   }
 
-  /**
-   * Sets the spawn rate in milliseconds between spawn ticks.
-   *
-   * @param spawnRate the spawn rate to set
-   */
+  /// Sets the spawn rate in milliseconds between spawn ticks.
+  ///
+  /// @param spawnRate the spawn rate to set
   public void setSpawnRate(final int spawnRate) {
     this.spawnRate = spawnRate;
   }
 
-  /**
-   * Gets the name of the spritesheet used by sprite-based particles.
-   *
-   * @return the spritesheet name
-   */
+  /// Gets the name of the spritesheet used by sprite-based particles.
+  ///
+  /// @return the spritesheet name
   @XmlTransient
   public String getSpritesheet() {
     return this.spritesheet;
   }
 
-  /**
-   * Sets the name of the spritesheet used by sprite-based particles.
-   *
-   * @param spritesheetName the spritesheet name
-   */
+  /// Sets the name of the spritesheet used by sprite-based particles.
+  ///
+  /// @param spritesheetName the spritesheet name
   public void setSpritesheet(final String spritesheetName) {
     this.spritesheet = spritesheetName;
   }
 
-  /**
-   * Sets the spritesheet used by sprite-based particles using a {@link Spritesheet} reference.
-   *
-   * @param spritesheet the spritesheet whose name will be stored
-   */
+  /// Sets the spritesheet used by sprite-based particles using a [Spritesheet] reference.
+  ///
+  /// @param spritesheet the spritesheet whose name will be stored
   public void setSpritesheet(final Spritesheet spritesheet) {
     this.spritesheet = spritesheet.getName();
   }
 
-  /**
-   * Gets the update rate of the emitter in milliseconds.
-   *
-   * @return the update rate
-   */
+  /// Gets the update rate of the emitter in milliseconds.
+  ///
+  /// @return the update rate
   @XmlTransient
   public int getUpdateRate() {
     return this.updateRate;
   }
 
-  /**
-   * Sets the update rate of the emitter in milliseconds. A value of {@code 0} is ignored.
-   *
-   * @param updateRate the update rate to set
-   */
+  /// Sets the update rate of the emitter in milliseconds. A value of `0` is ignored.
+  ///
+  /// @param updateRate the update rate to set
   public void setUpdateRate(final int updateRate) {
     if (updateRate == 0) {
       return;
@@ -944,120 +811,94 @@ public class EmitterAttributes implements Serializable, Resource {
     this.updateRate = updateRate;
   }
 
-  /**
-   * Gets the width of the emitter in pixels.
-   *
-   * @return the emitter width
-   */
+  /// Gets the width of the emitter in pixels.
+  ///
+  /// @return the emitter width
   @XmlTransient
   public float getWidth() {
     return this.width;
   }
 
-  /**
-   * Sets the width of the emitter in pixels.
-   *
-   * @param width the emitter width to set
-   */
+  /// Sets the width of the emitter in pixels.
+  ///
+  /// @param width the emitter width to set
   public void setWidth(final float width) {
     this.width = width;
   }
 
-  /**
-   * Returns whether sprite-based particles are animated.
-   *
-   * @return {@code true} if sprite animation is enabled
-   */
+  /// Returns whether sprite-based particles are animated.
+  ///
+  /// @return `true` if sprite animation is enabled
   public boolean isAnimatingSprite() {
     return this.animateSprite;
   }
 
-  /**
-   * Returns whether sprite-based particle animations are looped.
-   *
-   * @return {@code true} if sprite looping is enabled
-   */
+  /// Returns whether sprite-based particle animations are looped.
+  ///
+  /// @return `true` if sprite looping is enabled
   public boolean isLoopingSprite() {
     return this.loopSprite;
   }
 
-  /**
-   * Returns whether particles fade out over their lifetime.
-   *
-   * @return {@code true} if particles fade
-   */
+  /// Returns whether particles fade out over their lifetime.
+  ///
+  /// @return `true` if particles fade
   public boolean isFading() {
     return this.fade;
   }
 
-  /**
-   * Returns whether particles fade upon collision.
-   *
-   * @return {@code true} if particles fade on collision
-   */
+  /// Returns whether particles fade upon collision.
+  ///
+  /// @return `true` if particles fade on collision
   public boolean isFadingOnCollision() {
     return this.fadeOnCollision;
   }
 
-  /**
-   * Returns whether shape-based particles are rendered as outlines only.
-   *
-   * @return {@code true} if outline-only rendering is enabled
-   */
+  /// Returns whether shape-based particles are rendered as outlines only.
+  ///
+  /// @return `true` if outline-only rendering is enabled
   public boolean isOutlineOnly() {
     return this.outlineOnly;
   }
 
-  /**
-   * Sets whether shape-based particles are rendered as outlines only.
-   *
-   * @param outlineOnly {@code true} to enable outline-only rendering
-   */
+  /// Sets whether shape-based particles are rendered as outlines only.
+  ///
+  /// @param outlineOnly `true` to enable outline-only rendering
   public void setOutlineOnly(final boolean outlineOnly) {
     this.outlineOnly = outlineOnly;
   }
 
-  /**
-   * Returns whether particles are rendered with anti-aliasing.
-   *
-   * @return {@code true} if anti-aliasing is enabled
-   */
+  /// Returns whether particles are rendered with anti-aliasing.
+  ///
+  /// @return `true` if anti-aliasing is enabled
   public boolean isAntiAliased() {
     return this.antiAliasing;
   }
 
-  /**
-   * Sets whether sprite-based particles are animated.
-   *
-   * @param animateSprite {@code true} to enable sprite animation
-   */
+  /// Sets whether sprite-based particles are animated.
+  ///
+  /// @param animateSprite `true` to enable sprite animation
   public void setAnimateSprite(final boolean animateSprite) {
     this.animateSprite = animateSprite;
   }
 
-  /**
-   * Sets whether sprite-based particle animations are looped.
-   *
-   * @param loopSprite {@code true} to enable sprite looping
-   */
+  /// Sets whether sprite-based particle animations are looped.
+  ///
+  /// @param loopSprite `true` to enable sprite looping
   public void setLoopSprite(final boolean loopSprite) {
     this.loopSprite = loopSprite;
   }
 
-  /**
-   * Sets a single color used for spawning particles, replacing any previously configured colors.
-   *
-   * @param color the color to set
-   */
+  /// Sets a single color used for spawning particles, replacing any previously configured colors.
+  ///
+  /// @param color the color to set
   public void setColor(final Color color) {
     final List<String> tmpList = new ArrayList<>();
     tmpList.add(ColorHelper.encode(color));
     this.colors = tmpList;
   }
 
-  /**
-   * Initializes all configurable emitter and particle parameters to their {@code DEFAULT_*} values.
-   */
+  /// Initializes all configurable emitter and particle parameters to their `DEFAULT_*` values.
   public void initDefaults() {
     this.width = DEFAULT_WIDTH;
     this.height = DEFAULT_HEIGHT;
@@ -1111,47 +952,37 @@ public class EmitterAttributes implements Serializable, Resource {
     this.antiAliasing = DEFAULT_ANTIALIASING;
   }
 
-  /**
-   * Sets the per-particle angle delta parameter.
-   *
-   * @param deltaRotation the angle delta parameter to set
-   */
+  /// Sets the per-particle angle delta parameter.
+  ///
+  /// @param deltaRotation the angle delta parameter to set
   public void setDeltaRotation(final RangeAttribute<Float> deltaRotation) {
     this.deltaAngle = deltaRotation;
   }
 
-  /**
-   * Sets whether particles fade out over their lifetime.
-   *
-   * @param fade {@code true} to enable fading
-   */
+  /// Sets whether particles fade out over their lifetime.
+  ///
+  /// @param fade `true` to enable fading
   public void setFade(final boolean fade) {
     this.fade = fade;
   }
 
-  /**
-   * Sets whether particles fade upon collision.
-   *
-   * @param fadeOnCollision {@code true} to enable fade-on-collision
-   */
+  /// Sets whether particles fade upon collision.
+  ///
+  /// @param fadeOnCollision `true` to enable fade-on-collision
   public void setFadeOnCollision(final boolean fadeOnCollision) {
     this.fadeOnCollision = fadeOnCollision;
   }
 
-  /**
-   * Sets whether particles are rendered with anti-aliasing.
-   *
-   * @param antiAliasing {@code true} to enable anti-aliasing
-   */
+  /// Sets whether particles are rendered with anti-aliasing.
+  ///
+  /// @param antiAliasing `true` to enable anti-aliasing
   public void setAntiAliasing(final boolean antiAliasing) {
     this.antiAliasing = antiAliasing;
   }
 
-  /**
-   * Sets a single text used by text-rendering particles, replacing any previously configured texts.
-   *
-   * @param text the text to set
-   */
+  /// Sets a single text used by text-rendering particles, replacing any previously configured texts.
+  ///
+  /// @param text the text to set
   public void setText(final String text) {
     final List<String> tmpList = new ArrayList<>();
     tmpList.add(text);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/graphics/package-info.java
@@ -1,0 +1,6 @@
+/// Cameras, renderers, animation, lighting, image effects, and other visual engine services.
+///
+/// [de.gurkenlabs.litiengine.graphics.RenderEngine] draws the active environment through an
+/// [de.gurkenlabs.litiengine.graphics.ICamera]. Implement
+/// [de.gurkenlabs.litiengine.graphics.IRenderable] for custom render-loop content.
+package de.gurkenlabs.litiengine.graphics;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Appearance.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Appearance.java
@@ -9,83 +9,55 @@ import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
-/**
- * Represents the appearance settings for a GUI component.
- */
+/// Represents the appearance settings for a GUI component.
 public class Appearance {
-  /**
-   * A list of consumers to be notified when the appearance changes.
-   */
+  /// A list of consumers to be notified when the appearance changes.
   private final List<Consumer<Appearance>> changedConsumer;
-  /**
-   * The foreground color.
-   */
+  /// The foreground color.
   private Color foreColor;
-  /**
-   * The first background color.
-   */
+  /// The first background color.
   private Color backgroundColor1;
-  /**
-   * The second background color.
-   */
+  /// The second background color.
   private Color backgroundColor2;
-  /**
-   * The border color.
-   */
+  /// The border color.
   private Color borderColor;
-  /**
-   * The border style.
-   */
+  /// The border style.
   private Stroke borderStyle;
-  /**
-   * The border radius.
-   */
+  /// The border radius.
   private float borderRadius;
-  /**
-   * Indicates if the background gradient is horizontal.
-   */
+  /// Indicates if the background gradient is horizontal.
   private boolean horizontalBackgroundGradient;
-  /**
-   * Indicates if the background is transparent.
-   */
+  /// Indicates if the background is transparent.
   private boolean transparentBackground;
 
-  /**
-   * Constructs a new Appearance with default settings.
-   */
+  /// Constructs a new Appearance with default settings.
   public Appearance() {
     this.changedConsumer = new CopyOnWriteArrayList<>();
   }
 
-  /**
-   * Constructs a new Appearance with the specified foreground color.
-   *
-   * @param foreColor the foreground color
-   */
+  /// Constructs a new Appearance with the specified foreground color.
+  ///
+  /// @param foreColor the foreground color
   public Appearance(Color foreColor) {
     this();
     this.foreColor = foreColor;
     this.setTransparentBackground(true);
   }
 
-  /**
-   * Constructs a new Appearance with the specified foreground and background colors.
-   *
-   * @param foreColor the foreground color
-   * @param backColor the background color
-   */
+  /// Constructs a new Appearance with the specified foreground and background colors.
+  ///
+  /// @param foreColor the foreground color
+  /// @param backColor the background color
   public Appearance(Color foreColor, Color backColor) {
     this();
     this.foreColor = foreColor;
     this.backgroundColor1 = backColor;
   }
 
-  /**
-   * Compares this Appearance object to the specified object for equality.
-   *
-   * @param obj the object to compare with
-   * @return true if the specified object is equal to this Appearance, false otherwise
-   */
+  /// Compares this Appearance object to the specified object for equality.
+  ///
+  /// @param obj the object to compare with
+  /// @return true if the specified object is equal to this Appearance, false otherwise
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -104,11 +76,9 @@ public class Appearance {
       && Objects.equals(this.foreColor, app.foreColor);
   }
 
-  /**
-   * Returns a hash code value for this Appearance object.
-   *
-   * @return a hash code value for this Appearance object
-   */
+  /// Returns a hash code value for this Appearance object.
+  ///
+  /// @return a hash code value for this Appearance object
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -122,40 +92,32 @@ public class Appearance {
       this.foreColor);
   }
 
-  /**
-   * Gets the foreground color.
-   *
-   * @return the foreground color
-   */
+  /// Gets the foreground color.
+  ///
+  /// @return the foreground color
   public Color getForeColor() {
     return foreColor;
   }
 
-  /**
-   * Gets the first background color.
-   *
-   * @return the first background color
-   */
+  /// Gets the first background color.
+  ///
+  /// @return the first background color
   public Color getBackgroundColor1() {
     return this.backgroundColor1;
   }
 
-  /**
-   * Gets the second background color.
-   *
-   * @return the second background color
-   */
+  /// Gets the second background color.
+  ///
+  /// @return the second background color
   public Color getBackgroundColor2() {
     return this.backgroundColor2;
   }
 
-  /**
-   * Gets the background paint for the specified dimensions.
-   *
-   * @param width  the width of the component
-   * @param height the height of the component
-   * @return the background paint, or null if the background is transparent
-   */
+  /// Gets the background paint for the specified dimensions.
+  ///
+  /// @param width  the width of the component
+  /// @param height the height of the component
+  /// @return the background paint, or null if the background is transparent
   public Paint getBackgroundPaint(double width, double height) {
     if (this.isTransparentBackground()) {
       return null;
@@ -175,142 +137,112 @@ public class Appearance {
     }
   }
 
-  /**
-   * Gets the border color.
-   *
-   * @return the border color
-   */
+  /// Gets the border color.
+  ///
+  /// @return the border color
   public Color getBorderColor() {
     return this.borderColor;
   }
 
-  /**
-   * Gets the border style.
-   *
-   * @return the border style
-   */
+  /// Gets the border style.
+  ///
+  /// @return the border style
   public Stroke getBorderStyle() {
     return this.borderStyle;
   }
 
-  /**
-   * Gets the border radius.
-   *
-   * @return the border radius
-   */
+  /// Gets the border radius.
+  ///
+  /// @return the border radius
   public float getBorderRadius() {
     return this.borderRadius;
   }
 
-  /**
-   * Checks if the background gradient is horizontal.
-   *
-   * @return true if the background gradient is horizontal, false otherwise
-   */
+  /// Checks if the background gradient is horizontal.
+  ///
+  /// @return true if the background gradient is horizontal, false otherwise
   public boolean isHorizontalBackgroundGradient() {
     return this.horizontalBackgroundGradient;
   }
 
-  /**
-   * Checks if the background is transparent.
-   *
-   * @return true if the background is transparent, false otherwise
-   */
+  /// Checks if the background is transparent.
+  ///
+  /// @return true if the background is transparent, false otherwise
   public boolean isTransparentBackground() {
     return transparentBackground;
   }
 
-  /**
-   * Sets the foreground color and triggers a change event.
-   *
-   * @param foreColor the new foreground color
-   */
+  /// Sets the foreground color and triggers a change event.
+  ///
+  /// @param foreColor the new foreground color
   public void setForeColor(Color foreColor) {
     this.foreColor = foreColor;
     this.fireOnChangeEvent();
   }
 
-  /**
-   * Sets the first background color and triggers a change event.
-   *
-   * @param backColor1 the new first background color
-   */
+  /// Sets the first background color and triggers a change event.
+  ///
+  /// @param backColor1 the new first background color
   public void setBackgroundColor1(Color backColor1) {
     this.backgroundColor1 = backColor1;
     this.fireOnChangeEvent();
   }
 
-  /**
-   * Sets the second background color and triggers a change event.
-   *
-   * @param backColor2 the new second background color
-   */
+  /// Sets the second background color and triggers a change event.
+  ///
+  /// @param backColor2 the new second background color
   public void setBackgroundColor2(Color backColor2) {
     this.backgroundColor2 = backColor2;
     this.fireOnChangeEvent();
   }
 
-  /**
-   * Sets the border color.
-   *
-   * @param color the new border color
-   */
+  /// Sets the border color.
+  ///
+  /// @param color the new border color
   public void setBorderColor(Color color) {
     this.borderColor = color;
   }
 
-  /**
-   * Sets the border style.
-   *
-   * @param style the new border style
-   */
+  /// Sets the border style.
+  ///
+  /// @param style the new border style
   public void setBorderStyle(Stroke style) {
     this.borderStyle = style;
   }
 
-  /**
-   * Sets the border radius.
-   *
-   * @param radius the new border radius
-   */
+  /// Sets the border radius.
+  ///
+  /// @param radius the new border radius
   public void setBorderRadius(float radius) {
     this.borderRadius = radius;
   }
 
-  /**
-   * Sets whether the background gradient is horizontal and triggers a change event.
-   *
-   * @param horizontal true if the background gradient is horizontal, false otherwise
-   */
+  /// Sets whether the background gradient is horizontal and triggers a change event.
+  ///
+  /// @param horizontal true if the background gradient is horizontal, false otherwise
   public void setHorizontalBackgroundGradient(boolean horizontal) {
     this.horizontalBackgroundGradient = horizontal;
     this.fireOnChangeEvent();
   }
 
-  /**
-   * Sets whether the background is transparent and triggers a change event.
-   *
-   * @param transparentBackground true if the background is transparent, false otherwise
-   */
+  /// Sets whether the background is transparent and triggers a change event.
+  ///
+  /// @param transparentBackground true if the background is transparent, false otherwise
   public void setTransparentBackground(boolean transparentBackground) {
     this.transparentBackground = transparentBackground;
     this.fireOnChangeEvent();
   }
 
-  /**
-   * Adds a consumer to be notified when the appearance changes.
-   *
-   * @param cons the consumer to be added
-   */
+  /// Adds a consumer to be notified when the appearance changes.
+  ///
+  /// @param cons the consumer to be added
   public void onChange(Consumer<Appearance> cons) {
     this.changedConsumer.add(cons);
   }
 
-  /**
-   * Updates the appearance settings with the values from the specified Appearance object.
-   *
-   * @param updateAppearance the Appearance object containing the new settings
-   */
+  /// Updates the appearance settings with the values from the specified Appearance object.
+  ///
+  /// @param updateAppearance the Appearance object containing the new settings
   public void update(Appearance updateAppearance) {
     this.setBackgroundColor1(updateAppearance.getBackgroundColor1());
     this.setBackgroundColor2(updateAppearance.getBackgroundColor2());
@@ -322,9 +254,7 @@ public class Appearance {
     this.setTransparentBackground(updateAppearance.isTransparentBackground());
   }
 
-  /**
-   * Triggers the change event for all registered consumers.
-   */
+  /// Triggers the change event for all registered consumers.
   protected void fireOnChangeEvent() {
     for (Consumer<Appearance> cons : this.changedConsumer) {
       cons.accept(this);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/CheckBox.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/CheckBox.java
@@ -7,29 +7,25 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
-/**
- * A GUI component representing a checkbox with an optional spritesheet.
- */
+/// A GUI component representing a checkbox with an optional spritesheet.
 public class CheckBox extends ImageComponent {
-  /** The icon representing a checked state. */
+  /// The icon representing a checked state.
   public static final FontIcon CHECK = new FontIcon(ICON_FONT, "\uE847");
-  /** The icon representing an unchecked state. */
+  /// The icon representing an unchecked state.
   public static final FontIcon CROSS = new FontIcon(ICON_FONT, "\uE843");
-  /** A list of consumers to be notified when the checked state changes. */
+  /// A list of consumers to be notified when the checked state changes.
   private final List<Consumer<Boolean>> changeConsumer;
-  /** The current checked state of the checkbox. */
+  /// The current checked state of the checkbox.
   private boolean checked;
 
-  /**
-   * Constructs a new CheckBox.
-   *
-   * @param x the x-coordinate of the checkbox
-   * @param y the y-coordinate of the checkbox
-   * @param width the width of the checkbox
-   * @param height the height of the checkbox
-   * @param spritesheet the spritesheet for the checkbox
-   * @param checked the initial checked state of the checkbox
-   */
+  /// Constructs a new CheckBox.
+  ///
+  /// @param x the x-coordinate of the checkbox
+  /// @param y the y-coordinate of the checkbox
+  /// @param width the width of the checkbox
+  /// @param height the height of the checkbox
+  /// @param spritesheet the spritesheet for the checkbox
+  /// @param checked the initial checked state of the checkbox
   public CheckBox(
     final double x,
     final double y,
@@ -52,47 +48,37 @@ public class CheckBox extends ImageComponent {
     Input.keyboard().onKeyTyped(KeyEvent.VK_SPACE, e -> this.handleTriggerInput());
   }
 
-  /**
-   * Gets the list of consumers to be notified when the checked state changes.
-   *
-   * @return the list of change consumers
-   */
+  /// Gets the list of consumers to be notified when the checked state changes.
+  ///
+  /// @return the list of change consumers
   public List<Consumer<Boolean>> getChangeConsumer() {
     return this.changeConsumer;
   }
 
-  /**
-   * Checks if the checkbox is currently checked.
-   *
-   * @return true if the checkbox is checked, false otherwise
-   */
+  /// Checks if the checkbox is currently checked.
+  ///
+  /// @return true if the checkbox is checked, false otherwise
   public boolean isChecked() {
     return this.checked;
   }
 
-  /**
-   * Adds a consumer to be notified when the checked state changes.
-   *
-   * @param c the consumer to be added
-   */
+  /// Adds a consumer to be notified when the checked state changes.
+  ///
+  /// @param c the consumer to be added
   public void onChange(final Consumer<Boolean> c) {
     this.getChangeConsumer().add(c);
   }
 
-  /**
-   * Sets the checked state of the checkbox.
-   *
-   * @param checked the new checked state
-   */
+  /// Sets the checked state of the checkbox.
+  ///
+  /// @param checked the new checked state
   public void setChecked(final boolean checked) {
     this.checked = checked;
     this.getChangeConsumer().forEach(consumer -> consumer.accept(this.isChecked()));
     this.refreshText();
   }
 
-  /**
-   * Updates the text of the checkbox based on its checked state.
-   */
+  /// Updates the text of the checkbox based on its checked state.
   private void refreshText() {
     if (this.checked) {
       this.setText(CHECK.getText());
@@ -101,9 +87,7 @@ public class CheckBox extends ImageComponent {
     }
   }
 
-  /**
-   * Toggles the checked state of the checkbox.
-   */
+  /// Toggles the checked state of the checkbox.
   private void toggleChecked() {
     this.setChecked(!this.checked);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentMouseEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentMouseEvent.java
@@ -2,44 +2,36 @@ package de.gurkenlabs.litiengine.gui;
 
 import java.awt.event.MouseEvent;
 
-/**
- * A ComponentMouseEvent contains the original MouseEvent and the GuiComponent that sent the event as sender.
- */
+/// A ComponentMouseEvent contains the original MouseEvent and the GuiComponent that sent the event as sender.
 public class ComponentMouseEvent {
 
-  /** The event. */
+  /// The event.
   private final MouseEvent event;
 
-  /** The sender. */
+  /// The sender.
   private final GuiComponent sender;
 
-  /**
-   * Instantiates a new component mouse event.
-   *
-   * @param event
-   *          the event
-   * @param sender
-   *          the sender
-   */
+  /// Instantiates a new component mouse event.
+  ///
+  /// @param event
+  /// the event
+  /// @param sender
+  /// the sender
   public ComponentMouseEvent(final MouseEvent event, final GuiComponent sender) {
     this.event = event;
     this.sender = sender;
   }
 
-  /**
-   * Gets the event.
-   *
-   * @return the event
-   */
+  /// Gets the event.
+  ///
+  /// @return the event
   public MouseEvent getEvent() {
     return this.event;
   }
 
-  /**
-   * Gets the sender.
-   *
-   * @return the sender
-   */
+  /// Gets the sender.
+  ///
+  /// @return the sender
   public GuiComponent getSender() {
     return this.sender;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentMouseWheelEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentMouseWheelEvent.java
@@ -6,36 +6,30 @@ public class ComponentMouseWheelEvent {
 
   private final MouseWheelEvent event;
 
-  /** The sender. */
+  /// The sender.
   private final GuiComponent sender;
 
-  /**
-   * Instantiates a new component mouse event.
-   *
-   * @param event
-   *          the event
-   * @param sender
-   *          the sender
-   */
+  /// Instantiates a new component mouse event.
+  ///
+  /// @param event
+  /// the event
+  /// @param sender
+  /// the sender
   public ComponentMouseWheelEvent(final MouseWheelEvent event, final GuiComponent sender) {
     this.event = event;
     this.sender = sender;
   }
 
-  /**
-   * Gets the event.
-   *
-   * @return the event
-   */
+  /// Gets the event.
+  ///
+  /// @return the event
   public MouseWheelEvent getEvent() {
     return this.event;
   }
 
-  /**
-   * Gets the sender.
-   *
-   * @return the sender
-   */
+  /// Gets the sender.
+  ///
+  /// @return the sender
   public GuiComponent getSender() {
     return this.sender;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentRenderEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentRenderEvent.java
@@ -8,14 +8,12 @@ public class ComponentRenderEvent extends EventObject {
   private final transient Graphics2D graphics;
   private final transient GuiComponent component;
 
-  /**
-   * Constructs a prototypical Event.
-   *
-   * @param source
-   *          the object on which the Event initially occurred
-   * @throws IllegalArgumentException
-   *           if source is null
-   */
+  /// Constructs a prototypical Event.
+  ///
+  /// @param source
+  /// the object on which the Event initially occurred
+  /// @throws IllegalArgumentException
+  /// if source is null
   public ComponentRenderEvent(final Graphics2D graphics, final GuiComponent source) {
     super(source);
 
@@ -23,20 +21,16 @@ public class ComponentRenderEvent extends EventObject {
     this.component = source;
   }
 
-  /**
-   * Get the component involved with the rendering process.
-   *
-   * @return The component involved with the rendering process.
-   */
+  /// Get the component involved with the rendering process.
+  ///
+  /// @return The component involved with the rendering process.
   public GuiComponent getComponent() {
     return this.component;
   }
 
-  /**
-   * Gets the graphics object on which the entity is rendered.
-   *
-   * @return The graphics object on which the entity is rendered.
-   */
+  /// Gets the graphics object on which the entity is rendered.
+  ///
+  /// @return The graphics object on which the entity is rendered.
   public Graphics2D getGraphics() {
     return this.graphics;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentRenderListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentRenderListener.java
@@ -2,30 +2,24 @@ package de.gurkenlabs.litiengine.gui;
 
 import java.awt.Graphics2D;
 
-/**
- * This listener interface is used for receiving events during a component's rendering process.
- *
- * @see GuiComponent#render(Graphics2D)
- */
+/// This listener interface is used for receiving events during a component's rendering process.
+///
+/// @see GuiComponent#render(Graphics2D)
 public interface ComponentRenderListener extends ComponentRenderedListener {
 
-  /**
-   * This method gets called after all rendering checks have successfully passed and right before the component is about
-   * to be rendered.
-   *
-   * @param event
-   *          The event that contains the render data.
-   */
+  /// This method gets called after all rendering checks have successfully passed and right before the component is about
+  /// to be rendered.
+  ///
+  /// @param event
+  /// The event that contains the render data.
   default void rendering(ComponentRenderEvent event) {}
 
-  /**
-   * This method gets called before an {@code GuiComponent} is about to be rendered. Returning false prevents the
-   * rendering of the specified component.
-   *
-   * @param component
-   *          The component to be rendered.
-   * @return True if the component should be rendered; otherwise false.
-   */
+  /// This method gets called before an `GuiComponent` is about to be rendered. Returning false prevents the
+  /// rendering of the specified component.
+  ///
+  /// @param component
+  /// The component to be rendered.
+  /// @return True if the component should be rendered; otherwise false.
   default boolean canRender(GuiComponent component) {
     return true;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentRenderedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ComponentRenderedListener.java
@@ -3,19 +3,15 @@ package de.gurkenlabs.litiengine.gui;
 import java.awt.Graphics2D;
 import java.util.EventListener;
 
-/**
- * This listener interface is used for receiving events after an component was rendered.
- *
- * @see GuiComponent#render(Graphics2D)
- */
+/// This listener interface is used for receiving events after an component was rendered.
+///
+/// @see GuiComponent#render(Graphics2D)
 @FunctionalInterface
 public interface ComponentRenderedListener extends EventListener {
 
-  /**
-   * This method gets called after an {@link GuiComponent} was rendered.
-   *
-   * @param event
-   *          The event that contains the render data.
-   */
+  /// This method gets called after an [GuiComponent] was rendered.
+  ///
+  /// @param event
+  /// The event that contains the render data.
   void rendered(ComponentRenderEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/DropdownListField.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/DropdownListField.java
@@ -8,15 +8,11 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.IntConsumer;
 
-/**
- * A GUI component that displays a single selected entry from a list of choices and reveals the full list as a drop-down when the user clicks the
- * accompanying arrow button. The selection can also be navigated with arrow keys or the mouse wheel when
- * {@linkplain #isArrowKeyNavigation() arrow key navigation} is enabled.
- */
+/// A GUI component that displays a single selected entry from a list of choices and reveals the full list as a drop-down when the user clicks the
+/// accompanying arrow button. The selection can also be navigated with arrow keys or the mouse wheel when
+/// [arrow key navigation][#isArrowKeyNavigation()] is enabled.
 public class DropdownListField extends GuiComponent {
-  /**
-   * Down-pointing arrow icon shown on the drop-down toggle button.
-   */
+  /// Down-pointing arrow icon shown on the drop-down toggle button.
   public static final FontIcon ARROW_DOWN = new FontIcon(ICON_FONT, "\uE804");
 
   private boolean arrowKeyNavigation;
@@ -24,7 +20,7 @@ public class DropdownListField extends GuiComponent {
   private final Object[] content;
 
   private ListField contentList;
-  /** The drop down button. */
+  /// The drop down button.
   private ImageComponent dropDownButton;
 
   private ImageComponent chosenElementComponent;
@@ -34,16 +30,14 @@ public class DropdownListField extends GuiComponent {
 
   private final int numberOfShownElements;
 
-  /**
-   * Constructs a new {@code DropdownListField}.
-   *
-   * @param x             the x coordinate of the component
-   * @param y             the y coordinate of the component
-   * @param width         the width of the component
-   * @param height        the total height of the component including the drop-down list
-   * @param content       the selectable values
-   * @param elementsShown the number of list entries that are simultaneously shown when the drop-down is open
-   */
+  /// Constructs a new `DropdownListField`.
+  ///
+  /// @param x             the x coordinate of the component
+  /// @param y             the y coordinate of the component
+  /// @param width         the width of the component
+  /// @param height        the total height of the component including the drop-down list
+  /// @param content       the selectable values
+  /// @param elementsShown the number of list entries that are simultaneously shown when the drop-down is open
   public DropdownListField(
       final double x,
       final double y,
@@ -57,101 +51,79 @@ public class DropdownListField extends GuiComponent {
     this.changeConsumer = new CopyOnWriteArrayList<>();
   }
 
-  /**
-   * Gets the spritesheet used to render the drop-down button.
-   *
-   * @return the button spritesheet
-   */
+  /// Gets the spritesheet used to render the drop-down button.
+  ///
+  /// @return the button spritesheet
   public Spritesheet getButtonSprite() {
     return this.buttonSprite;
   }
 
-  /**
-   * Gets the list of registered change listeners.
-   *
-   * @return the change listener list
-   */
+  /// Gets the list of registered change listeners.
+  ///
+  /// @return the change listener list
   public List<IntConsumer> getChangeConsumer() {
     return this.changeConsumer;
   }
 
-  /**
-   * Gets the component that displays the currently selected element when the drop-down is collapsed.
-   *
-   * @return the chosen element component
-   */
+  /// Gets the component that displays the currently selected element when the drop-down is collapsed.
+  ///
+  /// @return the chosen element component
   public ImageComponent getChosenElementComponent() {
     return this.chosenElementComponent;
   }
 
-  /**
-   * Gets the array of selectable values.
-   *
-   * @return the content array
-   */
+  /// Gets the array of selectable values.
+  ///
+  /// @return the content array
   public Object[] getContentArray() {
     return this.content;
   }
 
-  /**
-   * Gets the internal list field used to render the drop-down entries.
-   *
-   * @return the content list
-   */
+  /// Gets the internal list field used to render the drop-down entries.
+  ///
+  /// @return the content list
   public ListField getContentList() {
     return this.contentList;
   }
 
-  /**
-   * Gets the toggle button used to open and close the drop-down.
-   *
-   * @return the drop-down toggle button
-   */
+  /// Gets the toggle button used to open and close the drop-down.
+  ///
+  /// @return the drop-down toggle button
   public ImageComponent getDropDownButton() {
     return this.dropDownButton;
   }
 
-  /**
-   * Gets the spritesheet used to render the drop-down entries.
-   *
-   * @return the entry spritesheet
-   */
+  /// Gets the spritesheet used to render the drop-down entries.
+  ///
+  /// @return the entry spritesheet
   public Spritesheet getEntrySprite() {
     return this.entrySprite;
   }
 
-  /**
-   * Gets the list of rendered drop-down entry components.
-   *
-   * @return the list entries
-   */
+  /// Gets the list of rendered drop-down entry components.
+  ///
+  /// @return the list entries
   public List<ImageComponent> getListEntries() {
     return this.getContentList().getListEntry(0);
   }
 
-  /**
-   * Gets the maximum number of list entries that are shown simultaneously.
-   *
-   * @return the number of shown elements
-   */
+  /// Gets the maximum number of list entries that are shown simultaneously.
+  ///
+  /// @return the number of shown elements
   public int getNumberOfShownElements() {
     return this.numberOfShownElements;
   }
 
-  /**
-   * Gets the index of the currently selected entry.
-   *
-   * @return the selected index
-   */
+  /// Gets the index of the currently selected entry.
+  ///
+  /// @return the selected index
   public int getSelectedIndex() {
     return this.getContentList().getSelectionRow();
   }
 
-  /**
-   * Gets the currently selected value.
-   *
-   * @return the selected value, or {@code null} if the content array is empty
-   */
+  /// Gets the currently selected value.
+  ///
+  /// @return the selected value, or `null` if the content array is empty
   public Object getSelectedObject() {
     if (this.getContentArray().length == 0) {
       return null;
@@ -160,29 +132,23 @@ public class DropdownListField extends GuiComponent {
     return this.getContentArray()[this.getContentList().getSelectionRow()];
   }
 
-  /**
-   * Returns whether arrow-key navigation is enabled.
-   *
-   * @return {@code true} if the selection can be changed using arrow keys / mouse wheel while the component is hovered
-   */
+  /// Returns whether arrow-key navigation is enabled.
+  ///
+  /// @return `true` if the selection can be changed using arrow keys / mouse wheel while the component is hovered
   public boolean isArrowKeyNavigation() {
     return this.arrowKeyNavigation;
   }
 
-  /**
-   * Returns whether the drop-down is currently expanded.
-   *
-   * @return {@code true} if the drop-down list is shown
-   */
+  /// Returns whether the drop-down is currently expanded.
+  ///
+  /// @return `true` if the drop-down list is shown
   public boolean isDroppedDown() {
     return this.isDroppedDown;
   }
 
-  /**
-   * Registers a callback that is invoked with the new selected index whenever the selection changes.
-   *
-   * @param c the change consumer
-   */
+  /// Registers a callback that is invoked with the new selected index whenever the selection changes.
+  ///
+  /// @param c the change consumer
   public void onChange(final IntConsumer c) {
     this.getChangeConsumer().add(c);
   }
@@ -252,38 +218,30 @@ public class DropdownListField extends GuiComponent {
                 .forEach(consumer -> consumer.accept(this.getSelectedIndex())));
   }
 
-  /**
-   * Sets whether arrow-key (and mouse-wheel) navigation should be used to change the selection while the component is hovered.
-   *
-   * @param arrowKeyNavigation {@code true} to enable arrow-key navigation
-   */
+  /// Sets whether arrow-key (and mouse-wheel) navigation should be used to change the selection while the component is hovered.
+  ///
+  /// @param arrowKeyNavigation `true` to enable arrow-key navigation
   public void setArrowKeyNavigation(final boolean arrowKeyNavigation) {
     this.arrowKeyNavigation = arrowKeyNavigation;
   }
 
-  /**
-   * Sets the spritesheet used to render the drop-down toggle button.
-   *
-   * @param buttonSprite the spritesheet
-   */
+  /// Sets the spritesheet used to render the drop-down toggle button.
+  ///
+  /// @param buttonSprite the spritesheet
   public void setButtonSprite(final Spritesheet buttonSprite) {
     this.buttonSprite = buttonSprite;
   }
 
-  /**
-   * Sets the spritesheet used to render the drop-down entries.
-   *
-   * @param entrySprite the spritesheet
-   */
+  /// Sets the spritesheet used to render the drop-down entries.
+  ///
+  /// @param entrySprite the spritesheet
   public void setEntrySprite(final Spritesheet entrySprite) {
     this.entrySprite = entrySprite;
   }
 
-  /**
-   * Sets the selection by index.
-   *
-   * @param selectionIndex the index of the entry to select
-   */
+  /// Sets the selection by index.
+  ///
+  /// @param selectionIndex the index of the entry to select
   public void setSelection(final int selectionIndex) {
     if (this.getContentList() == null) {
       return;
@@ -292,11 +250,9 @@ public class DropdownListField extends GuiComponent {
     this.getContentList().setSelection(0, selectionIndex);
   }
 
-  /**
-   * Sets the selection by value. The first entry that {@linkplain Object#equals(Object) equals} the given object is selected.
-   *
-   * @param selectedObject the value to select; ignored if {@code null}
-   */
+  /// Sets the selection by value. The first entry that [equals][Object#equals(Object)] the given object is selected.
+  ///
+  /// @param selectedObject the value to select; ignored if `null`
   public void setSelection(final Object selectedObject) {
     if (selectedObject == null) {
       return;
@@ -310,7 +266,7 @@ public class DropdownListField extends GuiComponent {
     }
   }
 
-  /** Toggle drop down. */
+  /// Toggle drop down.
   public void toggleDropDown() {
     if (this.isDroppedDown()) {
       this.getContentList().suspend();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/FontIcon.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/FontIcon.java
@@ -5,70 +5,54 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
 
-/**
- * Represents an icon rendered using a specific font and text.
- */
+/// Represents an icon rendered using a specific font and text.
 public class FontIcon {
-  /**
-   * The font used to render the icon.
-   */
+  /// The font used to render the icon.
   private final Font font;
 
-  /**
-   * The text or unicode character to be rendered as the icon.
-   */
+  /// The text or unicode character to be rendered as the icon.
   private final String text;
 
-  /**
-   * Constructs a FontIcon with the specified font and character.
-   *
-   * @param font the font used to render the icon
-   * @param text the character to be rendered as the icon
-   */
+  /// Constructs a FontIcon with the specified font and character.
+  ///
+  /// @param font the font used to render the icon
+  /// @param text the character to be rendered as the icon
   public FontIcon(final Font font, final char text) {
     this.font = font;
     this.text = String.valueOf(text);
   }
 
-  /**
-   * Constructs a FontIcon with the specified font and unicode string.
-   *
-   * @param font    the font used to render the icon
-   * @param unicode the unicode string to be rendered as the icon
-   */
+  /// Constructs a FontIcon with the specified font and unicode string.
+  ///
+  /// @param font    the font used to render the icon
+  /// @param unicode the unicode string to be rendered as the icon
   public FontIcon(final Font font, final String unicode) {
     this.font = font;
     this.text = unicode;
   }
 
-  /**
-   * Returns the font used to render the icon.
-   *
-   * @return the font used to render the icon
-   */
+  /// Returns the font used to render the icon.
+  ///
+  /// @return the font used to render the icon
   public Font getFont() {
     return this.font;
   }
 
-  /**
-   * Returns the text or unicode character to be rendered as the icon.
-   *
-   * @return the text or unicode character to be rendered as the icon
-   */
+  /// Returns the text or unicode character to be rendered as the icon.
+  ///
+  /// @return the text or unicode character to be rendered as the icon
   public String getText() {
     return this.text;
   }
 
-  /**
-   * Renders the icon using the specified graphics context, color, font size, and position.
-   *
-   * @param g        the graphics context to use for rendering
-   * @param color    the color to render the icon
-   * @param fontSize the size of the font to render the icon
-   * @param x        the x-coordinate where the icon should be rendered
-   * @param y        the y-coordinate where the icon should be rendered
-   * @param bold     true if the font should be bold, false otherwise
-   */
+  /// Renders the icon using the specified graphics context, color, font size, and position.
+  ///
+  /// @param g        the graphics context to use for rendering
+  /// @param color    the color to render the icon
+  /// @param fontSize the size of the font to render the icon
+  /// @param x        the x-coordinate where the icon should be rendered
+  /// @param y        the y-coordinate where the icon should be rendered
+  /// @param bold     true if the font should be bold, false otherwise
   public void render(
     final Graphics2D g,
     final Color color,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiComponent.java
@@ -36,11 +36,9 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
-/**
- * The abstract Class GuiComponent provides all properties and methods needed for screens, built-in,
- * and custom GUI components such as buttons, sliders, etc... It includes mouse event handling,
- * different hovering states and appearances, and texts to be rendered.
- */
+/// The abstract Class GuiComponent provides all properties and methods needed for screens, built-in,
+/// and custom GUI components such as buttons, sliders, etc... It includes mouse event handling,
+/// different hovering states and appearances, and texts to be rendered.
 public abstract class GuiComponent
   implements MouseListener, MouseMotionListener, MouseWheelListener, IRenderable, Tweenable {
 
@@ -115,24 +113,20 @@ public abstract class GuiComponent
   private boolean hasRelativeLayout;
   private boolean autoScaling = true;
 
-  /**
-   * Instantiates a new gui component with the dimension (0,0) at the given location.
-   *
-   * @param x the x
-   * @param y the y
-   */
+  /// Instantiates a new gui component with the dimension (0,0) at the given location.
+  ///
+  /// @param x the x
+  /// @param y the y
   protected GuiComponent(final double x, final double y) {
     this(x, y, 0, 0);
   }
 
-  /**
-   * Instantiates a new gui component at the point (x,y) with the dimension (width,height).
-   *
-   * @param x      the x
-   * @param y      the y
-   * @param width  the width
-   * @param height the height
-   */
+  /// Instantiates a new gui component at the point (x,y) with the dimension (width,height).
+  ///
+  /// @param x      the x
+  /// @param y      the y
+  /// @param width  the width
+  /// @param height the height
   protected GuiComponent(final double x, final double y, final double width, final double height) {
     this.components = new ChildComponentList();
     this.clickConsumer = new CopyOnWriteArrayList<>();
@@ -191,38 +185,30 @@ public abstract class GuiComponent
     updateRelativeLayout();
   }
 
-  /**
-   * Gets the default appearance object for this GuiComponent.
-   *
-   * @return the appearance
-   */
+  /// Gets the default appearance object for this GuiComponent.
+  ///
+  /// @return the appearance
   public Appearance getAppearance() {
     return appearance;
   }
 
-  /**
-   * Gets the appearance object for this GuiComponent while disabled.
-   *
-   * @return the appearance disabled
-   */
+  /// Gets the appearance object for this GuiComponent while disabled.
+  ///
+  /// @return the appearance disabled
   public Appearance getAppearanceDisabled() {
     return disabledAppearance;
   }
 
-  /**
-   * Gets the appearance object for this GuiComponent while hovered.
-   *
-   * @return the hovered appearance
-   */
+  /// Gets the appearance object for this GuiComponent while hovered.
+  ///
+  /// @return the hovered appearance
   public Appearance getAppearanceHovered() {
     return hoveredAppearance;
   }
 
-  /**
-   * Gets the bounding box of this GuiComponent.
-   *
-   * @return the bounding box
-   */
+  /// Gets the bounding box of this GuiComponent.
+  ///
+  /// @return the bounding box
   public Rectangle2D getBoundingBox() {
     if (boundingBox != null) {
       return boundingBox;
@@ -232,11 +218,9 @@ public abstract class GuiComponent
     return boundingBox;
   }
 
-  /**
-   * Gets the component id of this GuiComponent.
-   *
-   * @return the component id
-   */
+  /// Gets the component id of this GuiComponent.
+  ///
+  /// @return the component id
   public int getComponentId() {
     return componentId;
   }
@@ -245,123 +229,97 @@ public abstract class GuiComponent
     return focusedComponent;
   }
 
-  /**
-   * Gets the child components of this GuiComponent. Components are rendered in list order. A later
-   * component is therefore above an earlier component and receives mouse input first where their
-   * bounds overlap.
-   *
-   * @return the child components
-   */
+  /// Gets the child components of this GuiComponent. Components are rendered in list order. A later
+  /// component is therefore above an earlier component and receives mouse input first where their
+  /// bounds overlap.
+  ///
+  /// @return the child components
   public List<GuiComponent> getComponents() {
     return components;
   }
 
-  /**
-   * Gets the font of this GuiComponent's text.
-   *
-   * @return the GuiComponent's font
-   */
+  /// Gets the font of this GuiComponent's text.
+  ///
+  /// @return the GuiComponent's font
   public Font getFont() {
     return font;
   }
 
-  /**
-   * Gets the height of this GuiComponent.
-   *
-   * @return the height
-   */
+  /// Gets the height of this GuiComponent.
+  ///
+  /// @return the height
   public double getHeight() {
     return height;
   }
 
-  /**
-   * Gets the sound that is played when hovering the GuiComponent.
-   *
-   * @return the hover sound
-   */
+  /// Gets the sound that is played when hovering the GuiComponent.
+  ///
+  /// @return the hover sound
   public Sound getHoverSound() {
     return hoverSound;
   }
 
-  /**
-   * Gets the screen location of this GuiComponent.
-   *
-   * @return the screen location
-   */
+  /// Gets the screen location of this GuiComponent.
+  ///
+  /// @return the screen location
   public Point2D getLocation() {
     return location;
   }
 
-  /**
-   * Gets the name of this GuiComponent.
-   *
-   * @return the name
-   */
+  /// Gets the name of this GuiComponent.
+  ///
+  /// @return the name
   public String getName() {
     return name;
   }
 
-  /**
-   * Gets the tag.
-   *
-   * @return the tag
-   */
+  /// Gets the tag.
+  ///
+  /// @return the tag
   public Object getTag() {
     return tag;
   }
 
-  /**
-   * Gets the entire Text associated with this GuiComponent. Parts of the Text may get cropped and
-   * can therefore be invisible. To retrieve only the visible part of the text, use
-   * {@code GuiComponent.getTextToRender(Graphics2D g)}.
-   *
-   * @return the entire text on this GuiComponent
-   */
+  /// Gets the entire Text associated with this GuiComponent. Parts of the Text may get cropped and
+  /// can therefore be invisible. To retrieve only the visible part of the text, use
+  /// `GuiComponent.getTextToRender(Graphics2D g)`.
+  ///
+  /// @return the entire text on this GuiComponent
   public String getText() {
     return text;
   }
 
-  /**
-   * Gets the horizontal text alignment.
-   *
-   * @return the horizontal text alignment
-   */
+  /// Gets the horizontal text alignment.
+  ///
+  /// @return the horizontal text alignment
   public Align getTextAlign() {
     return textAlign;
   }
 
-  /**
-   * Gets the vertical text alignment.
-   *
-   * @return the vertical text alignment
-   */
+  /// Gets the vertical text alignment.
+  ///
+  /// @return the vertical text alignment
   public Valign getTextValign() {
     return textValign;
   }
 
-  /**
-   * Gets the text angle.
-   *
-   * @return the text angle
-   */
+  /// Gets the text angle.
+  ///
+  /// @return the text angle
   public int getTextAngle() {
     return textAngle;
   }
 
-  /**
-   * Check whether text antialiasing is activated.
-   *
-   * @return true, if this GuiComponent is currently configured to draw its text with antialiasing.
-   */
+  /// Check whether text antialiasing is activated.
+  ///
+  /// @return true, if this GuiComponent is currently configured to draw its text with antialiasing.
   public boolean hasTextAntialiasing() {
     return textAntialiasing;
   }
 
-  /**
-   * Check whether text shadow is activated.
-   *
-   * @return true, if this GuiComponent is currently configured to draw a shadow below its text.
-   */
+  /// Check whether text shadow is activated.
+  ///
+  /// @return true, if this GuiComponent is currently configured to draw a shadow below its text.
   public boolean hasTextShadow() {
     return textShadow;
   }
@@ -386,13 +344,11 @@ public abstract class GuiComponent
     return automaticLineBreaks;
   }
 
-  /**
-   * Gets only the non-cropped bits of Text visible on this GuiComponent.m To retrieve only the
-   * entire text associated with this GuiComponent, use {@code GuiComponent.getText()}.
-   *
-   * @param g The graphics object to render on.
-   * @return the text to render
-   */
+  /// Gets only the non-cropped bits of Text visible on this GuiComponent.m To retrieve only the
+  /// entire text associated with this GuiComponent, use `GuiComponent.getText()`.
+  ///
+  /// @param g The graphics object to render on.
+  /// @return the text to render
   public String getTextToRender(final Graphics2D g) {
     if (getText() == null) {
       return "";
@@ -408,101 +364,81 @@ public abstract class GuiComponent
     return newText;
   }
 
-  /**
-   * Gets the text X coordinate.
-   *
-   * @return the text X
-   */
+  /// Gets the text X coordinate.
+  ///
+  /// @return the text X
   public double getTextX() {
     return textX;
   }
 
-  /**
-   * Gets the text Y coordinate.
-   *
-   * @return the text Y
-   */
+  /// Gets the text Y coordinate.
+  ///
+  /// @return the text Y
   public double getTextY() {
     return textY;
   }
 
-  /**
-   * Gets the width of this GuiComponent.
-   *
-   * @return the width
-   */
+  /// Gets the width of this GuiComponent.
+  ///
+  /// @return the width
   public double getWidth() {
     return width;
   }
 
-  /**
-   * Gets the x coordinate of this GuiComponent.
-   *
-   * @return the x coordinate
-   */
+  /// Gets the x coordinate of this GuiComponent.
+  ///
+  /// @return the x coordinate
   public double getX() {
     return getLocation().getX();
   }
 
-  /**
-   * Gets x coordinate of this GuiComponent's center point.
-   *
-   * @return the center x coordinate
-   */
+  /// Gets x coordinate of this GuiComponent's center point.
+  ///
+  /// @return the center x coordinate
   public double getCenterX() {
     return getBoundingBox().getCenterX();
   }
 
-  /**
-   * Gets y coordinate of this GuiComponent's center point.
-   *
-   * @return the center y coordinate
-   */
+  /// Gets y coordinate of this GuiComponent's center point.
+  ///
+  /// @return the center y coordinate
   public double getCenterY() {
     return getBoundingBox().getCenterY();
   }
 
 
-  /**
-   * Gets the y coordinate of this GuiComponent.
-   *
-   * @return the y coordinate
-   */
+  /// Gets the y coordinate of this GuiComponent.
+  ///
+  /// @return the y coordinate
   public double getY() {
     return getLocation().getY();
   }
 
-  /**
-   * Checks if the GuiComponent is enabled.
-   *
-   * @return true, if is enabled
-   */
+  /// Checks if the GuiComponent is enabled.
+  ///
+  /// @return true, if is enabled
   public boolean isEnabled() {
     return enabled;
   }
 
-  /**
-   * Returns whether this component automatically scales its position and size proportionally when
-   * the game window resolution changes.
-   *
-   * <p>When enabled (the default), the component's position and size are stored as fractions of the
-   * window dimensions and recalculated on each resolution change via
-   * {@link #onResolutionChanged(Dimension)}. When disabled, the component retains its absolute pixel
-   * position and size across resolution changes; only child propagation still occurs.</p>
-   *
-   * @return {@code true} if proportional auto-scaling is enabled; {@code false} otherwise
-   * @see #setAutoScaling(boolean)
-   * @see #onResolutionChanged(Dimension)
-   */
+  /// Returns whether this component automatically scales its position and size proportionally when
+  /// the game window resolution changes.
+  ///
+  /// When enabled (the default), the component's position and size are stored as fractions of the
+  /// window dimensions and recalculated on each resolution change via
+  /// [#onResolutionChanged(Dimension)]. When disabled, the component retains its absolute pixel
+  /// position and size across resolution changes; only child propagation still occurs.
+  ///
+  /// @return `true` if proportional auto-scaling is enabled; `false` otherwise
+  /// @see #setAutoScaling(boolean)
+  /// @see #onResolutionChanged(Dimension)
   public boolean isAutoScaling() {
     return autoScaling;
   }
 
-  /**
-   * Checks if mouse events are being forwarded by this GuiComponent.
-   *
-   * @return true, the GuiComponent forwards mouse events
-   */
+  /// Checks if mouse events are being forwarded by this GuiComponent.
+  ///
+  /// @return true, the GuiComponent forwards mouse events
   public boolean isForwardMouseEvents() {
     return forwardMouseEvents;
   }
@@ -515,47 +451,37 @@ public abstract class GuiComponent
     return isFocusable() && getFocusedComponent() == this;
   }
 
-  /**
-   * Checks if the cursor bounding box intersects with this GuiComponent's bounding box.
-   *
-   * @return true, if the GuiComponent is hovered
-   */
+  /// Checks if the cursor bounding box intersects with this GuiComponent's bounding box.
+  ///
+  /// @return true, if the GuiComponent is hovered
   public boolean isHovered() {
     return isHovered;
   }
 
-  /**
-   * Checks if the mouse button is currently being pressed on this GuiComponent.
-   *
-   * @return true, if the mouse is currently pressed on the GuiComponent
-   */
+  /// Checks if the mouse button is currently being pressed on this GuiComponent.
+  ///
+  /// @return true, if the mouse is currently pressed on the GuiComponent
   public boolean isPressed() {
     return isPressed;
   }
 
-  /**
-   * Checks if the GuiComponent is currently selected.
-   *
-   * @return true, if the GuiComponent is selected
-   */
+  /// Checks if the GuiComponent is currently selected.
+  ///
+  /// @return true, if the GuiComponent is selected
   public boolean isSelected() {
     return isSelected;
   }
 
-  /**
-   * Checks if the GuiComponent is currently suspended.
-   *
-   * @return true, if the GuiComponent is suspended
-   */
+  /// Checks if the GuiComponent is currently suspended.
+  ///
+  /// @return true, if the GuiComponent is suspended
   public boolean isSuspended() {
     return suspended;
   }
 
-  /**
-   * Checks if the GuiComponent is currently visible.
-   *
-   * @return true, if the GuiComponent is visible
-   */
+  /// Checks if the GuiComponent is currently visible.
+  ///
+  /// @return true, if the GuiComponent is visible
   public boolean isVisible() {
     return visible;
   }
@@ -684,115 +610,95 @@ public abstract class GuiComponent
       consumer -> consumer.accept(new ComponentMouseWheelEvent(e, this)));
   }
 
-  /**
-   * Add a callback that is being executed if this GuiComponent is clicked once.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if this GuiComponent is clicked once.
+  ///
+  /// @param callback the callback
   public void onClicked(final Consumer<ComponentMouseEvent> callback) {
     if (!getClickConsumer().contains(callback)) {
       getClickConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if this GuiComponent is hovered with the mouse.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if this GuiComponent is hovered with the mouse.
+  ///
+  /// @param callback the callback
   public void onHovered(final Consumer<ComponentMouseEvent> callback) {
     if (!getHoverConsumer().contains(callback)) {
       getHoverConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse is pressed and moving around while within
-   * the bounds of this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse is pressed and moving around while within
+  /// the bounds of this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMouseDragged(final Consumer<ComponentMouseEvent> callback) {
     if (!getMouseDraggedConsumer().contains(callback)) {
       getMouseDraggedConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse enters the bounds of this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse enters the bounds of this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMouseEnter(final Consumer<ComponentMouseEvent> callback) {
     if (!getMouseEnterConsumer().contains(callback)) {
       getMouseEnterConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse leaves the bounds of this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse leaves the bounds of this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMouseLeave(final Consumer<ComponentMouseEvent> callback) {
     if (!getMouseLeaveConsumer().contains(callback)) {
       getMouseLeaveConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse is moving around while within the bounds of
-   * this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse is moving around while within the bounds of
+  /// this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMouseMoved(final Consumer<ComponentMouseEvent> callback) {
     if (!getMouseMovedConsumer().contains(callback)) {
       getMouseMovedConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse is continually pressed while within the
-   * bounds of this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse is continually pressed while within the
+  /// bounds of this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMousePressed(final Consumer<ComponentMouseEvent> callback) {
     if (!getMousePressedConsumer().contains(callback)) {
       getMousePressedConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse button is released while within the bounds
-   * of this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse button is released while within the bounds
+  /// of this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMouseReleased(final Consumer<ComponentMouseEvent> callback) {
     if (!getMouseReleasedConsumer().contains(callback)) {
       getMouseReleasedConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the mouse wheel is scrolled while within the bounds of
-   * this GuiComponent.
-   *
-   * @param callback the callback
-   */
+  /// Add a callback that is being executed if the mouse wheel is scrolled while within the bounds of
+  /// this GuiComponent.
+  ///
+  /// @param callback the callback
   public void onMouseWheelScrolled(final Consumer<ComponentMouseWheelEvent> callback) {
     if (!getMouseWheelConsumer().contains(callback)) {
       getMouseWheelConsumer().add(callback);
     }
   }
 
-  /**
-   * Add a callback that is being executed if the text on this GuiComponent changes.
-   *
-   * @param cons the cons
-   */
+  /// Add a callback that is being executed if the text on this GuiComponent changes.
+  ///
+  /// @param cons the cons
   public void onTextChanged(final Consumer<String> cons) {
     this.textChangedConsumer.add(cons);
   }
@@ -813,10 +719,8 @@ public abstract class GuiComponent
     this.renderedListeners.remove(listener);
   }
 
-  /**
-   * Prepare the GuiComponent and all its child Components (Makes the GuiComponent visible and adds
-   * mouse listeners.). This is, for example, done right before switching to a new screen.
-   */
+  /// Prepare the GuiComponent and all its child Components (Makes the GuiComponent visible and adds
+  /// mouse listeners.). This is, for example, done right before switching to a new screen.
   public void prepare() {
     this.suspended = false;
     this.visible = true;
@@ -828,10 +732,8 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Note: If you override this and are modifying swing components, be sure you are in the AWT
-   * thread when you do so!
-   */
+  /// Note: If you override this and are modifying swing components, be sure you are in the AWT
+  /// thread when you do so!
   @Override
   public void render(final Graphics2D g) {
     if (isSuspended() || !isVisible()) {
@@ -996,41 +898,31 @@ public abstract class GuiComponent
       getCurrentAppearance().getBorderRadius());
   }
 
-  /**
-   * Sets the width and height of this GuiComponent.
-   *
-   * @param width  the width
-   * @param height the height
-   */
+  /// Sets the width and height of this GuiComponent.
+  ///
+  /// @param width  the width
+  /// @param height the height
   public void setDimension(final double width, final double height) {
     setWidth(width);
     setHeight(height);
   }
 
-  /**
-   * Called when the game window resolution changes, e.g. after switching {@code DisplayMode} at runtime.
-   *
-   * <p>
-   * If {@link #isAutoScaling()} is {@code true} (the default) and this component was initialized
-   * with valid window dimensions, its position and size are recalculated from the stored relative
-   * fractions so the component scales proportionally with the window. When auto-scaling is disabled,
-   * the component retains its absolute pixel position and size.
-   * </p>
-   *
-   * <p>
-   * The event is always recursively forwarded to all child components regardless of the parent's
-   * auto-scaling setting.
-   * </p>
-   *
-   * <p>
-   * Override this method to implement custom re-layout logic that goes beyond proportional scaling.
-   * </p>
-   *
-   * @param resolution
-   *          The new window dimensions.
-   * @see #setAutoScaling(boolean)
-   * @see de.gurkenlabs.litiengine.GameWindow.ResolutionChangedListener
-   */
+  /// Called when the game window resolution changes, e.g. after switching `DisplayMode` at runtime.
+  ///
+  /// If [#isAutoScaling()] is `true` (the default) and this component was initialized
+  /// with valid window dimensions, its position and size are recalculated from the stored relative
+  /// fractions so the component scales proportionally with the window. When auto-scaling is disabled,
+  /// the component retains its absolute pixel position and size.
+  ///
+  /// The event is always recursively forwarded to all child components regardless of the parent's
+  /// auto-scaling setting.
+  ///
+  /// Override this method to implement custom re-layout logic that goes beyond proportional scaling.
+  ///
+  /// @param resolution
+  /// The new window dimensions.
+  /// @see #setAutoScaling(boolean)
+  /// @see de.gurkenlabs.litiengine.GameWindow.ResolutionChangedListener
   public void onResolutionChanged(Dimension resolution) {
     if (autoScaling) {
       if (hasRelativeLayout) {
@@ -1056,16 +948,14 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Recomputes the stored relative position and size of this component as fractions of the current
-   * game window dimensions. These values are used by {@link #onResolutionChanged(Dimension)} to
-   * proportionally rescale the component when the window is resized.
-   *
-   * <p>The method is a no-op when the game runs in no-GUI mode or the window has not been
-   * initialized yet (dimensions ≤ 0), so components created before the window is ready will
-   * compute their relative layout lazily on the first setter call that occurs after the window
-   * becomes available.</p>
-   */
+  /// Recomputes the stored relative position and size of this component as fractions of the current
+  /// game window dimensions. These values are used by [#onResolutionChanged(Dimension)] to
+  /// proportionally rescale the component when the window is resized.
+  ///
+  /// The method is a no-op when the game runs in no-GUI mode or the window has not been
+  /// initialized yet (dimensions ≤ 0), so components created before the window is ready will
+  /// compute their relative layout lazily on the first setter call that occurs after the window
+  /// becomes available.
   private void updateRelativeLayout() {
     if (!autoScaling) {
       return;
@@ -1080,13 +970,11 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Computes and stores the relative position and size of this component as fractions of the given
-   * reference resolution. After this call, {@link #onResolutionChanged(Dimension)} will
-   * proportionally rescale the component based on these stored fractions.
-   *
-   * @param referenceResolution the window dimensions to treat as the 100% baseline
-   */
+  /// Computes and stores the relative position and size of this component as fractions of the given
+  /// reference resolution. After this call, [#onResolutionChanged(Dimension)] will
+  /// proportionally rescale the component based on these stored fractions.
+  ///
+  /// @param referenceResolution the window dimensions to treat as the 100% baseline
   void initRelativeLayout(Dimension referenceResolution) {
     if (referenceResolution != null
       && referenceResolution.getWidth() > 0 && referenceResolution.getHeight() > 0) {
@@ -1098,11 +986,9 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Sets the "enabled" property on this GuiComponent and its child components.
-   *
-   * @param enabled the new enabled property
-   */
+  /// Sets the "enabled" property on this GuiComponent and its child components.
+  ///
+  /// @param enabled the new enabled property
   public void setEnabled(final boolean enabled) {
     this.enabled = enabled;
     for (final GuiComponent comp : getComponents()) {
@@ -1110,29 +996,25 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Enables or disables automatic proportional scaling of this component when the game window
-   * resolution changes.
-   *
-   * <p>When set to {@code false}, the component keeps its current absolute pixel position and size
-   * across resolution changes. The resolution change event is still propagated to child components,
-   * so children with auto-scaling enabled will still scale even if the parent does not.</p>
-   *
-   * <p>Auto-scaling is enabled by default.</p>
-   *
-   * @param autoScaling {@code true} to enable proportional auto-scaling; {@code false} to disable it
-   * @see #isAutoScaling()
-   * @see #onResolutionChanged(Dimension)
-   */
+  /// Enables or disables automatic proportional scaling of this component when the game window
+  /// resolution changes.
+  ///
+  /// When set to `false`, the component keeps its current absolute pixel position and size
+  /// across resolution changes. The resolution change event is still propagated to child components,
+  /// so children with auto-scaling enabled will still scale even if the parent does not.
+  ///
+  /// Auto-scaling is enabled by default.
+  ///
+  /// @param autoScaling `true` to enable proportional auto-scaling; `false` to disable it
+  /// @see #isAutoScaling()
+  /// @see #onResolutionChanged(Dimension)
   public void setAutoScaling(final boolean autoScaling) {
     this.autoScaling = autoScaling;
   }
 
-  /**
-   * Sets the font for this GuiComponent's text.
-   *
-   * @param font the new font
-   */
+  /// Sets the font for this GuiComponent's text.
+  ///
+  /// @param font the new font
   public void setFont(final Font font) {
     this.font = font;
   }
@@ -1144,11 +1026,9 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Sets the font size for this GuiComponent's text.
-   *
-   * @param size the new font size
-   */
+  /// Sets the font size for this GuiComponent's text.
+  ///
+  /// @param size the new font size
   public void setFontSize(final float size) {
     if (this.font == null) {
       return;
@@ -1156,59 +1036,47 @@ public abstract class GuiComponent
     setFont(getFont().deriveFont(size));
   }
 
-  /**
-   * Enable or disable forwarding mouse events by this GuiComponent.
-   *
-   * @param forwardMouseEvents the new forward mouse events
-   */
+  /// Enable or disable forwarding mouse events by this GuiComponent.
+  ///
+  /// @param forwardMouseEvents the new forward mouse events
   public void setForwardMouseEvents(final boolean forwardMouseEvents) {
     this.forwardMouseEvents = forwardMouseEvents;
   }
 
-  /**
-   * Sets the GuiComponent's height.
-   *
-   * @param height the new height
-   */
+  /// Sets the GuiComponent's height.
+  ///
+  /// @param height the new height
   public void setHeight(final double height) {
     this.height = height;
     this.boundingBox = null; // trigger recreation in next boundingBox getter call
     updateRelativeLayout();
   }
 
-  /**
-   * Sets the "hovered" property on this GuiComponent.
-   *
-   * @param hovered the new hovered
-   */
+  /// Sets the "hovered" property on this GuiComponent.
+  ///
+  /// @param hovered the new hovered
   public void setHovered(final boolean hovered) {
     this.isHovered = hovered;
   }
 
-  /**
-   * Sets the hover sound.
-   *
-   * @param hoverSound the new hover sound
-   */
+  /// Sets the hover sound.
+  ///
+  /// @param hoverSound the new hover sound
   public void setHoverSound(final Sound hoverSound) {
     this.hoverSound = hoverSound;
   }
 
-  /**
-   * Sets this GuiComponent's location.
-   *
-   * @param x the new x coordinate
-   * @param y the new y coordinate
-   */
+  /// Sets this GuiComponent's location.
+  ///
+  /// @param x the new x coordinate
+  /// @param y the new y coordinate
   public void setLocation(final double x, final double y) {
     setLocation(new Point2D.Double(x, y));
   }
 
-  /**
-   * Sets this GuiComponent's location.
-   *
-   * @param location the new location
-   */
+  /// Sets this GuiComponent's location.
+  ///
+  /// @param location the new location
   public void setLocation(final Point2D location) {
     final double deltaX = location.getX() - getX();
     final double deltaY = location.getY() - getY();
@@ -1222,39 +1090,31 @@ public abstract class GuiComponent
     updateRelativeLayout();
   }
 
-  /**
-   * Sets this GuiComponent's name.
-   *
-   * @param name the new name
-   */
+  /// Sets this GuiComponent's name.
+  ///
+  /// @param name the new name
   public void setName(final String name) {
     this.name = name;
   }
 
-  /**
-   * Sets the "selected" property on this GuiComponent.
-   *
-   * @param bool the new selected
-   */
+  /// Sets the "selected" property on this GuiComponent.
+  ///
+  /// @param bool the new selected
   public void setSelected(final boolean bool) {
     this.isSelected = bool;
     updateFocusState();
   }
 
-  /**
-   * Sets the tag.
-   *
-   * @param tag the new tag
-   */
+  /// Sets the tag.
+  ///
+  /// @param tag the new tag
   public void setTag(final Object tag) {
     this.tag = tag;
   }
 
-  /**
-   * Sets the text.
-   *
-   * @param text the new text
-   */
+  /// Sets the text.
+  ///
+  /// @param text the new text
   public void setText(final String text) {
     this.text = text;
     for (final Consumer<String> cons : this.textChangedConsumer) {
@@ -1262,12 +1122,10 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Sets the {@link RenderingHints#KEY_TEXT_ANTIALIASING} settings for the rendered text.
-   *
-   * @param antialiasing Either {@link RenderingHints#VALUE_TEXT_ANTIALIAS_ON} or
-   *                     {@link RenderingHints#VALUE_TEXT_ANTIALIAS_OFF}
-   */
+  /// Sets the [RenderingHints#KEY_TEXT_ANTIALIASING] settings for the rendered text.
+  ///
+  /// @param antialiasing Either [RenderingHints#VALUE_TEXT_ANTIALIAS_ON] or
+  /// [RenderingHints#VALUE_TEXT_ANTIALIAS_OFF]
   public void setTextAntialiasing(boolean antialiasing) {
     this.textAntialiasing = antialiasing;
   }
@@ -1276,38 +1134,30 @@ public abstract class GuiComponent
     this.automaticLineBreaks = automaticLineBreaks;
   }
 
-  /**
-   * Sets the horizontal text alignment.
-   *
-   * @param textAlign the new text align
-   */
+  /// Sets the horizontal text alignment.
+  ///
+  /// @param textAlign the new text align
   public void setTextAlign(final Align textAlign) {
     this.textAlign = textAlign;
   }
 
-  /**
-   * Sets the vertical text alignment.
-   *
-   * @param textValign the new text align
-   */
+  /// Sets the vertical text alignment.
+  ///
+  /// @param textValign the new text align
   public void setTextValign(final Valign textValign) {
     this.textValign = textValign;
   }
 
-  /**
-   * Sets the text angle in degrees.
-   *
-   * @param textAngle the new text angle in degrees
-   */
+  /// Sets the text angle in degrees.
+  ///
+  /// @param textAngle the new text angle in degrees
   public void setTextAngle(final int textAngle) {
     this.textAngle = textAngle;
   }
 
-  /**
-   * Enable or disable the shadow being drawn below the text
-   *
-   * @param drawTextShadow the boolean determining if a text shadow should be drawn
-   */
+  /// Enable or disable the shadow being drawn below the text
+  ///
+  /// @param drawTextShadow the boolean determining if a text shadow should be drawn
   public void setTextShadow(final boolean drawTextShadow) {
     this.textShadow = drawTextShadow;
     for (final GuiComponent comp : getComponents()) {
@@ -1315,29 +1165,23 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Sets the text X coordinate.
-   *
-   * @param x the new text X
-   */
+  /// Sets the text X coordinate.
+  ///
+  /// @param x the new text X
   public void setTextX(final double x) {
     this.textX = x;
   }
 
-  /**
-   * Sets the text Y coordinate.
-   *
-   * @param y the new text Y
-   */
+  /// Sets the text Y coordinate.
+  ///
+  /// @param y the new text Y
   public void setTextY(final double y) {
     this.textY = y;
   }
 
-  /**
-   * Sets the "visible" property on this GuiComponent.
-   *
-   * @param visible the new visible
-   */
+  /// Sets the "visible" property on this GuiComponent.
+  ///
+  /// @param visible the new visible
   public void setVisible(final boolean visible) {
     this.visible = visible;
     for (final GuiComponent component : getComponents()) {
@@ -1345,39 +1189,31 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Sets the GuiComponent's width.
-   *
-   * @param width the new width
-   */
+  /// Sets the GuiComponent's width.
+  ///
+  /// @param width the new width
   public void setWidth(final double width) {
     this.width = width;
     this.boundingBox = null; // trigger recreation in next boundingBox getter call
     updateRelativeLayout();
   }
 
-  /**
-   * Sets the GuiComponent's x coordinate.
-   *
-   * @param x the new x coordinate
-   */
+  /// Sets the GuiComponent's x coordinate.
+  ///
+  /// @param x the new x coordinate
   public void setX(final double x) {
     setLocation(x, getY());
   }
 
-  /**
-   * Sets the GuiComponent's y coordinate.
-   *
-   * @param y the new y coordinate
-   */
+  /// Sets the GuiComponent's y coordinate.
+  ///
+  /// @param y the new y coordinate
   public void setY(final double y) {
     setLocation(getX(), y);
   }
 
-  /**
-   * Suspend the GuiComponent and all its child Components (Makes the GuiComponent invisible and
-   * removes mouse listeners.).
-   */
+  /// Suspend the GuiComponent and all its child Components (Makes the GuiComponent invisible and
+  /// removes mouse listeners.).
   public void suspend() {
     Input.mouse().removeMouseListener(this);
     Input.mouse().removeMouseWheelListener(this);
@@ -1392,17 +1228,13 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Toggle this GuiComponent's selection.
-   */
+  /// Toggle this GuiComponent's selection.
   public void toggleSelection() {
     setSelected(!isSelected());
   }
 
-  /**
-   * Toggle this GuiComponent's suspension state. If it's suspended, prepare it. If it's prepared,
-   * suspend it.
-   */
+  /// Toggle this GuiComponent's suspension state. If it's suspended, prepare it. If it's prepared,
+  /// suspend it.
   public void toggleSuspension() {
     if (!isSuspended()) {
       suspend();
@@ -1418,90 +1250,70 @@ public abstract class GuiComponent
     return isHovered() ? getAppearanceHovered() : getAppearance();
   }
 
-  /**
-   * Gets the click consumer list.
-   *
-   * @return the click consumer list
-   */
+  /// Gets the click consumer list.
+  ///
+  /// @return the click consumer list
   protected List<Consumer<ComponentMouseEvent>> getClickConsumer() {
     return clickConsumer;
   }
 
-  /**
-   * Gets the hover consumer list.
-   *
-   * @return the hover consumer list
-   */
+  /// Gets the hover consumer list.
+  ///
+  /// @return the hover consumer list
   protected List<Consumer<ComponentMouseEvent>> getHoverConsumer() {
     return hoverConsumer;
   }
 
-  /**
-   * Gets the mouse dragged consumer list.
-   *
-   * @return the mouse dragged consumer list
-   */
+  /// Gets the mouse dragged consumer list.
+  ///
+  /// @return the mouse dragged consumer list
   protected List<Consumer<ComponentMouseEvent>> getMouseDraggedConsumer() {
     return mouseDraggedConsumer;
   }
 
-  /**
-   * Gets the mouse enter consumer list.
-   *
-   * @return the mouse enter consumer list
-   */
+  /// Gets the mouse enter consumer list.
+  ///
+  /// @return the mouse enter consumer list
   protected List<Consumer<ComponentMouseEvent>> getMouseEnterConsumer() {
     return mouseEnterConsumer;
   }
 
-  /**
-   * Gets the mouse leave consumer list.
-   *
-   * @return the mouse leave consumer list
-   */
+  /// Gets the mouse leave consumer list.
+  ///
+  /// @return the mouse leave consumer list
   protected List<Consumer<ComponentMouseEvent>> getMouseLeaveConsumer() {
     return mouseLeaveConsumer;
   }
 
-  /**
-   * Gets the mouse moved consumer list.
-   *
-   * @return the mouse moved consumer list
-   */
+  /// Gets the mouse moved consumer list.
+  ///
+  /// @return the mouse moved consumer list
   protected List<Consumer<ComponentMouseEvent>> getMouseMovedConsumer() {
     return mouseMovedConsumer;
   }
 
-  /**
-   * Gets the mouse pressed consumer list.
-   *
-   * @return the mouse pressed consumer list
-   */
+  /// Gets the mouse pressed consumer list.
+  ///
+  /// @return the mouse pressed consumer list
   protected List<Consumer<ComponentMouseEvent>> getMousePressedConsumer() {
     return mousePressedConsumer;
   }
 
-  /**
-   * Gets the mouse released consumer list.
-   *
-   * @return the mouse released consumer list
-   */
+  /// Gets the mouse released consumer list.
+  ///
+  /// @return the mouse released consumer list
   protected List<Consumer<ComponentMouseEvent>> getMouseReleasedConsumer() {
     return mouseReleasedConsumer;
   }
 
-  /**
-   * Gets the mouse wheel consumer list.
-   *
-   * @return the mouse wheel consumer list
-   */
+  /// Gets the mouse wheel consumer list.
+  ///
+  /// @return the mouse wheel consumer list
   protected List<Consumer<ComponentMouseWheelEvent>> getMouseWheelConsumer() {
     return mouseWheelConsumer;
   }
 
-  /**
-   * Initialize child components.
-   */
+  /// Initialize child components.
   protected void initializeComponents() {
     // nothing to do in the base class
   }
@@ -1527,12 +1339,10 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Check if a Mouse event should be forwarded.
-   *
-   * @param e the mouse event
-   * @return true, if the Mouse event should be forwarded
-   */
+  /// Check if a Mouse event should be forwarded.
+  ///
+  /// @param e the mouse event
+  /// @return true, if the Mouse event should be forwarded
   protected boolean mouseEventShouldBeForwarded(final MouseEvent e) {
     return acceptsMouseEvent(e) && isTopmostComponentAt(e);
   }
@@ -1724,11 +1534,9 @@ public abstract class GuiComponent
     }
   }
 
-  /**
-   * Render this GuiComponent's text.
-   *
-   * @param g the {@code Graphics2D} object used for drawing
-   */
+  /// Render this GuiComponent's text.
+  ///
+  /// @param g the `Graphics2D` object used for drawing
   private void renderText(final Graphics2D g) {
     if (getText() == null || getText().isEmpty()) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiProperties.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/GuiProperties.java
@@ -5,265 +5,195 @@ import de.gurkenlabs.litiengine.Valign;
 import java.awt.Color;
 import java.awt.Font;
 
-/**
- * This class contains globally used properties for all the {@link GuiComponent}s that might be added to the game.
- */
+/// This class contains globally used properties for all the [GuiComponent]s that might be added to the game.
 public class GuiProperties {
-  /**
-   * The default appearance for GUI components.
-   */
+  /// The default appearance for GUI components.
   private static Appearance defaultAppearance = new Appearance(new Color(255, 255, 255));
 
-  /**
-   * The default appearance for disabled GUI components.
-   */
+  /// The default appearance for disabled GUI components.
   private static Appearance defaultAppearanceDisabled = new Appearance(new Color(136, 136, 136));
 
-  /**
-   * The default appearance for hovered GUI components.
-   */
+  /// The default appearance for hovered GUI components.
   private static Appearance defaultAppearanceHovered = new Appearance(new Color(200, 200, 200));
 
-  /**
-   * The default font for GUI components.
-   */
+  /// The default font for GUI components.
   private static Font defaultFont;
 
-  /**
-   * The default horizontal alignment for text in GUI components.
-   */
+  /// The default horizontal alignment for text in GUI components.
   private static Align defaultTextAlign = Align.CENTER;
 
-  /**
-   * The default vertical alignment for text in GUI components.
-   */
+  /// The default vertical alignment for text in GUI components.
   private static Valign defaultTextValign = Valign.MIDDLE;
 
-  /**
-   * Indicates whether text antialiasing is enabled by default.
-   */
+  /// Indicates whether text antialiasing is enabled by default.
   private static boolean defaultTextAntialiasing = true;
 
-  /**
-   * Indicates whether text shadow is enabled by default.
-   */
+  /// Indicates whether text shadow is enabled by default.
   private static boolean defaultTextShadow = false;
 
-  /**
-   * The default color for text shadows.
-   */
+  /// The default color for text shadows.
   private static Color defaultTextShadowColor;
 
-  /**
-   * The default radius for text shadows.
-   */
+  /// The default radius for text shadows.
   private static float defaultTextShadowRadius = 2f;
 
-  /**
-   * The default display time for speech bubbles in milliseconds.
-   */
+  /// The default display time for speech bubbles in milliseconds.
   private static int defaultSpeechBubbleDisplayTime = 2000;
 
-  /**
-   * Private constructor to prevent instantiation.
-   */
+  /// Private constructor to prevent instantiation.
   private GuiProperties() {
   }
 
-  /**
-   * Gets the default appearance for GUI components.
-   *
-   * @return the default appearance
-   */
+  /// Gets the default appearance for GUI components.
+  ///
+  /// @return the default appearance
   public static Appearance getDefaultAppearance() {
     return defaultAppearance;
   }
 
-  /**
-   * Sets the default appearance for GUI components.
-   *
-   * @param app the new default appearance
-   */
+  /// Sets the default appearance for GUI components.
+  ///
+  /// @param app the new default appearance
   public static void setDefaultAppearance(Appearance app) {
     defaultAppearance = app;
   }
 
-  /**
-   * Gets the default appearance for hovered GUI components.
-   *
-   * @return the default appearance for hovered components
-   */
+  /// Gets the default appearance for hovered GUI components.
+  ///
+  /// @return the default appearance for hovered components
   public static Appearance getDefaultAppearanceHovered() {
     return defaultAppearanceHovered;
   }
 
-  /**
-   * Gets the default appearance for disabled GUI components.
-   *
-   * @return the default appearance for disabled components
-   */
+  /// Gets the default appearance for disabled GUI components.
+  ///
+  /// @return the default appearance for disabled components
   public static Appearance getDefaultAppearanceDisabled() {
     return defaultAppearanceDisabled;
   }
 
-  /**
-   * Sets the default appearance for disabled GUI components.
-   *
-   * @param app the new default appearance for disabled components
-   */
+  /// Sets the default appearance for disabled GUI components.
+  ///
+  /// @param app the new default appearance for disabled components
   public static void setDefaultAppearanceDisabled(Appearance app) {
     defaultAppearanceDisabled = app;
   }
 
-  /**
-   * Sets the default appearance for hovered GUI components.
-   *
-   * @param app the new default appearance for hovered components
-   */
+  /// Sets the default appearance for hovered GUI components.
+  ///
+  /// @param app the new default appearance for hovered components
   public static void setDefaultAppearanceHovered(Appearance app) {
     defaultAppearanceHovered = app;
   }
 
-  /**
-   * Gets the default font for GUI components.
-   *
-   * @return the default font
-   */
+  /// Gets the default font for GUI components.
+  ///
+  /// @return the default font
   public static Font getDefaultFont() {
     return defaultFont;
   }
 
-  /**
-   * Sets the default font for GUI components.
-   *
-   * @param newFont the new default font
-   */
+  /// Sets the default font for GUI components.
+  ///
+  /// @param newFont the new default font
   public static void setDefaultFont(Font newFont) {
     defaultFont = newFont;
   }
 
-  /**
-   * Gets whether text antialiasing is enabled by default.
-   *
-   * @return true if text antialiasing is enabled by default, false otherwise
-   */
+  /// Gets whether text antialiasing is enabled by default.
+  ///
+  /// @return true if text antialiasing is enabled by default, false otherwise
   public static boolean getDefaultTextAntialiasing() {
     return defaultTextAntialiasing;
   }
 
-  /**
-   * Sets whether text antialiasing is enabled by default.
-   *
-   * @param newDefault true to enable text antialiasing by default, false otherwise
-   */
+  /// Sets whether text antialiasing is enabled by default.
+  ///
+  /// @param newDefault true to enable text antialiasing by default, false otherwise
   public static void setDefaultTextAntialiasing(boolean newDefault) {
     defaultTextAntialiasing = newDefault;
   }
 
-  /**
-   * Gets whether text shadow is enabled by default.
-   *
-   * @return true if text shadow is enabled by default, false otherwise
-   */
+  /// Gets whether text shadow is enabled by default.
+  ///
+  /// @return true if text shadow is enabled by default, false otherwise
   public static boolean getDefaultTextShadow() {
     return defaultTextShadow;
   }
 
-  /**
-   * Sets whether text shadow is enabled by default.
-   *
-   * @param newDefault true to enable text shadow by default, false otherwise
-   */
+  /// Sets whether text shadow is enabled by default.
+  ///
+  /// @param newDefault true to enable text shadow by default, false otherwise
   public static void setDefaultTextShadow(boolean newDefault) {
     defaultTextShadow = newDefault;
   }
 
-  /**
-   * Gets the default color for text shadows.
-   *
-   * @return the default text shadow color
-   */
+  /// Gets the default color for text shadows.
+  ///
+  /// @return the default text shadow color
   public static Color getDefaultTextShadowColor() {
     return defaultTextShadowColor;
   }
 
-  /**
-   * Sets the default color for text shadows.
-   *
-   * @param newDefault the new default text shadow color
-   */
+  /// Sets the default color for text shadows.
+  ///
+  /// @param newDefault the new default text shadow color
   public static void setDefaultTextShadowColor(Color newDefault) {
     defaultTextShadowColor = newDefault;
   }
 
-  /**
-   * Gets the default radius for text shadows.
-   *
-   * @return the default text shadow radius
-   */
+  /// Gets the default radius for text shadows.
+  ///
+  /// @return the default text shadow radius
   public static float getDefaultTextShadowRadius() {
     return defaultTextShadowRadius;
   }
 
-  /**
-   * Sets the default radius for text shadows.
-   *
-   * @param newDefault the new default text shadow radius
-   */
+  /// Sets the default radius for text shadows.
+  ///
+  /// @param newDefault the new default text shadow radius
   public static void setDefaultTextShadowRadius(float newDefault) {
     defaultTextShadowRadius = newDefault;
   }
 
-  /**
-   * Gets the default horizontal alignment for text in GUI components.
-   *
-   * @return the default text alignment
-   */
+  /// Gets the default horizontal alignment for text in GUI components.
+  ///
+  /// @return the default text alignment
   public static Align getDefaultTextAlign() {
     return defaultTextAlign;
   }
 
-  /**
-   * Sets the default horizontal alignment for text in GUI components.
-   *
-   * @param newDefault the new default text alignment
-   */
+  /// Sets the default horizontal alignment for text in GUI components.
+  ///
+  /// @param newDefault the new default text alignment
   public static void setDefaultTextAlign(Align newDefault) {
     defaultTextAlign = newDefault;
   }
 
-  /**
-   * Gets the default vertical alignment for text in GUI components.
-   *
-   * @return the default text vertical alignment
-   */
+  /// Gets the default vertical alignment for text in GUI components.
+  ///
+  /// @return the default text vertical alignment
   public static Valign getDefaultTextValign() {
     return defaultTextValign;
   }
 
-  /**
-   * Sets the default vertical alignment for text in GUI components.
-   *
-   * @param newDefault the new default text vertical alignment
-   */
+  /// Sets the default vertical alignment for text in GUI components.
+  ///
+  /// @param newDefault the new default text vertical alignment
   public static void setDefaultTextValign(Valign newDefault) {
     defaultTextValign = newDefault;
   }
 
-  /**
-   * Gets the default display time for speech bubbles in milliseconds.
-   *
-   * @return the default speech bubble display time
-   */
+  /// Gets the default display time for speech bubbles in milliseconds.
+  ///
+  /// @return the default speech bubble display time
   public static int getDefaultSpeechBubbleDisplayTime() {
     return defaultSpeechBubbleDisplayTime;
   }
 
-  /**
-   * Sets the default display time for speech bubbles in milliseconds.
-   *
-   * @param newDefault the new default speech bubble display time
-   */
+  /// Sets the default display time for speech bubbles in milliseconds.
+  ///
+  /// @param newDefault the new default speech bubble display time
   public static void setDefaultSpeechBubbleDisplayTime(int newDefault) {
     defaultSpeechBubbleDisplayTime = newDefault;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/HorizontalSlider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/HorizontalSlider.java
@@ -1,8 +1,6 @@
-/**
- * Represents a horizontal slider GUI component. A horizontal slider allows the user to select a value from a range by dragging a slider thumb along a
- * horizontal bar. This implementation also supports rendering tick marks, custom left and right arrow buttons, and updating slider dimensions
- * dynamically.
- */
+/// Represents a horizontal slider GUI component. A horizontal slider allows the user to select a value from a range by dragging a slider thumb along a
+/// horizontal bar. This implementation also supports rendering tick marks, custom left and right arrow buttons, and updating slider dimensions
+/// dynamically.
 package de.gurkenlabs.litiengine.gui;
 
 import de.gurkenlabs.litiengine.graphics.ShapeRenderer;
@@ -12,42 +10,32 @@ import java.awt.event.KeyEvent;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 
-/**
- * A GUI component that represents a horizontal slider with customizable appearance and behavior.
- */
+/// A GUI component that represents a horizontal slider with customizable appearance and behavior.
 public class HorizontalSlider extends Slider {
 
-  /**
-   * Font icon for the left arrow button.
-   */
+  /// Font icon for the left arrow button.
   public static final FontIcon ARROW_LEFT = new FontIcon(ICON_FONT, "\uE805");
 
-  /**
-   * Font icon for the right arrow button.
-   */
+  /// Font icon for the right arrow button.
   public static final FontIcon ARROW_RIGHT = new FontIcon(ICON_FONT, "\uE806");
 
-  /**
-   * Initializes a new instance of the {@code HorizontalSlider} class with the specified properties.
-   *
-   * @param x        The x-coordinate of the slider's position.
-   * @param y        The y-coordinate of the slider's position.
-   * @param width    The width of the slider.
-   * @param height   The height of the slider.
-   * @param minValue The minimum value of the slider.
-   * @param maxValue The maximum value of the slider.
-   * @param stepSize The step size for the slider.
-   */
+  /// Initializes a new instance of the `HorizontalSlider` class with the specified properties.
+  ///
+  /// @param x        The x-coordinate of the slider's position.
+  /// @param y        The y-coordinate of the slider's position.
+  /// @param width    The width of the slider.
+  /// @param height   The height of the slider.
+  /// @param minValue The minimum value of the slider.
+  /// @param maxValue The maximum value of the slider.
+  /// @param stepSize The step size for the slider.
   public HorizontalSlider(final double x, final double y, final double width, final double height, final float minValue, final float maxValue,
     final float stepSize) {
     super(x, y, width, height, minValue, maxValue, stepSize);
   }
 
-  /**
-   * Gets the relative location of the slider thumb based on the current value.
-   *
-   * @return A {@code Point2D} representing the relative position of the slider thumb.
-   */
+  /// Gets the relative location of the slider thumb based on the current value.
+  ///
+  /// @return A `Point2D` representing the relative position of the slider thumb.
   @Override public Point2D getRelativeSliderLocation() {
     try {
       float frac = Math.clamp((getCurrentValue() - getMinValue()) / (getMaxValue() - getMinValue()), 0, 1);
@@ -58,25 +46,19 @@ public class HorizontalSlider extends Slider {
     }
   }
 
-  /**
-   * Updates the dimensions of the slider thumb based on the number of steps.
-   */
+  /// Updates the dimensions of the slider thumb based on the number of steps.
   @Override protected void updateSliderDimensions() {
     getSliderComponent().setWidth(getWidth() / (getSteps()));
   }
 
-  /**
-   * Gets the relative value of the mouse's x-coordinate within the slider's range.
-   *
-   * @return A {@code float} representing the relative mouse value.
-   */
+  /// Gets the relative value of the mouse's x-coordinate within the slider's range.
+  ///
+  /// @return A `float` representing the relative mouse value.
   @Override protected float getRelativeMouseValue() {
     return (float) ((Input.mouse().getLocation().getX() - getX()) / getWidth());
   }
 
-  /**
-   * Initializes the components of the slider, including its buttons and thumb.
-   */
+  /// Initializes the components of the slider, including its buttons and thumb.
   @Override protected void initializeComponents() {
     super.initializeComponents();
     setButton1(new ImageComponent(getX() - getHeight(), getY(), getHeight(), getHeight(), getButtonSpritesheet(), ARROW_LEFT.getText(), null));
@@ -88,21 +70,17 @@ public class HorizontalSlider extends Slider {
         "", null));
   }
 
-  /**
-   * Renders the slider's bar on the specified graphics context.
-   *
-   * @param g The {@code Graphics2D} context on which to render the bar.
-   */
+  /// Renders the slider's bar on the specified graphics context.
+  ///
+  /// @param g The `Graphics2D` context on which to render the bar.
   @Override protected void renderBar(Graphics2D g) {
     ShapeRenderer.renderOutline(g, new Line2D.Double(getX(), getY() + getHeight() / 2d, getX() + getWidth(), getY() + getHeight() / 2d),
       (float) (getHeight() / 10f) * getTickSize());
   }
 
-  /**
-   * Renders the tick marks of the slider on the specified graphics context.
-   *
-   * @param g The {@code Graphics2D} context on which to render the tick marks.
-   */
+  /// Renders the tick marks of the slider on the specified graphics context.
+  ///
+  /// @param g The `Graphics2D` context on which to render the tick marks.
   @Override protected void renderTicks(Graphics2D g) {
     for (int i = 1; i < getSteps(); i++) {
       ShapeRenderer.renderOutline(g,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ImageComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ImageComponent.java
@@ -13,10 +13,8 @@ import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import javax.swing.JLabel;
 
-/**
- * The ImageComponent class extends the GuiComponent class to provide functionality for handling images and spritesheets within a GUI component. It
- * supports various image scaling modes, alignment, and a caching mechanism to retain the scaled images in memory.
- */
+/// The ImageComponent class extends the GuiComponent class to provide functionality for handling images and spritesheets within a GUI component. It
+/// supports various image scaling modes, alignment, and a caching mechanism to retain the scaled images in memory.
 public class ImageComponent extends GuiComponent {
 
   public static final int BACKGROUND_INDEX = 0;
@@ -40,39 +38,33 @@ public class ImageComponent extends GuiComponent {
   private double horizontalImagePadding;
   private double verticalImagePadding;
 
-  /**
-   * Constructs an ImageComponent with the specified position and image.
-   *
-   * @param x     The x-coordinate of the component.
-   * @param y     The y-coordinate of the component.
-   * @param image The image to be displayed by the component.
-   */
+  /// Constructs an ImageComponent with the specified position and image.
+  ///
+  /// @param x     The x-coordinate of the component.
+  /// @param y     The y-coordinate of the component.
+  /// @param image The image to be displayed by the component.
   public ImageComponent(final double x, final double y, final Image image) {
     super(x, y, image.getWidth(null), image.getHeight(null));
     this.baseImage = (BufferedImage) image;
   }
 
-  /**
-   * Constructs an ImageComponent with the specified position and dimensions.
-   *
-   * @param x      The x-coordinate of the component.
-   * @param y      The y-coordinate of the component.
-   * @param width  The width of the component.
-   * @param height The height of the component.
-   */
+  /// Constructs an ImageComponent with the specified position and dimensions.
+  ///
+  /// @param x      The x-coordinate of the component.
+  /// @param y      The y-coordinate of the component.
+  /// @param width  The width of the component.
+  /// @param height The height of the component.
   public ImageComponent(final double x, final double y, final double width, final double height) {
     super(x, y, width, height);
   }
 
-  /**
-   * Constructs an ImageComponent with the specified position, dimensions, and text.
-   *
-   * @param x      The x-coordinate of the component.
-   * @param y      The y-coordinate of the component.
-   * @param width  The width of the component.
-   * @param height The height of the component.
-   * @param text   The text to be displayed by the component.
-   */
+  /// Constructs an ImageComponent with the specified position, dimensions, and text.
+  ///
+  /// @param x      The x-coordinate of the component.
+  /// @param y      The y-coordinate of the component.
+  /// @param width  The width of the component.
+  /// @param height The height of the component.
+  /// @param text   The text to be displayed by the component.
   public ImageComponent(final double x, final double y, final double width, final double height, final String text) {
     super(x, y, width, height);
     Font defFont = new JLabel().getFont().deriveFont((float) (this.getHeight() * 3 / 6f));
@@ -82,31 +74,27 @@ public class ImageComponent extends GuiComponent {
     this.setText(text);
   }
 
-  /**
-   * Constructs an ImageComponent with the specified position, dimensions, and image.
-   *
-   * @param x      The x-coordinate of the component.
-   * @param y      The y-coordinate of the component.
-   * @param width  The width of the component.
-   * @param height The height of the component.
-   * @param image  The image to be displayed by the component.
-   */
+  /// Constructs an ImageComponent with the specified position, dimensions, and image.
+  ///
+  /// @param x      The x-coordinate of the component.
+  /// @param y      The y-coordinate of the component.
+  /// @param width  The width of the component.
+  /// @param height The height of the component.
+  /// @param image  The image to be displayed by the component.
   public ImageComponent(final double x, final double y, final double width, final double height, final Image image) {
     super(x, y, width, height);
     this.setImage(image);
   }
 
-  /**
-   * Constructs an ImageComponent with the specified position, dimensions, spritesheet, text, and image.
-   *
-   * @param x           The x-coordinate of the component.
-   * @param y           The y-coordinate of the component.
-   * @param width       The width of the component.
-   * @param height      The height of the component.
-   * @param spritesheet The spritesheet to be used by the component.
-   * @param text        The text to be displayed by the component.
-   * @param image       The image to be displayed by the component.
-   */
+  /// Constructs an ImageComponent with the specified position, dimensions, spritesheet, text, and image.
+  ///
+  /// @param x           The x-coordinate of the component.
+  /// @param y           The y-coordinate of the component.
+  /// @param width       The width of the component.
+  /// @param height      The height of the component.
+  /// @param spritesheet The spritesheet to be used by the component.
+  /// @param text        The text to be displayed by the component.
+  /// @param image       The image to be displayed by the component.
   public ImageComponent(final double x, final double y, final double width, final double height, final Spritesheet spritesheet, final String text,
     final Image image) {
     this(x, y, width, height, text);
@@ -118,12 +106,10 @@ public class ImageComponent extends GuiComponent {
     }
   }
 
-  /**
-   * Retrieves the background image for the component based on its current state. The image is fetched from a cache if available, otherwise it is
-   * generated and added to the cache.
-   *
-   * @return The background image, or null if no spritesheet is set.
-   */
+  /// Retrieves the background image for the component based on its current state. The image is fetched from a cache if available, otherwise it is
+  /// generated and added to the cache.
+  ///
+  /// @return The background image, or null if no spritesheet is set.
   public Image getBackground() {
     if (this.getSpritesheet() == null) {
       return null;
@@ -157,10 +143,8 @@ public class ImageComponent extends GuiComponent {
     });
   }
 
-  /**
-   * Rescales the base image according to the component's dimensions and the specified image scale mode. The rescaled image is cached to improve
-   * performance on subsequent calls.
-   */
+  /// Rescales the base image according to the component's dimensions and the specified image scale mode. The rescaled image is cached to improve
+  /// performance on subsequent calls.
   public void rescaleImage() {
     if (baseImage == null) {
       this.scaledImage = null;
@@ -188,105 +172,83 @@ public class ImageComponent extends GuiComponent {
       });
   }
 
-  /**
-   * Retrieves the image to be displayed by the component. If a scaled image is available, it returns the scaled image; otherwise, it returns the base
-   * image.
-   *
-   * @return The image to be displayed by the component.
-   */
+  /// Retrieves the image to be displayed by the component. If a scaled image is available, it returns the scaled image; otherwise, it returns the base
+  /// image.
+  ///
+  /// @return The image to be displayed by the component.
   public BufferedImage getImage() {
     return scaledImage != null ? scaledImage : baseImage;
   }
 
-  /**
-   * Gets the horizontal alignment of the image within the component.
-   *
-   * @return The horizontal alignment of the image.
-   */
+  /// Gets the horizontal alignment of the image within the component.
+  ///
+  /// @return The horizontal alignment of the image.
   public Align getImageAlign() {
     return imageAlign;
   }
 
-  /**
-   * Gets the scale mode for the image.
-   *
-   * @return The scale mode for the image.
-   */
+  /// Gets the scale mode for the image.
+  ///
+  /// @return The scale mode for the image.
   public ImageScaleMode getImageScaleMode() {
     return imageScaleMode;
   }
 
-  /**
-   * Gets the scale mode for the spritesheet.
-   *
-   * @return The scale mode for the spritesheet.
-   */
+  /// Gets the scale mode for the spritesheet.
+  ///
+  /// @return The scale mode for the spritesheet.
   public ImageScaleMode getSpritesheetScaleMode() {
     return spritesheetScaleMode;
   }
 
-  /**
-   * Gets the scale factor for the spritesheet.
-   *
-   * @return The scale factor for the spritesheet.
-   */
+  /// Gets the scale factor for the spritesheet.
+  ///
+  /// @return The scale factor for the spritesheet.
   public float getSpritesheetScaleFactor() {
     return spritesheetScaleFactor;
   }
 
-  /**
-   * Gets the horizontal padding for the image.
-   *
-   * @return The horizontal padding for the image.
-   */
+  /// Gets the horizontal padding for the image.
+  ///
+  /// @return The horizontal padding for the image.
   public double getHorizontalImagePadding() {
     return horizontalImagePadding;
   }
 
-  /**
-   * Sets the horizontal padding for the image.
-   *
-   * @param horizontalImagePadding The horizontal padding to set.
-   */
+  /// Sets the horizontal padding for the image.
+  ///
+  /// @param horizontalImagePadding The horizontal padding to set.
   public void setHorizontalImagePadding(double horizontalImagePadding) {
     this.horizontalImagePadding = horizontalImagePadding;
     rescaleImage();
   }
 
-  /**
-   * Gets the vertical padding for the image.
-   *
-   * @return The vertical padding for the image.
-   */
+  /// Gets the vertical padding for the image.
+  ///
+  /// @return The vertical padding for the image.
   public double getVerticalImagePadding() {
     return verticalImagePadding;
   }
 
-  /**
-   * Sets the vertical padding for the image.
-   *
-   * @param verticalImagePadding The vertical padding to set.
-   */
+  /// Sets the vertical padding for the image.
+  ///
+  /// @param verticalImagePadding The vertical padding to set.
   public void setVerticalImagePadding(double verticalImagePadding) {
     this.verticalImagePadding = verticalImagePadding;
     rescaleImage();
   }
 
-  /**
-   * Gets the vertical alignment of the image within the component.
-   *
-   * @return The vertical alignment of the image.
-   */
+  /// Gets the vertical alignment of the image within the component.
+  ///
+  /// @return The vertical alignment of the image.
   public Valign getImageValign() {
     return imageValign;
   }
 
-  /**
-   * Renders the component using the provided Graphics2D context. If the component is suspended or not visible, the method returns immediately.
-   * Otherwise, it renders the background image (if available) and the main image (if available), and then calls the superclass's render method.
-   *
-   * @param g The Graphics2D context used for rendering.
-   */
+  /// Renders the component using the provided Graphics2D context. If the component is suspended or not visible, the method returns immediately.
+  /// Otherwise, it renders the background image (if available) and the main image (if available), and then calls the superclass's render method.
+  ///
+  /// @param g The Graphics2D context used for rendering.
   @Override
   public void render(final Graphics2D g) {
     if (isSuspended() || !isVisible()) {
@@ -307,174 +269,140 @@ public class ImageComponent extends GuiComponent {
     super.render(g);
   }
 
-  /**
-   * Sets the image to be displayed by the component and rescales it.
-   *
-   * @param image The image to be displayed by the component.
-   */
+  /// Sets the image to be displayed by the component and rescales it.
+  ///
+  /// @param image The image to be displayed by the component.
   public void setImage(final Image image) {
     this.baseImage = (BufferedImage) image;
     rescaleImage();
   }
 
-  /**
-   * Sets the scale mode for the image and rescales it.
-   *
-   * @param imageScaleMode The scale mode for the image.
-   */
+  /// Sets the scale mode for the image and rescales it.
+  ///
+  /// @param imageScaleMode The scale mode for the image.
   public void setImageScaleMode(ImageScaleMode imageScaleMode) {
     this.imageScaleMode = imageScaleMode;
     rescaleImage();
   }
 
-  /**
-   * Gets the interpolation type used for scaling the image. The interpolation type is one of the AffineTransformOp integer constants: -
-   * AffineTransformOp.TYPE_NEAREST_NEIGHBOR - AffineTransformOp.TYPE_BILINEAR - AffineTransformOp.TYPE_BICUBIC
-   *
-   * @return The interpolation type used for scaling the image.
-   */
+  /// Gets the interpolation type used for scaling the image. The interpolation type is one of the AffineTransformOp integer constants: -
+  /// AffineTransformOp.TYPE_NEAREST_NEIGHBOR - AffineTransformOp.TYPE_BILINEAR - AffineTransformOp.TYPE_BICUBIC
+  ///
+  /// @return The interpolation type used for scaling the image.
   public int getImageScaleInterpolation() {
     return imageScaleInterpolation;
   }
 
-  /**
-   * Sets the interpolation type used for scaling the image and rescales it. The interpolation type should be one of the AffineTransformOp integer
-   * constants: - AffineTransformOp.TYPE_NEAREST_NEIGHBOR - AffineTransformOp.TYPE_BILINEAR - AffineTransformOp.TYPE_BICUBIC
-   *
-   * @param imageScaleInterpolation The interpolation type used for scaling the image.
-   */
+  /// Sets the interpolation type used for scaling the image and rescales it. The interpolation type should be one of the AffineTransformOp integer
+  /// constants: - AffineTransformOp.TYPE_NEAREST_NEIGHBOR - AffineTransformOp.TYPE_BILINEAR - AffineTransformOp.TYPE_BICUBIC
+  ///
+  /// @param imageScaleInterpolation The interpolation type used for scaling the image.
   public void setImageScaleInterpolation(int imageScaleInterpolation) {
     this.imageScaleInterpolation = imageScaleInterpolation;
     this.rescaleImage();
   }
 
-  /**
-   * Sets the scale mode for the spritesheet and rescales the image.
-   *
-   * @param spritesheetScaleMode The scale mode for the spritesheet.
-   */
+  /// Sets the scale mode for the spritesheet and rescales the image.
+  ///
+  /// @param spritesheetScaleMode The scale mode for the spritesheet.
   public void setSpritesheetScaleMode(ImageScaleMode spritesheetScaleMode) {
     this.spritesheetScaleMode = spritesheetScaleMode;
     this.rescaleImage();
   }
 
-  /**
-   * Sets the scale factor for the spritesheet.
-   *
-   * @param spritesheetScaleFactor The scale factor for the spritesheet.
-   */
+  /// Sets the scale factor for the spritesheet.
+  ///
+  /// @param spritesheetScaleFactor The scale factor for the spritesheet.
   public void setSpritesheetScaleFactor(float spritesheetScaleFactor) {
     this.spritesheetScaleFactor = spritesheetScaleFactor;
   }
 
-  /**
-   * Gets the interpolation type used for scaling the spritesheet. The interpolation type should be one of the {@code AffineTransformOp} interpolation
-   * constants:
-   * <ul>
-   *   <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR},
-   *   <li>{@link AffineTransformOp#TYPE_BILINEAR},
-   *   <li>{@link AffineTransformOp#TYPE_BICUBIC}
-   * </ul>
-   *
-   * @return The interpolation type used for scaling the spritesheet.
-   */
+  /// Gets the interpolation type used for scaling the spritesheet. The interpolation type should be one of the `AffineTransformOp` interpolation
+  /// constants:
+  ///
+  /// - [AffineTransformOp#TYPE_NEAREST_NEIGHBOR],
+  /// - [AffineTransformOp#TYPE_BILINEAR],
+  /// - [AffineTransformOp#TYPE_BICUBIC]
+  ///
+  /// @return The interpolation type used for scaling the spritesheet.
   public int getSpritesheetScaleInterpolation() {
     return spritesheetScaleInterpolation;
   }
 
-  /**
-   * Sets the interpolation type used for scaling the spritesheet and rescales the image. The interpolation type should be one of the
-   * {@code AffineTransformOp} interpolation constants:
-   * <ul>
-   *   <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR},
-   *   <li>{@link AffineTransformOp#TYPE_BILINEAR},
-   *   <li>{@link AffineTransformOp#TYPE_BICUBIC}
-   * </ul>
-   *
-   * @param spritesheetScaleInterpolation The interpolation type used for scaling the spritesheet.
-   */
+  /// Sets the interpolation type used for scaling the spritesheet and rescales the image. The interpolation type should be one of the
+  /// `AffineTransformOp` interpolation constants:
+  ///
+  /// - [AffineTransformOp#TYPE_NEAREST_NEIGHBOR],
+  /// - [AffineTransformOp#TYPE_BILINEAR],
+  /// - [AffineTransformOp#TYPE_BICUBIC]
+  ///
+  /// @param spritesheetScaleInterpolation The interpolation type used for scaling the spritesheet.
   public void setSpritesheetScaleInterpolation(int spritesheetScaleInterpolation) {
     this.spritesheetScaleInterpolation = spritesheetScaleInterpolation;
     this.rescaleImage();
   }
 
-  /**
-   * Sets the spritesheet to be used by the component.
-   *
-   * @param spr The spritesheet to be used by the component.
-   */
+  /// Sets the spritesheet to be used by the component.
+  ///
+  /// @param spr The spritesheet to be used by the component.
   public void setSpritesheet(final Spritesheet spr) {
     this.spritesheet = spr;
   }
 
-  /**
-   * Sets the spritesheet and its scale mode to be used by the component.
-   *
-   * @param spr       The spritesheet to be used by the component.
-   * @param scaleMode The scale mode for the spritesheet.
-   */
+  /// Sets the spritesheet and its scale mode to be used by the component.
+  ///
+  /// @param spr       The spritesheet to be used by the component.
+  /// @param scaleMode The scale mode for the spritesheet.
   public void setSpritesheet(final Spritesheet spr, ImageScaleMode scaleMode) {
     setSpritesheet(spr);
     setSpritesheetScaleMode(scaleMode);
   }
 
-  /**
-   * Sets the spritesheet, its scale mode, and scale factor to be used by the component.
-   *
-   * @param spr         The spritesheet to be used by the component.
-   * @param scaleMode   The scale mode for the spritesheet.
-   * @param scaleFactor The scale factor for the spritesheet.
-   */
+  /// Sets the spritesheet, its scale mode, and scale factor to be used by the component.
+  ///
+  /// @param spr         The spritesheet to be used by the component.
+  /// @param scaleMode   The scale mode for the spritesheet.
+  /// @param scaleFactor The scale factor for the spritesheet.
   public void setSpritesheet(final Spritesheet spr, ImageScaleMode scaleMode, float scaleFactor) {
     setSpritesheet(spr, scaleMode);
     setSpritesheetScaleFactor(scaleFactor);
   }
 
-  /**
-   * Sets the horizontal alignment of the image within the component.
-   *
-   * @param imageAlign The horizontal alignment of the image.
-   */
+  /// Sets the horizontal alignment of the image within the component.
+  ///
+  /// @param imageAlign The horizontal alignment of the image.
   public void setImageAlign(Align imageAlign) {
     this.imageAlign = imageAlign;
   }
 
-  /**
-   * Sets the vertical alignment of the image within the component.
-   *
-   * @param imageValign The vertical alignment of the image.
-   */
+  /// Sets the vertical alignment of the image within the component.
+  ///
+  /// @param imageValign The vertical alignment of the image.
   public void setImageValign(Valign imageValign) {
     this.imageValign = imageValign;
   }
 
-  /**
-   * Sets the height of the component and rescales the image.
-   *
-   * @param height The new height of the component.
-   */
+  /// Sets the height of the component and rescales the image.
+  ///
+  /// @param height The new height of the component.
   @Override
   public void setHeight(double height) {
     super.setHeight(height);
     rescaleImage();
   }
 
-  /**
-   * Sets the width of the component and rescales the image.
-   *
-   * @param width The new width of the component.
-   */
+  /// Sets the width of the component and rescales the image.
+  ///
+  /// @param width The new width of the component.
   @Override
   public void setWidth(double width) {
     super.setWidth(width);
     rescaleImage();
   }
 
-  /**
-   * Retrieves the spritesheet used by the component.
-   *
-   * @return The spritesheet used by the component.
-   */
+  /// Retrieves the spritesheet used by the component.
+  ///
+  /// @return The spritesheet used by the component.
   protected Spritesheet getSpritesheet() {
     return spritesheet;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ImageComponentList.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ImageComponentList.java
@@ -5,9 +5,7 @@ import java.awt.Image;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * Represents a list of image components in a GUI. This class provides functionality to manage and display a list of image components.
- */
+/// Represents a list of image components in a GUI. This class provides functionality to manage and display a list of image components.
 public class ImageComponentList extends GuiComponent {
 
   private final Spritesheet background;
@@ -52,47 +50,37 @@ public class ImageComponentList extends GuiComponent {
     }
   }
 
-  /**
-   * Gets the background spritesheet of the image component list.
-   *
-   * @return The background spritesheet.
-   */
+  /// Gets the background spritesheet of the image component list.
+  ///
+  /// @return The background spritesheet.
   public Spritesheet getBackground() {
     return this.background;
   }
 
-  /**
-   * Gets the list of image components (cells) in the image component list.
-   *
-   * @return The list of image components.
-   */
+  /// Gets the list of image components (cells) in the image component list.
+  ///
+  /// @return The list of image components.
   public List<ImageComponent> getCellComponents() {
     return this.cells;
   }
 
-  /**
-   * Gets the number of columns in the image component list.
-   *
-   * @return The number of columns.
-   */
+  /// Gets the number of columns in the image component list.
+  ///
+  /// @return The number of columns.
   public int getColumns() {
     return this.columns;
   }
 
-  /**
-   * Gets the list of images in the image component list.
-   *
-   * @return The list of images.
-   */
+  /// Gets the list of images in the image component list.
+  ///
+  /// @return The list of images.
   public List<Image> getImages() {
     return this.images;
   }
 
-  /**
-   * Gets the number of rows in the image component list.
-   *
-   * @return The number of rows.
-   */
+  /// Gets the number of rows in the image component list.
+  ///
+  /// @return The number of rows.
   public int getRows() {
     return this.rows;
   }
@@ -125,72 +113,58 @@ public class ImageComponentList extends GuiComponent {
     super.prepare();
   }
 
-  /**
-   * Gets the height of each row in the image component list.
-   *
-   * @return The height of each row.
-   */
+  /// Gets the height of each row in the image component list.
+  ///
+  /// @return The height of each row.
   public double getRowHeight() {
     return this.rowHeight;
   }
 
-  /**
-   * Sets the height of each row in the image component list.
-   *
-   * @param rowHeight The height to set for each row.
-   */
+  /// Sets the height of each row in the image component list.
+  ///
+  /// @param rowHeight The height to set for each row.
   public void setRowHeight(double rowHeight) {
     this.rowHeight = rowHeight;
   }
 
-  /**
-   * Gets the width of each column in the image component list.
-   *
-   * @return The width of each column.
-   */
+  /// Gets the width of each column in the image component list.
+  ///
+  /// @return The width of each column.
   public double getColumnWidth() {
     return this.columnWidth;
   }
 
-  /**
-   * Sets the width of each column in the image component list.
-   *
-   * @param columnWidth The width to set for each column.
-   */
+  /// Sets the width of each column in the image component list.
+  ///
+  /// @param columnWidth The width to set for each column.
   public void setColumnWidth(double columnWidth) {
     this.columnWidth = columnWidth;
   }
 
-  /**
-   * Sets the horizontal offset for the image component list.
-   *
-   * @param xOffset The horizontal offset to set.
-   */
+  /// Sets the horizontal offset for the image component list.
+  ///
+  /// @param xOffset The horizontal offset to set.
   public void setXOffset(final double xOffset) {
     this.xOffset = xOffset;
   }
 
-  /**
-   * Sets the vertical offset for the image component list.
-   *
-   * @param yOffset The vertical offset to set.
-   */
+  /// Sets the vertical offset for the image component list.
+  ///
+  /// @param yOffset The vertical offset to set.
   public void setYOffset(final double yOffset) {
     this.yOffset = yOffset;
   }
 
-  /**
-   * Creates a new image component entry.
-   *
-   * @param x           The x-coordinate of the new entry.
-   * @param y           The y-coordinate of the new entry.
-   * @param width       The width of the new entry.
-   * @param height      The height of the new entry.
-   * @param spritesheet The spritesheet to be used for the new entry.
-   * @param text        The text to be displayed on the new entry.
-   * @param image       The image to be displayed on the new entry.
-   * @return The newly created image component.
-   */
+  /// Creates a new image component entry.
+  ///
+  /// @param x           The x-coordinate of the new entry.
+  /// @param y           The y-coordinate of the new entry.
+  /// @param width       The width of the new entry.
+  /// @param height      The height of the new entry.
+  /// @param spritesheet The spritesheet to be used for the new entry.
+  /// @param text        The text to be displayed on the new entry.
+  /// @param image       The image to be displayed on the new entry.
+  /// @return The newly created image component.
   protected ImageComponent createNewEntry(final double x, final double y, final double width, final double height, final Spritesheet spritesheet,
     final String text, final Image image) {
     return new ImageComponent(x, y, width, height, spritesheet, text, image);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ImageScaleMode.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ImageScaleMode.java
@@ -1,26 +1,16 @@
 package de.gurkenlabs.litiengine.gui;
 
-/**
- * Enum representing different modes for scaling images.
- */
+/// Enum representing different modes for scaling images.
 public enum ImageScaleMode {
-  /**
-   * No scaling is applied to the image.
-   */
+  /// No scaling is applied to the image.
   NORMAL,
 
-  /**
-   * The image is stretched to fill the available space.
-   */
+  /// The image is stretched to fill the available space.
   STRETCH,
 
-  /**
-   * The image is scaled to fit within the available space while maintaining its aspect ratio.
-   */
+  /// The image is scaled to fit within the available space while maintaining its aspect ratio.
   FIT,
 
-  /**
-   * The image is scaled and cropped to fill the available space while maintaining its aspect ratio.
-   */
+  /// The image is scaled and cropped to fill the available space while maintaining its aspect ratio.
   SLICE
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ListField.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/ListField.java
@@ -15,9 +15,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.IntConsumer;
 
-/**
- * The Class ListField.
- */
+/// The Class ListField.
 public class ListField extends GuiComponent {
   private final List<IntConsumer> changeConsumer;
   private final CopyOnWriteArrayList<CopyOnWriteArrayList<ImageComponent>> listEntries;
@@ -43,56 +41,52 @@ public class ListField extends GuiComponent {
   private HorizontalSlider horizontalSlider;
   private boolean sliderInside = false;
 
-  /**
-   * Creates a vertical list field. <br>
-   * <br>
-   * The <b>content</b> of this list field can only be accessed through the first column (column 0). <br>
-   * Examples:
-   *
-   * <blockquote>
-   * <p>
-   * content[0][0] - ok<br>
-   * content[0][1] - ok<br>
-   * content[0][8] - ok<br>
-   * content[1][5] - NOK<br>
-   * content[2][0] - NOK<br>
-   *
-   * </blockquote>
-   *
-   * @param x         The x-coordinate of the ListField.
-   * @param y         The y-coordinate of the ListField.
-   * @param width     The width of the ListField.
-   * @param height    The height of the ListField.
-   * @param content   The 1 dimension array to show in the ListField.
-   * @param shownRows The number of rows/elements to display before the user needs to scroll for more possible rows/elements.
-   * @see #ListField(double, double, double, double, Object[], int)
-   */
+  /// Creates a vertical list field.
+  ///
+  /// The **content** of this list field can only be accessed through the first column (column 0).
+  ///
+  /// Examples:
+  ///
+  /// > content[0][0] - ok
+  ///
+  /// > content[0][1] - ok
+  ///
+  /// > content[0][8] - ok
+  ///
+  /// > content[1][5] - NOK
+  ///
+  /// > content[2][0] - NOK
+  ///
+  /// @param x         The x-coordinate of the ListField.
+  /// @param y         The y-coordinate of the ListField.
+  /// @param width     The width of the ListField.
+  /// @param height    The height of the ListField.
+  /// @param content   The 1 dimension array to show in the ListField.
+  /// @param shownRows The number of rows/elements to display before the user needs to scroll for more possible rows/elements.
+  /// @see #ListField(double, double, double, double, Object[], int)
   public ListField(final double x, final double y, final double width, final double height, final Object[] content, final int shownRows) {
     this(x, y, width, height, new Object[][]{content}, shownRows, 1);
   }
 
-  /**
-   * Creates a 2D vertical list field. <br>
-   * <br>
-   * The given <b>content</b> should be arranged as columns of elements. <br>
-   * Examples:
-   *
-   * <blockquote>
-   * <p>
-   * content[0][0] - column 0, row 0<br>
-   * content[0][1] - column 0, row 1<br>
-   * content[2][8] - column 2, row 8<br>
-   *
-   * </blockquote>
-   *
-   * @param x            The x-coordinate of the ListField.
-   * @param y            The y-coordinate of the ListField.
-   * @param width        The width of the ListField.
-   * @param height       The height of the ListField.
-   * @param content      The 2 dimension array to show in the ListField.
-   * @param shownRows    The number of rows to display before the user needs to scroll for more possible rows.
-   * @param shownColumns The number of columns to display before the user needs to scroll for more possible columns.
-   */
+  /// Creates a 2D vertical list field.
+  ///
+  /// The given **content** should be arranged as columns of elements.
+  ///
+  /// Examples:
+  ///
+  /// > content[0][0] - column 0, row 0
+  ///
+  /// > content[0][1] - column 0, row 1
+  ///
+  /// > content[2][8] - column 2, row 8
+  ///
+  /// @param x            The x-coordinate of the ListField.
+  /// @param y            The y-coordinate of the ListField.
+  /// @param width        The width of the ListField.
+  /// @param height       The height of the ListField.
+  /// @param content      The 2 dimension array to show in the ListField.
+  /// @param shownRows    The number of rows to display before the user needs to scroll for more possible rows.
+  /// @param shownColumns The number of columns to display before the user needs to scroll for more possible columns.
   public ListField(final double x, final double y, final double width, final double height, final Object[][] content, final int shownRows, final int shownColumns) {
     super(x, y, width, height);
     this.changeConsumer = new CopyOnWriteArrayList<>();
@@ -108,106 +102,85 @@ public class ListField extends GuiComponent {
     prepareInput();
   }
 
-  /**
-   * Resets the ListField's selection to {@code null}. <br>
-   * The ListField will then show no selection.
-   */
+  /// Resets the ListField's selection to `null`.
+  ///
+  /// The ListField will then show no selection.
   public void deselect() {
     this.selectionColumn = -1;
     this.selectionRow = -1;
     this.selectedComponent = null;
   }
 
-  /**
-   * Gets the spritesheet used for the button.
-   *
-   * @return The spritesheet for the button.
-   */
+  /// Gets the spritesheet used for the button.
+  ///
+  /// @return The spritesheet for the button.
   public Spritesheet getButtonSprite() {
     return this.buttonSprite;
   }
 
-  /**
-   * Sets the spritesheet for the button and reinitializes the content list.
-   *
-   * @param buttonSprite The spritesheet to set for the button.
-   */
+  /// Sets the spritesheet for the button and reinitializes the content list.
+  ///
+  /// @param buttonSprite The spritesheet to set for the button.
   public void setButtonSprite(final Spritesheet buttonSprite) {
     this.buttonSprite = buttonSprite;
     initContentList();
   }
 
-  /**
-   * Gets the list of change consumers.
-   * Change consumers are functions that are executed when the selection changes.
-   *
-   * @return A list of IntConsumer objects representing the change consumers.
-   */
+  /// Gets the list of change consumers.
+  /// Change consumers are functions that are executed when the selection changes.
+  ///
+  /// @return A list of IntConsumer objects representing the change consumers.
   public List<IntConsumer> getChangeConsumer() {
     return this.changeConsumer;
   }
 
-  /**
-   * Gets the content of the list field.
-   *
-   * @return A 2D array of objects representing the content of the list field.
-   */
+  /// Gets the content of the list field.
+  ///
+  /// @return A 2D array of objects representing the content of the list field.
   public Object[][] getContent() {
     return this.content;
   }
 
-  /**
-   * Gets the spritesheet used for the list entries.
-   *
-   * @return The spritesheet for the list entries.
-   */
+  /// Gets the spritesheet used for the list entries.
+  ///
+  /// @return The spritesheet for the list entries.
   public Spritesheet getEntrySprite() {
     return this.entrySprite;
   }
 
-  /**
-   * Sets the spritesheet for the list entries and reinitializes the content list.
-   *
-   * @param entrySprite The spritesheet to set for the list entries.
-   */
+  /// Sets the spritesheet for the list entries and reinitializes the content list.
+  ///
+  /// @param entrySprite The spritesheet to set for the list entries.
   public void setEntrySprite(final Spritesheet entrySprite) {
     this.entrySprite = entrySprite;
     initContentList();
   }
 
-  /**
-   * Gets the current horizontal lower bound of the list field.
-   *
-   * @return The horizontal lower bound.
-   */
+  /// Gets the current horizontal lower bound of the list field.
+  ///
+  /// @return The horizontal lower bound.
   public int getHorizontalLowerBound() {
     return this.horizontalLowerBound;
   }
 
-  /**
-   * Sets the horizontal lower bound of the list field.
-   *
-   * @param lowerBound The new horizontal lower bound to set.
-   */
+  /// Sets the horizontal lower bound of the list field.
+  ///
+  /// @param lowerBound The new horizontal lower bound to set.
   public void setHorizontalLowerBound(final int lowerBound) {
     this.horizontalLowerBound = lowerBound;
   }
 
-  /**
-   * Gets the horizontal slider associated with the list field.
-   *
-   * @return The horizontal slider.
-   */
+  /// Gets the horizontal slider associated with the list field.
+  ///
+  /// @return The horizontal slider.
   public HorizontalSlider getHorizontalSlider() {
     return this.horizontalSlider;
   }
 
-  /**
-   * Returns all list items of a specified column.
-   *
-   * @param column the column
-   * @return a list of items
-   */
+  /// Returns all list items of a specified column.
+  ///
+  /// @param column the column
+  /// @return a list of items
   public List<ImageComponent> getListEntry(final int column) {
     if (column < 0 || column >= this.listEntries.size()) {
       return new ArrayList<>();
@@ -215,13 +188,11 @@ public class ListField extends GuiComponent {
     return this.listEntries.get(column);
   }
 
-  /**
-   * Returns item at a specified column and row.
-   *
-   * @param column the column
-   * @param row    the row
-   * @return ImageComponent at [column,row]
-   */
+  /// Returns item at a specified column and row.
+  ///
+  /// @param column the column
+  /// @param row    the row
+  /// @return ImageComponent at [column,row]
   public ImageComponent getListEntry(final int column, final int row) {
     if (column < 0 || row < 0 || column >= this.listEntries.size() || row >= this.listEntries.get(column).size()) {
       return null;
@@ -229,11 +200,9 @@ public class ListField extends GuiComponent {
     return this.listEntries.get(column).get(row);
   }
 
-  /**
-   * Returns the number of rows of the tallest column.
-   *
-   * @return int representing the length of the tallest column
-   */
+  /// Returns the number of rows of the tallest column.
+  ///
+  /// @return int representing the length of the tallest column
   public int getMaxRows() {
     int result = 0;
     for (Object[] o : this.getContent()) {
@@ -244,38 +213,30 @@ public class ListField extends GuiComponent {
     return result;
   }
 
-  /**
-   * Gets the number of rows currently shown in the list field.
-   *
-   * @return The number of rows displayed in the list field.
-   */
+  /// Gets the number of rows currently shown in the list field.
+  ///
+  /// @return The number of rows displayed in the list field.
   public int getNumberOfShownRows() {
     return shownRows;
   }
 
-  /**
-   * Gets the number of columns currently shown in the list field.
-   *
-   * @return The number of columns displayed in the list field.
-   */
+  /// Gets the number of columns currently shown in the list field.
+  ///
+  /// @return The number of columns displayed in the list field.
   public int getNumberOfShownColumns() {
     return shownColumns;
   }
 
-  /**
-   * Gets the currently selected component in the list field.
-   *
-   * @return The selected ImageComponent, or null if no component is selected.
-   */
+  /// Gets the currently selected component in the list field.
+  ///
+  /// @return The selected ImageComponent, or null if no component is selected.
   public ImageComponent getSelectedComponent() {
     return selectedComponent;
   }
 
-  /**
-   * Gets the object associated with the currently selected component in the list field.
-   *
-   * @return The object at the selected position, or null if no component is selected.
-   */
+  /// Gets the object associated with the currently selected component in the list field.
+  ///
+  /// @return The object at the selected position, or null if no component is selected.
   public Object getSelectedObject() {
     if (this.getSelectedComponent() == null) {
       return null;
@@ -283,11 +244,9 @@ public class ListField extends GuiComponent {
     return getContent()[selectionColumn][selectionRow];
   }
 
-  /**
-   * Returns the selected column.
-   *
-   * @return number of the column; -1 if isEntireRowSelected() is true
-   */
+  /// Returns the selected column.
+  ///
+  /// @return number of the column; -1 if isEntireRowSelected() is true
   public int getSelectionColumn() {
     if (isEntireRowSelected()) {
       return -1;
@@ -295,72 +254,56 @@ public class ListField extends GuiComponent {
     return selectionColumn;
   }
 
-  /**
-   * Returns the selected row.
-   *
-   * @return number of the row
-   */
+  /// Returns the selected row.
+  ///
+  /// @return number of the row
   public int getSelectionRow() {
     return selectionRow;
   }
 
-  /**
-   * Gets the current vertical lower bound of the list field.
-   *
-   * @return The vertical lower bound.
-   */
+  /// Gets the current vertical lower bound of the list field.
+  ///
+  /// @return The vertical lower bound.
   public int getVerticalLowerBound() {
     return verticalLowerBound;
   }
 
-  /**
-   * Sets the vertical lower bound of the list field.
-   *
-   * @param lowerBound The new vertical lower bound to set.
-   */
+  /// Sets the vertical lower bound of the list field.
+  ///
+  /// @param lowerBound The new vertical lower bound to set.
   public void setVerticalLowerBound(final int lowerBound) {
     this.verticalLowerBound = lowerBound;
   }
 
-  /**
-   * Gets the vertical slider associated with the list field.
-   *
-   * @return The vertical slider.
-   */
+  /// Gets the vertical slider associated with the list field.
+  ///
+  /// @return The vertical slider.
   public VerticalSlider getVerticalSlider() {
     return verticalSlider;
   }
 
-  /**
-   * Checks if arrow key navigation is enabled for the list field.
-   *
-   * @return True if arrow key navigation is enabled, false otherwise.
-   */
+  /// Checks if arrow key navigation is enabled for the list field.
+  ///
+  /// @return True if arrow key navigation is enabled, false otherwise.
   public boolean isArrowKeyNavigation() {
     return arrowKeyNavigation;
   }
 
-  /**
-   * Enables or disables arrow key navigation for the list field.
-   *
-   * @param arrowKeyNavigation True to enable arrow key navigation, false to disable it.
-   */
+  /// Enables or disables arrow key navigation for the list field.
+  ///
+  /// @param arrowKeyNavigation True to enable arrow key navigation, false to disable it.
   public void setArrowKeyNavigation(final boolean arrowKeyNavigation) {
     this.arrowKeyNavigation = arrowKeyNavigation;
   }
 
-  /**
-   * Registers a new change consumer to be executed when the selection changes.
-   *
-   * @param c The IntConsumer to be added to the list of change consumers.
-   */
+  /// Registers a new change consumer to be executed when the selection changes.
+  ///
+  /// @param c The IntConsumer to be added to the list of change consumers.
   public void onChange(final IntConsumer c) {
     getChangeConsumer().add(c);
   }
 
-  /**
-   * Refreshes the list field by updating the list entries and selecting the current component.
-   */
+  /// Refreshes the list field by updating the list entries and selecting the current component.
   public void refresh() {
     refreshListEntries();
     selectComponent();
@@ -392,12 +335,10 @@ public class ListField extends GuiComponent {
     }
   }
 
-  /**
-   * Sets whether mouse events should be forwarded for all components in the specified column.
-   *
-   * @param column             The column index for which to set the mouse event forwarding.
-   * @param forwardMouseEvents True to enable forwarding of mouse events, false to disable it.
-   */
+  /// Sets whether mouse events should be forwarded for all components in the specified column.
+  ///
+  /// @param column             The column index for which to set the mouse event forwarding.
+  /// @param forwardMouseEvents True to enable forwarding of mouse events, false to disable it.
   public void setForwardMouseEvents(final int column, final boolean forwardMouseEvents) {
     if (column < 0 && column >= nbOfColumns) {
       return;
@@ -429,72 +370,59 @@ public class ListField extends GuiComponent {
     refresh();
   }
 
-  /**
-   * If set to true, selecting an element will show a selection of the entire column on which that element is on. Without
-   * taking account of its row. <br>
-   * <br>
-   * Set to <b>false</b> as default.
-   *
-   * @param selectEntireColumn a boolean
-   */
+  /// If set to true, selecting an element will show a selection of the entire column on which that element is on. Without
+  /// taking account of its row.
+  ///
+  /// Set to **false** as default.
+  ///
+  /// @param selectEntireColumn a boolean
   public void setSelectEntireColumn(boolean selectEntireColumn) {
     this.selectEntireColumn = selectEntireColumn;
   }
 
-  /**
-   * If set to true, selecting an element will show a selection of the entire row on which that element is on. Without
-   * taking account of its column. <br>
-   * <br>
-   * Set to <b>false</b> as default.
-   *
-   * @param selectEntireRow a boolean
-   */
+  /// If set to true, selecting an element will show a selection of the entire row on which that element is on. Without
+  /// taking account of its column.
+  ///
+  /// Set to **false** as default.
+  ///
+  /// @param selectEntireRow a boolean
   public void setSelectEntireRow(boolean selectEntireRow) {
     this.selectEntireRow = selectEntireRow;
   }
 
-  /**
-   * See {@link #setSelectEntireColumn(boolean)}
-   *
-   * @return true if selection is set to select the entire column; false otherwise
-   */
+  /// See [#setSelectEntireColumn(boolean)]
+  ///
+  /// @return true if selection is set to select the entire column; false otherwise
   public boolean isEntireColumnSelected() {
     return selectEntireColumn;
   }
 
-  /**
-   * See {@link #setSelectEntireRow(boolean)}
-   *
-   * @return true if selection is set to select the entire row; false otherwise
-   */
+  /// See [#setSelectEntireRow(boolean)]
+  ///
+  /// @return true if selection is set to select the entire row; false otherwise
   public boolean isEntireRowSelected() {
     return selectEntireRow;
   }
 
-  /**
-   * Verify if sliders are set to be inside the ListField.
-   *
-   * @return true if slider is set to be inside the ListField; false otherwise
-   */
+  /// Verify if sliders are set to be inside the ListField.
+  ///
+  /// @return true if slider is set to be inside the ListField; false otherwise
   public boolean isSliderInside() {
     return sliderInside;
   }
 
-  /**
-   * If set to true, the sliders of this ListField will be displayed within its boundaries. This is necessary, for
-   * example, when a ListField covers an entire screen. <br>
-   * Set to <b>false</b> as default.
-   *
-   * @param sliderInside a boolean
-   */
+  /// If set to true, the sliders of this ListField will be displayed within its boundaries. This is necessary, for
+  /// example, when a ListField covers an entire screen.
+  ///
+  /// Set to **false** as default.
+  ///
+  /// @param sliderInside a boolean
   public void setSliderInside(boolean sliderInside) {
     this.sliderInside = sliderInside;
     initSliders();
   }
 
-  /**
-   * Slides the ListField up by one row.
-   */
+  /// Slides the ListField up by one row.
   public void slideUp() {
     if (getVerticalLowerBound() <= 0) {
       return;
@@ -504,9 +432,7 @@ public class ListField extends GuiComponent {
     refresh();
   }
 
-  /**
-   * Slides the ListField down by one row.
-   */
+  /// Slides the ListField down by one row.
   public void slideDown() {
     if (getVerticalLowerBound() >= getMaxRows() - getNumberOfShownRows()) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Menu.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Menu.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.IntConsumer;
 
-/**
- * Represents a menu component that extends the ImageComponentList. This class provides functionality to create a menu with selectable items.
- */
+/// Represents a menu component that extends the ImageComponentList. This class provides functionality to create a menu with selectable items.
 public class Menu extends ImageComponentList {
 
   private int currentSelection;
@@ -20,16 +18,14 @@ public class Menu extends ImageComponentList {
 
   private final Orientation orientation;
 
-  /**
-   * Constructs a new Menu with the specified position, size, and orientation.
-   *
-   * @param x           The x-coordinate of the menu.
-   * @param y           The y-coordinate of the menu.
-   * @param width       The width of the menu.
-   * @param height      The height of the menu.
-   * @param orientation The orientation of the menu (horizontal or vertical).
-   * @param items       The items to be displayed in the menu.
-   */
+  /// Constructs a new Menu with the specified position, size, and orientation.
+  ///
+  /// @param x           The x-coordinate of the menu.
+  /// @param y           The y-coordinate of the menu.
+  /// @param width       The width of the menu.
+  /// @param height      The height of the menu.
+  /// @param orientation The orientation of the menu (horizontal or vertical).
+  /// @param items       The items to be displayed in the menu.
   public Menu(
     double x,
     double y,
@@ -40,15 +36,13 @@ public class Menu extends ImageComponentList {
     this(x, y, width, height, null, orientation, items);
   }
 
-  /**
-   * Constructs a new Menu with the specified position, size, and items.
-   *
-   * @param x      The x-coordinate of the menu.
-   * @param y      The y-coordinate of the menu.
-   * @param width  The width of the menu.
-   * @param height The height of the menu.
-   * @param items  The items to be displayed in the menu.
-   */
+  /// Constructs a new Menu with the specified position, size, and items.
+  ///
+  /// @param x      The x-coordinate of the menu.
+  /// @param y      The y-coordinate of the menu.
+  /// @param width  The width of the menu.
+  /// @param height The height of the menu.
+  /// @param items  The items to be displayed in the menu.
   public Menu(
     double x,
     double y,
@@ -58,17 +52,15 @@ public class Menu extends ImageComponentList {
     this(x, y, width, height, null, Orientation.VERTICAL, items);
   }
 
-  /**
-   * Constructs a new Menu with the specified position, size, background, and orientation.
-   *
-   * @param x           The x-coordinate of the menu.
-   * @param y           The y-coordinate of the menu.
-   * @param width       The width of the menu.
-   * @param height      The height of the menu.
-   * @param background  The background of the menu.
-   * @param orientation The orientation of the menu (horizontal or vertical).
-   * @param items       The items to be displayed in the menu.
-   */
+  /// Constructs a new Menu with the specified position, size, background, and orientation.
+  ///
+  /// @param x           The x-coordinate of the menu.
+  /// @param y           The y-coordinate of the menu.
+  /// @param width       The width of the menu.
+  /// @param height      The height of the menu.
+  /// @param background  The background of the menu.
+  /// @param orientation The orientation of the menu (horizontal or vertical).
+  /// @param items       The items to be displayed in the menu.
   public Menu(
     double x,
     double y,
@@ -88,36 +80,28 @@ public class Menu extends ImageComponentList {
     this.prepareInput();
   }
 
-  /**
-   * Gets the current selection index of the menu.
-   *
-   * @return The current selection index of the menu.
-   */
+  /// Gets the current selection index of the menu.
+  ///
+  /// @return The current selection index of the menu.
   public int getCurrentSelection() {
     return this.currentSelection;
   }
 
-  /**
-   * Gets the orientation of the menu.
-   *
-   * @return The orientation of the menu.
-   */
+  /// Gets the orientation of the menu.
+  ///
+  /// @return The orientation of the menu.
   public Orientation getOrientation() {
     return orientation;
   }
 
-  /**
-   * Adds a consumer that will be notified when the selection of the menu changes.
-   *
-   * @param cons The consumer that will be notified when the selection of the menu changes.
-   */
+  /// Adds a consumer that will be notified when the selection of the menu changes.
+  ///
+  /// @param cons The consumer that will be notified when the selection of the menu changes.
   public void onChange(final IntConsumer cons) {
     this.selectionChangeConsumers.add(cons);
   }
 
-  /**
-   * Prepares the menu by setting the text of the menu buttons and adding the click listeners.
-   */
+  /// Prepares the menu by setting the text of the menu buttons and adding the click listeners.
   @Override
   public void prepare() {
 
@@ -133,11 +117,9 @@ public class Menu extends ImageComponentList {
     }
   }
 
-  /**
-   * Sets the current selection index of the menu and updates the selection state of the menu items.
-   *
-   * @param newSelection The index of the item to be selected.
-   */
+  /// Sets the current selection index of the menu and updates the selection state of the menu items.
+  ///
+  /// @param newSelection The index of the item to be selected.
   public void setCurrentSelection(final int newSelection) {
     if (getCellComponents().isEmpty()) {
       return;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/MouseDrawComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/MouseDrawComponent.java
@@ -9,36 +9,26 @@ import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import javax.swing.SwingUtilities;
 
-/**
- * Represents a GUI component that supports freehand drawing using mouse input.
- */
+/// Represents a GUI component that supports freehand drawing using mouse input.
 public class MouseDrawComponent extends ImageComponent {
-  /**
-   * The size of the brush used for drawing.
-   */
+  /// The size of the brush used for drawing.
   private double brushSize = 2;
 
-  /**
-   * The canvas where the drawing is performed.
-   */
+  /// The canvas where the drawing is performed.
   private final BufferedImage drawingSpace;
 
-  /**
-   * The current color of the brush.
-   */
+  /// The current color of the brush.
   private Color drawingColor = Color.WHITE;
 
-  /**
-   * Creates a new instance of the {@code MouseDrawComponent}.
-   *
-   * @param x           The x-coordinate of the component's position.
-   * @param y           The y-coordinate of the component's position.
-   * @param width       The width of the component.
-   * @param height      The height of the component.
-   * @param spritesheet The spritesheet associated with the component.
-   * @param text        The text displayed on the component.
-   * @param image       The image used for rendering the component.
-   */
+  /// Creates a new instance of the `MouseDrawComponent`.
+  ///
+  /// @param x           The x-coordinate of the component's position.
+  /// @param y           The y-coordinate of the component's position.
+  /// @param width       The width of the component.
+  /// @param height      The height of the component.
+  /// @param spritesheet The spritesheet associated with the component.
+  /// @param text        The text displayed on the component.
+  /// @param image       The image used for rendering the component.
   public MouseDrawComponent(
     double x,
     double y,
@@ -51,59 +41,47 @@ public class MouseDrawComponent extends ImageComponent {
     this.drawingSpace = Imaging.getCompatibleImage((int) width, (int) height);
   }
 
-  /**
-   * Renders the component and the current drawing on the graphics context.
-   *
-   * @param g The {@code Graphics2D} context used for rendering.
-   */
+  /// Renders the component and the current drawing on the graphics context.
+  ///
+  /// @param g The `Graphics2D` context used for rendering.
   @Override
   public void render(Graphics2D g) {
     super.render(g);
     g.drawImage(this.drawingSpace, (int) getX(), (int) getY(), null);
   }
 
-  /**
-   * Sets the size of the brush used for drawing.
-   *
-   * @param newSize The new brush size.
-   */
+  /// Sets the size of the brush used for drawing.
+  ///
+  /// @param newSize The new brush size.
   public void setBrushSize(double newSize) {
     this.brushSize = newSize;
   }
 
-  /**
-   * Gets the size of the brush used for drawing.
-   *
-   * @return The current brush size.
-   */
+  /// Gets the size of the brush used for drawing.
+  ///
+  /// @return The current brush size.
   public double getBrushSize() {
     return brushSize;
   }
 
-  /**
-   * Gets the current color of the brush.
-   *
-   * @return The current drawing color.
-   */
+  /// Gets the current color of the brush.
+  ///
+  /// @return The current drawing color.
   public Color getDrawingColor() {
     return this.drawingColor;
   }
 
-  /**
-   * Sets the color of the brush used for drawing.
-   *
-   * @param color The new drawing color.
-   */
+  /// Sets the color of the brush used for drawing.
+  ///
+  /// @param color The new drawing color.
   public void setDrawingColor(Color color) {
     this.drawingColor = color;
   }
 
-  /**
-   * Handles mouse drag events to draw or erase on the component. Left mouse button draws with the current brush color, while right mouse button
-   * clears the area.
-   *
-   * @param e The {@code MouseEvent} triggered by dragging the mouse.
-   */
+  /// Handles mouse drag events to draw or erase on the component. Left mouse button draws with the current brush color, while right mouse button
+  /// clears the area.
+  ///
+  /// @param e The `MouseEvent` triggered by dragging the mouse.
   @Override
   public void mouseDragged(MouseEvent e) {
     if (!mouseEventShouldBeForwarded(e)) {
@@ -130,18 +108,14 @@ public class MouseDrawComponent extends ImageComponent {
     }
   }
 
-  /**
-   * Clears the entire drawing space, removing all drawings.
-   */
+  /// Clears the entire drawing space, removing all drawings.
   public void clearDrawingSpace() {
     drawingSpace.getGraphics().clearRect(0, 0, drawingSpace.getWidth(), drawingSpace.getHeight());
   }
 
-  /**
-   * Gets the current drawing space.
-   *
-   * @return The {@code BufferedImage} used for drawing.
-   */
+  /// Gets the current drawing space.
+  ///
+  /// @return The `BufferedImage` used for drawing.
   public BufferedImage getDrawingSpace() {
     return this.drawingSpace;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Orientation.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Orientation.java
@@ -1,8 +1,6 @@
 package de.gurkenlabs.litiengine.gui;
 
-/**
- * Represents the orientation of a menu or component. It can be either horizontal or vertical.
- */
+/// Represents the orientation of a menu or component. It can be either horizontal or vertical.
 public enum Orientation {
   HORIZONTAL,
   VERTICAL

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Slider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Slider.java
@@ -9,13 +9,10 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 
-/**
- * Abstract base class for GUI slider components that allow a user to pick a numerical value within a configurable range and step size.
- * <p>
- * Subclasses provide the concrete orientation (e.g. horizontal / vertical) and implement the slider geometry through {@link #renderBar(Graphics2D)},
- * {@link #renderTicks(Graphics2D)} and the location/mouse mapping helpers.
- * </p>
- */
+/// Abstract base class for GUI slider components that allow a user to pick a numerical value within a configurable range and step size.
+///
+/// Subclasses provide the concrete orientation (e.g. horizontal / vertical) and implement the slider geometry through [#renderBar(Graphics2D)],
+/// [#renderTicks(Graphics2D)] and the location/mouse mapping helpers.
 public abstract class Slider extends GuiComponent {
 
   private final List<Consumer<Float>> changeConsumer = new CopyOnWriteArrayList<>();
@@ -35,17 +32,15 @@ public abstract class Slider extends GuiComponent {
   private float tickSize;
 
 
-  /**
-   * Constructs a new slider with the given bounds and value range.
-   *
-   * @param x        the x position of the slider
-   * @param y        the y position of the slider
-   * @param width    the width of the slider
-   * @param height   the height of the slider
-   * @param minValue the minimum selectable value
-   * @param maxValue the maximum selectable value
-   * @param stepSize the step size between adjacent selectable values
-   */
+  /// Constructs a new slider with the given bounds and value range.
+  ///
+  /// @param x        the x position of the slider
+  /// @param y        the y position of the slider
+  /// @param width    the width of the slider
+  /// @param height   the height of the slider
+  /// @param minValue the minimum selectable value
+  /// @param maxValue the maximum selectable value
+  /// @param stepSize the step size between adjacent selectable values
   protected Slider(final double x, final double y, final double width, final double height, final float minValue, final float maxValue,
     final float stepSize) {
     super(x, y, width, height);
@@ -75,20 +70,16 @@ public abstract class Slider extends GuiComponent {
 
   }
 
-  /**
-   * Gets the first arrow button (e.g. decrease).
-   *
-   * @return the first button component
-   */
+  /// Gets the first arrow button (e.g. decrease).
+  ///
+  /// @return the first button component
   public ImageComponent getButton1() {
     return button1;
   }
 
-  /**
-   * Sets the first arrow button (typically used to decrease the slider value).
-   *
-   * @param button1 the button component to register
-   */
+  /// Sets the first arrow button (typically used to decrease the slider value).
+  ///
+  /// @param button1 the button component to register
   protected void setButton1(final ImageComponent button1) {
     this.button1 = button1;
     this.button1.onClicked(e -> {
@@ -99,20 +90,16 @@ public abstract class Slider extends GuiComponent {
     this.getComponents().add(this.getButton1());
   }
 
-  /**
-   * Gets the second arrow button (e.g. increase).
-   *
-   * @return the second button component
-   */
+  /// Gets the second arrow button (e.g. increase).
+  ///
+  /// @return the second button component
   public ImageComponent getButton2() {
     return button2;
   }
 
-  /**
-   * Sets the second arrow button (typically used to increase the slider value).
-   *
-   * @param button2 the button component to register
-   */
+  /// Sets the second arrow button (typically used to increase the slider value).
+  ///
+  /// @param button2 the button component to register
   protected void setButton2(final ImageComponent button2) {
     this.button2 = button2;
     this.button2.onClicked(e -> {
@@ -123,154 +110,120 @@ public abstract class Slider extends GuiComponent {
     getComponents().add(getButton2());
   }
 
-  /**
-   * Gets the spritesheet used to render the arrow buttons.
-   *
-   * @return the button spritesheet
-   */
+  /// Gets the spritesheet used to render the arrow buttons.
+  ///
+  /// @return the button spritesheet
   public Spritesheet getButtonSpritesheet() {
     return buttonSprite;
   }
 
-  /**
-   * Sets the spritesheet used to render the arrow buttons.
-   *
-   * @param buttonSprite the spritesheet to use
-   */
+  /// Sets the spritesheet used to render the arrow buttons.
+  ///
+  /// @param buttonSprite the spritesheet to use
   public void setButtonSpritesheet(Spritesheet buttonSprite) {
     this.buttonSprite = buttonSprite;
   }
 
-  /**
-   * Gets the list of registered change listeners.
-   *
-   * @return the change listener list
-   */
+  /// Gets the list of registered change listeners.
+  ///
+  /// @return the change listener list
   public List<Consumer<Float>> getChangeConsumer() {
     return changeConsumer;
   }
 
-  /**
-   * Gets the currently selected value.
-   *
-   * @return the current value
-   */
+  /// Gets the currently selected value.
+  ///
+  /// @return the current value
   public float getCurrentValue() {
     return currentValue;
   }
 
-  /**
-   * Sets the currently selected value. The value is clamped to the configured min/max range and registered change listeners are notified.
-   *
-   * @param newValue the new value
-   */
+  /// Sets the currently selected value. The value is clamped to the configured min/max range and registered change listeners are notified.
+  ///
+  /// @param newValue the new value
   public void setCurrentValue(final float newValue) {
     this.currentValue = Math.clamp(newValue, getMinValue(), getMaxValue());
     getChangeConsumer().forEach(consumer -> consumer.accept(getCurrentValue()));
   }
 
-  /**
-   * Gets the relative size factor used when rendering the slider's tick marks.
-   *
-   * @return the tick size factor
-   */
+  /// Gets the relative size factor used when rendering the slider's tick marks.
+  ///
+  /// @return the tick size factor
   public float getTickSize() {
     return tickSize;
   }
 
-  /**
-   * Sets the relative size factor used when rendering the slider's tick marks.
-   *
-   * @param tickSize the tick size factor
-   */
+  /// Sets the relative size factor used when rendering the slider's tick marks.
+  ///
+  /// @param tickSize the tick size factor
   public void setTickSize(float tickSize) {
     this.tickSize = tickSize;
   }
 
-  /**
-   * Computes the number of discrete steps between {@link #getMinValue()} and {@link #getMaxValue()} given the current step size.
-   *
-   * @return the number of selectable steps
-   */
+  /// Computes the number of discrete steps between [#getMinValue()] and [#getMaxValue()] given the current step size.
+  ///
+  /// @return the number of selectable steps
   public int getSteps() {
     return (int) ((getMaxValue() - getMinValue()) / getStepSize()) + 1;
   }
 
-  /**
-   * Gets the maximum selectable value.
-   *
-   * @return the maximum value
-   */
+  /// Gets the maximum selectable value.
+  ///
+  /// @return the maximum value
   public float getMaxValue() {
     return maxValue;
   }
 
-  /**
-   * Sets the maximum selectable value and refreshes the slider dimensions.
-   *
-   * @param maxValue the maximum value
-   */
+  /// Sets the maximum selectable value and refreshes the slider dimensions.
+  ///
+  /// @param maxValue the maximum value
   public void setMaxValue(final float maxValue) {
     this.maxValue = maxValue;
     updateSliderDimensions();
   }
 
-  /**
-   * Gets the minimum selectable value.
-   *
-   * @return the minimum value
-   */
+  /// Gets the minimum selectable value.
+  ///
+  /// @return the minimum value
   public float getMinValue() {
     return minValue;
   }
 
-  /**
-   * Sets the minimum selectable value and refreshes the slider dimensions.
-   *
-   * @param minValue the minimum value
-   */
+  /// Sets the minimum selectable value and refreshes the slider dimensions.
+  ///
+  /// @param minValue the minimum value
   public void setMinValue(final float minValue) {
     this.minValue = minValue;
     updateSliderDimensions();
 
   }
 
-  /**
-   * Computes the relative location of the slider thumb within the slider for the current value.
-   *
-   * @return the relative location of the slider thumb
-   */
+  /// Computes the relative location of the slider thumb within the slider for the current value.
+  ///
+  /// @return the relative location of the slider thumb
   public abstract Point2D getRelativeSliderLocation();
 
-  /**
-   * Computes a normalized value (typically in {@code [0, 1]}) corresponding to the current mouse location relative to the slider.
-   *
-   * @return the relative mouse value
-   */
+  /// Computes a normalized value (typically in `[0, 1]`) corresponding to the current mouse location relative to the slider.
+  ///
+  /// @return the relative mouse value
   protected abstract float getRelativeMouseValue();
 
-  /**
-   * Gets the slider thumb component.
-   *
-   * @return the slider thumb component
-   */
+  /// Gets the slider thumb component.
+  ///
+  /// @return the slider thumb component
   public ImageComponent getSliderComponent() {
     return sliderComponent;
   }
 
-  /**
-   * Sets the slider thumb component.
-   *
-   * @param slider the slider thumb component to register
-   */
+  /// Sets the slider thumb component.
+  ///
+  /// @param slider the slider thumb component to register
   protected void setSliderComponent(final ImageComponent slider) {
     this.sliderComponent = slider;
     getComponents().add(getSliderComponent());
   }
 
-  /**
-   * Updates the geometry of the slider in response to a change in min/max value or step size.
-   */
+  /// Updates the geometry of the slider in response to a change in min/max value or step size.
   protected abstract void updateSliderDimensions();
 
   @Override public void render(Graphics2D g) {
@@ -282,116 +235,90 @@ public abstract class Slider extends GuiComponent {
     super.render(g);
   }
 
-  /**
-   * Renders the slider bar (track).
-   *
-   * @param g the graphics context to draw to
-   */
+  /// Renders the slider bar (track).
+  ///
+  /// @param g the graphics context to draw to
   protected abstract void renderBar(Graphics2D g);
 
-  /**
-   * Renders the slider tick marks.
-   *
-   * @param g the graphics context to draw to
-   */
+  /// Renders the slider tick marks.
+  ///
+  /// @param g the graphics context to draw to
   protected abstract void renderTicks(Graphics2D g);
 
-  /**
-   * Determines whether the slider value should be increased when the given key is typed.
-   *
-   * @param keyCode the typed key code
-   * @return {@code true} if the value should be increased
-   */
+  /// Determines whether the slider value should be increased when the given key is typed.
+  ///
+  /// @param keyCode the typed key code
+  /// @return `true` if the value should be increased
   protected boolean shouldIncreaseOnKey(final int keyCode) {
     return false;
   }
 
-  /**
-   * Determines whether the slider value should be decreased when the given key is typed.
-   *
-   * @param keyCode the typed key code
-   * @return {@code true} if the value should be decreased
-   */
+  /// Determines whether the slider value should be decreased when the given key is typed.
+  ///
+  /// @param keyCode the typed key code
+  /// @return `true` if the value should be decreased
   protected boolean shouldDecreaseOnKey(final int keyCode) {
     return false;
   }
 
-  /**
-   * Gets the spritesheet used to render the slider thumb.
-   *
-   * @return the slider spritesheet
-   */
+  /// Gets the spritesheet used to render the slider thumb.
+  ///
+  /// @return the slider spritesheet
   public Spritesheet getSliderSpritesheet() {
     return sliderSprite;
   }
 
-  /**
-   * Sets the spritesheet used to render the slider thumb.
-   *
-   * @param sliderSprite the spritesheet to use
-   */
+  /// Sets the spritesheet used to render the slider thumb.
+  ///
+  /// @param sliderSprite the spritesheet to use
   public void setSliderSpritesheet(Spritesheet sliderSprite) {
     this.sliderSprite = sliderSprite;
   }
 
-  /**
-   * Gets the step size between adjacent selectable values.
-   *
-   * @return the step size
-   */
+  /// Gets the step size between adjacent selectable values.
+  ///
+  /// @return the step size
   public float getStepSize() {
     return stepSize;
   }
 
-  /**
-   * Sets the step size between adjacent selectable values and refreshes the slider dimensions.
-   *
-   * @param stepSize the step size
-   */
+  /// Sets the step size between adjacent selectable values and refreshes the slider dimensions.
+  ///
+  /// @param stepSize the step size
   public void setStepSize(final float stepSize) {
     this.stepSize = stepSize;
     updateSliderDimensions();
   }
 
-  /**
-   * Returns whether the slider is currently being dragged by the user.
-   *
-   * @return {@code true} if the slider thumb is being dragged
-   */
+  /// Returns whether the slider is currently being dragged by the user.
+  ///
+  /// @return `true` if the slider thumb is being dragged
   public boolean isDragging() {
     return isDragging;
   }
 
-  /**
-   * Returns whether the slider is rendering tick marks.
-   *
-   * @return {@code true} if tick marks are shown
-   */
+  /// Returns whether the slider is rendering tick marks.
+  ///
+  /// @return `true` if tick marks are shown
   public boolean isShowingTicks() {
     return showTicks;
   }
 
-  /**
-   * Sets whether the slider should render tick marks.
-   *
-   * @param showTicks {@code true} to show tick marks
-   */
+  /// Sets whether the slider should render tick marks.
+  ///
+  /// @param showTicks `true` to show tick marks
   public void setShowTicks(boolean showTicks) {
     this.showTicks = showTicks;
   }
 
-  /**
-   * Registers a callback that is invoked whenever the slider value changes.
-   *
-   * @param c the change consumer to register
-   */
+  /// Registers a callback that is invoked whenever the slider value changes.
+  ///
+  /// @param c the change consumer to register
   public void onChange(final Consumer<Float> c) {
     this.getChangeConsumer().add(c);
   }
 
-  /**
-   * Infers the current value from the current mouse location and updates the slider accordingly.
-   */
+  /// Infers the current value from the current mouse location and updates the slider accordingly.
   protected void inferValueFromMouseLocation() {
     float frac = (getMinValue() + getRelativeMouseValue() * getSteps()) / getSteps();
     int currentStep = (int) (frac * getSteps());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/SpeechBubble.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/SpeechBubble.java
@@ -12,12 +12,10 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 
-/**
- * A SpeechBubble is a GuiComponent with a given text that is pinned to an entity and moves with it. After initializing
- * the speech bubble, you can start it separately, which will add the component to the current screen, register it for
- * updates and make it visible on screen. Stopping the speech bubble will remove the component and deregister its
- * updates.
- */
+/// A SpeechBubble is a GuiComponent with a given text that is pinned to an entity and moves with it. After initializing
+/// the speech bubble, you can start it separately, which will add the component to the current screen, register it for
+/// updates and make it visible on screen. Stopping the speech bubble will remove the component and deregister its
+/// updates.
 public class SpeechBubble extends GuiComponent implements IUpdateable {
   private int displayTime = GuiProperties.getDefaultSpeechBubbleDisplayTime();
   private long startedTick;
@@ -33,33 +31,29 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
   private long lastTypeTick;
   private final String totalText;
 
-  /**
-   * Instantiates a new speech bubble.
-   *
-   * @param entity
-   *          the entity to which the Speech bubble will be pinned
-   * @param text
-   *          the text which will appear in the speech bubble
-   */
+  /// Instantiates a new speech bubble.
+  ///
+  /// @param entity
+  /// the entity to which the Speech bubble will be pinned
+  /// @param text
+  /// the text which will appear in the speech bubble
   public SpeechBubble(IEntity entity, String text) {
     this(entity, entity.getWidth() * 4 * Game.world().camera().getRenderScale(), entity.getHeight() * 2 * Game.world().camera().getRenderScale(),
         3000, text);
   }
 
-  /**
-   * Instantiates a new Speech bubble.
-   *
-   * @param entity
-   *          the entity to which the Speech bubble will be pinned
-   * @param width
-   *          the width of the text box
-   * @param height
-   *          the height of the text box
-   * @param displayTime
-   *          the display time in milliseconds
-   * @param text
-   *          the text which will appear in the speech bubble
-   */
+  /// Instantiates a new Speech bubble.
+  ///
+  /// @param entity
+  /// the entity to which the Speech bubble will be pinned
+  /// @param width
+  /// the width of the text box
+  /// @param height
+  /// the height of the text box
+  /// @param displayTime
+  /// the display time in milliseconds
+  /// @param text
+  /// the text which will appear in the speech bubble
   public SpeechBubble(IEntity entity, double width, double height, int displayTime, String text) {
     super(Game.world().camera().getViewportDimensionCenter(entity).getX() * Game.world().camera().getRenderScale() - width / 2d,
         Game.world().camera().getViewportLocation(entity).getY() * Game.world().camera().getRenderScale() - height, width, height);
@@ -74,38 +68,30 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     setTypeDelay((int) (getDisplayTime() * 0.5 / totalText.length()));
   }
 
-  /**
-   * Gets the entity to which this speech bubble is pinned.
-   *
-   * @return the entity
-   */
+  /// Gets the entity to which this speech bubble is pinned.
+  ///
+  /// @return the entity
   public IEntity getEntity() {
     return entity;
   }
 
-  /**
-   * Gets the duration in milliseconds for which this speech bubble will be active.
-   *
-   * @return the display time in milliseconds
-   */
+  /// Gets the duration in milliseconds for which this speech bubble will be active.
+  ///
+  /// @return the display time in milliseconds
   public int getDisplayTime() {
     return displayTime;
   }
 
-  /**
-   * Sets the duration in milliseconds for which this speech bubble will be active.
-   *
-   * @param displayTime
-   *          the display time in milliseconds
-   */
+  /// Sets the duration in milliseconds for which this speech bubble will be active.
+  ///
+  /// @param displayTime
+  /// the display time in milliseconds
   public void setDisplayTime(int displayTime) {
     this.displayTime = displayTime;
   }
 
-  /**
-   * Start the speech bubble. This will add it to the current Screen's components, make it visible and register it for
-   * updates in the Game loop. After the display time has elapsed, the speech bubble will be stopped automatically.
-   */
+  /// Start the speech bubble. This will add it to the current Screen's components, make it visible and register it for
+  /// updates in the Game loop. After the display time has elapsed, the speech bubble will be stopped automatically.
   public void start() {
     startedTick = Game.time().now();
     Game.screens().current().getComponents().add(this);
@@ -113,10 +99,8 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     Game.loop().attach(this);
   }
 
-  /**
-   * Stop the speech bubble. This will remove it from the current Screen's components, make it invisible and deregister it
-   * from updates in the Game loop.
-   */
+  /// Stop the speech bubble. This will remove it from the current Screen's components, make it invisible and deregister it
+  /// from updates in the Game loop.
   public void stop() {
     Game.screens().current().getComponents().remove(this);
     suspend();
@@ -136,21 +120,17 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     super.render(g);
   }
 
-  /**
-   * Gets the horizontal speech bubble alignment that dictates its position relative to the entity center point.
-   *
-   * @return the box Align
-   */
+  /// Gets the horizontal speech bubble alignment that dictates its position relative to the entity center point.
+  ///
+  /// @return the box Align
   public Align getBoxAlign() {
     return boxAlign;
   }
 
-  /**
-   * Sets the horizontal speech bubble alignment that dictates its position relative to the entity center point.
-   *
-   * @param boxAlign
-   *          the box Align
-   */
+  /// Sets the horizontal speech bubble alignment that dictates its position relative to the entity center point.
+  ///
+  /// @param boxAlign
+  /// the box Align
   public void setBoxAlign(Align boxAlign) {
     this.boxAlign = boxAlign;
   }
@@ -172,21 +152,17 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     type();
   }
 
-  /**
-   * Checks if the triangle indicator is active.
-   *
-   * @return true, if the speech bubble is rendering a triangle indicator on the bottom.
-   */
+  /// Checks if the triangle indicator is active.
+  ///
+  /// @return true, if the speech bubble is rendering a triangle indicator on the bottom.
   public boolean isRenderingTriangle() {
     return renderTriangle;
   }
 
-  /**
-   * Sets the visibility status of the triangle indicator.
-   *
-   * @param renderTriangle
-   *          if true, the triangle will be visible.
-   */
+  /// Sets the visibility status of the triangle indicator.
+  ///
+  /// @param renderTriangle
+  /// if true, the triangle will be visible.
   public void setRenderTriangle(boolean renderTriangle) {
     this.renderTriangle = renderTriangle;
   }
@@ -209,11 +185,9 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     super.setHeight(height);
   }
 
-  /**
-   * Gets the triangle indicator's shape, translated to the correct location on screen.
-   *
-   * @return A Path2D object representing the triangle indicator.
-   */
+  /// Gets the triangle indicator's shape, translated to the correct location on screen.
+  ///
+  /// @return A Path2D object representing the triangle indicator.
   public Path2D getTriangle() {
     if (triangle != null) {
       return triangle;
@@ -231,29 +205,23 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     return triangle;
   }
 
-  /**
-   * Gets the triangle indicator size. Its size is identical for width and height.
-   *
-   * @return the triangle indicator size
-   */
+  /// Gets the triangle indicator size. Its size is identical for width and height.
+  ///
+  /// @return the triangle indicator size
   public double getTriangleSize() {
     return triangleSize;
   }
 
-  /**
-   * Gets the triangle indicator size. Its size is identical for width and height.
-   *
-   * @param triangleSize
-   *          the new triangle indicator size
-   */
+  /// Gets the triangle indicator size. Its size is identical for width and height.
+  ///
+  /// @param triangleSize
+  /// the new triangle indicator size
   public void setTriangleSize(double triangleSize) {
     this.triangle = null; // trigger recreation in next boundingBox getter call
     this.triangleSize = triangleSize;
   }
 
-  /**
-   * Updates the displayed text for a typewriter effect
-   */
+  /// Updates the displayed text for a typewriter effect
   private void type() {
     // display new text
     if (textIndex < totalText.length() && Game.time().since(lastTypeTick) > getTypeDelay()) {
@@ -266,49 +234,39 @@ public class SpeechBubble extends GuiComponent implements IUpdateable {
     }
   }
 
-  /**
-   * Gets type delay, which determines how fast the typewriter effect will be.
-   *
-   * @return the type delay in milliseconds
-   */
+  /// Gets type delay, which determines how fast the typewriter effect will be.
+  ///
+  /// @return the type delay in milliseconds
   public int getTypeDelay() {
     return typeDelay;
   }
 
-  /**
-   * Sets type delay, which determines how fast the typewriter effect will be.
-   *
-   * @param typeDelay
-   *          the type delay in milliseconds
-   */
+  /// Sets type delay, which determines how fast the typewriter effect will be.
+  ///
+  /// @param typeDelay
+  /// the type delay in milliseconds
   public void setTypeDelay(int typeDelay) {
     this.typeDelay = typeDelay;
   }
 
-  /**
-   * Gets the sound that is played every time a new letter appears.
-   *
-   * @return the type sound
-   */
+  /// Gets the sound that is played every time a new letter appears.
+  ///
+  /// @return the type sound
   public Sound getTypeSound() {
     return typeSound;
   }
 
-  /**
-   * Sets the sound that is played every time a new letter appears.
-   *
-   * @param typeSound
-   *          the type sound
-   */
+  /// Sets the sound that is played every time a new letter appears.
+  ///
+  /// @param typeSound
+  /// the type sound
   public void setTypeSound(Sound typeSound) {
     this.typeSound = typeSound;
   }
 
-  /**
-   * Gets the total text that this Speech bubble will display.
-   *
-   * @return the total text
-   */
+  /// Gets the total text that this Speech bubble will display.
+  ///
+  /// @return the total text
   public String getTotalText() {
     return totalText;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Spinner.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/Spinner.java
@@ -9,17 +9,13 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * A numeric text-field component with attached up/down arrow buttons that adjust the current value by a configurable
- * {@linkplain #getStepSize() step size} within a bounded range. The value can also be edited directly via the text field or adjusted using the
- * up/down arrow keys.
- */
+/// A numeric text-field component with attached up/down arrow buttons that adjust the current value by a configurable
+/// [step size][#getStepSize()] within a bounded range. The value can also be edited directly via the text field or adjusted using the
+/// up/down arrow keys.
 public class Spinner extends TextFieldComponent {
-  /**
-   * Down-arrow icon shown on the decrement button.
-   */
+  /// Down-arrow icon shown on the decrement button.
   public static final FontIcon ARROW_DOWN = new FontIcon(ICON_FONT, "\uE84A");
-  /** Up-arrow icon shown on the increment button. */
+  /// Up-arrow icon shown on the increment button.
   public static final FontIcon ARROW_UP = new FontIcon(ICON_FONT, "\uE84B");
   private static final Logger log = Logger.getLogger(Spinner.class.getName());
   private BigDecimal step;
@@ -28,18 +24,16 @@ public class Spinner extends TextFieldComponent {
   private BigDecimal currentValue;
   private final List<Consumer<BigDecimal>> valueChangeConsumers;
 
-  /**
-   * Constructs a new spinner.
-   *
-   * @param x          the x coordinate of the component
-   * @param y          the y coordinate of the component
-   * @param width      the width of the component
-   * @param height     the height of the component
-   * @param lowerBound the lowest allowed value
-   * @param upperBound the highest allowed value
-   * @param startValue the initial value
-   * @param stepSize   the step size between adjacent values
-   */
+  /// Constructs a new spinner.
+  ///
+  /// @param x          the x coordinate of the component
+  /// @param y          the y coordinate of the component
+  /// @param width      the width of the component
+  /// @param height     the height of the component
+  /// @param lowerBound the lowest allowed value
+  /// @param upperBound the highest allowed value
+  /// @param startValue the initial value
+  /// @param stepSize   the step size between adjacent values
   public Spinner(
       final double x,
       final double y,
@@ -60,61 +54,47 @@ public class Spinner extends TextFieldComponent {
     Input.keyboard().onKeyTyped(KeyEvent.VK_DOWN, e -> this.handleAdjustmentInput(false));
   }
 
-  /**
-   * Decreases the current value by one {@linkplain #getStepSize() step}, clamping to the lower bound.
-   */
+  /// Decreases the current value by one [step][#getStepSize()], clamping to the lower bound.
   public void decrement() {
     this.setCurrentValue(this.getCurrentValue().subtract(this.getStepSize()));
   }
 
-  /**
-   * Gets the current value of the spinner.
-   *
-   * @return the current value
-   */
+  /// Gets the current value of the spinner.
+  ///
+  /// @return the current value
   public BigDecimal getCurrentValue() {
     return this.currentValue;
   }
 
-  /**
-   * Gets the lowest allowed value of the spinner.
-   *
-   * @return the lower bound
-   */
+  /// Gets the lowest allowed value of the spinner.
+  ///
+  /// @return the lower bound
   public BigDecimal getLowerBound() {
     return this.lowerBound;
   }
 
-  /**
-   * Gets the step size between adjacent spinner values.
-   *
-   * @return the step size
-   */
+  /// Gets the step size between adjacent spinner values.
+  ///
+  /// @return the step size
   public BigDecimal getStepSize() {
     return this.step;
   }
 
-  /**
-   * Gets the highest allowed value of the spinner.
-   *
-   * @return the upper bound
-   */
+  /// Gets the highest allowed value of the spinner.
+  ///
+  /// @return the upper bound
   public BigDecimal getUpperBound() {
     return this.upperBound;
   }
 
-  /**
-   * Increases the current value by one {@linkplain #getStepSize() step}, clamping to the upper bound.
-   */
+  /// Increases the current value by one [step][#getStepSize()], clamping to the upper bound.
   public void increment() {
     this.setCurrentValue(this.getCurrentValue().add(this.getStepSize()));
   }
 
-  /**
-   * Registers a callback invoked whenever the spinner value changes.
-   *
-   * @param cons the change consumer
-   */
+  /// Registers a callback invoked whenever the spinner value changes.
+  ///
+  /// @param cons the change consumer
   public void onValueChange(final Consumer<BigDecimal> cons) {
     this.valueChangeConsumers.add(cons);
   }
@@ -161,11 +141,9 @@ public class Spinner extends TextFieldComponent {
         });
   }
 
-  /**
-   * Sets the current value, clamped to the configured range, and notifies registered change listeners.
-   *
-   * @param newValue the new value
-   */
+  /// Sets the current value, clamped to the configured range, and notifies registered change listeners.
+  ///
+  /// @param newValue the new value
   public void setCurrentValue(final BigDecimal newValue) {
     if (newValue.compareTo(this.getUpperBound()) > 0) {
       this.currentValue = this.getUpperBound();
@@ -178,11 +156,9 @@ public class Spinner extends TextFieldComponent {
     this.valueChangeConsumers.forEach(c -> c.accept(this.getCurrentValue()));
   }
 
-  /**
-   * Sets the lowest allowed value. If the current value is below the new bound, the current value is clamped to the new bound.
-   *
-   * @param lowerBound the new lower bound
-   */
+  /// Sets the lowest allowed value. If the current value is below the new bound, the current value is clamped to the new bound.
+  ///
+  /// @param lowerBound the new lower bound
   public void setLowerBound(final BigDecimal lowerBound) {
     this.lowerBound = lowerBound;
     if (this.getCurrentValue().compareTo(this.getLowerBound()) < 0) {
@@ -190,20 +166,16 @@ public class Spinner extends TextFieldComponent {
     }
   }
 
-  /**
-   * Sets the step size between adjacent spinner values.
-   *
-   * @param stepSize the step size
-   */
+  /// Sets the step size between adjacent spinner values.
+  ///
+  /// @param stepSize the step size
   public void setStepSize(final BigDecimal stepSize) {
     this.step = stepSize;
   }
 
-  /**
-   * Sets the highest allowed value. If the current value is above the new bound, the current value is clamped to the new bound.
-   *
-   * @param upperBound the new upper bound
-   */
+  /// Sets the highest allowed value. If the current value is above the new bound, the current value is clamped to the new bound.
+  ///
+  /// @param upperBound the new upper bound
   public void setUpperBound(final BigDecimal upperBound) {
     this.upperBound = upperBound;
     if (this.getCurrentValue().compareTo(this.getUpperBound()) > 0) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/TextFieldComponent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/TextFieldComponent.java
@@ -13,19 +13,13 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * A single-line text input GUI component. Supports input filtering through a regex {@linkplain #getFormat() format}, a maximum length, a flickering
- * caret while focused, and confirmation listeners that fire when the user presses {@code ENTER}/{@code ESC} or clicks outside the component.
- */
+/// A single-line text input GUI component. Supports input filtering through a regex [format][#getFormat()], a maximum length, a flickering
+/// caret while focused, and confirmation listeners that fire when the user presses `ENTER`/`ESC` or clicks outside the component.
 public class TextFieldComponent extends ImageComponent {
 
-  /**
-   * Regex matching signed decimal numbers including scientific notation.
-   */
+  /// Regex matching signed decimal numbers including scientific notation.
   public static final String DOUBLE_FORMAT = "[-+]?[0-9]*\\.?[0-9]*([eE][-+]?[0-9]*)?";
-  /**
-   * Regex matching positive integers up to 10 digits.
-   */
+  /// Regex matching positive integers up to 10 digits.
   public static final String INTEGER_FORMAT = "[0-9]{1,10}";
   private static final Logger log = Logger.getLogger(TextFieldComponent.class.getName());
   private final List<Consumer<String>> changeConfirmedConsumers;
@@ -37,15 +31,13 @@ public class TextFieldComponent extends ImageComponent {
   private long lastToggled;
   private int maxLength = 0;
 
-  /**
-   * Constructs a new {@code TextFieldComponent}.
-   *
-   * @param x      the x coordinate of the component
-   * @param y      the y coordinate of the component
-   * @param width  the width of the component
-   * @param height the height of the component
-   * @param text   the initial text content
-   */
+  /// Constructs a new `TextFieldComponent`.
+  ///
+  /// @param x      the x coordinate of the component
+  /// @param y      the y coordinate of the component
+  /// @param width  the width of the component
+  /// @param height the height of the component
+  /// @param text   the initial text content
   public TextFieldComponent(
       final double x, final double y, final double width, final double height, final String text) {
     super(x, y, width, height, text);
@@ -72,56 +64,44 @@ public class TextFieldComponent extends ImageComponent {
     setAutomaticLineBreaks(true);
   }
 
-  /**
-   * Gets the regex pattern used to filter typed input.
-   *
-   * @return the format pattern, or {@code null} if no filter is set
-   */
+  /// Gets the regex pattern used to filter typed input.
+  ///
+  /// @return the format pattern, or `null` if no filter is set
   public String getFormat() {
     return format;
   }
 
-  /**
-   * Sets the regex pattern used to filter typed input.
-   *
-   * @param format the format pattern, or {@code null} to disable filtering
-   */
+  /// Sets the regex pattern used to filter typed input.
+  ///
+  /// @param format the format pattern, or `null` to disable filtering
   public void setFormat(final String format) {
     this.format = format;
   }
 
-  /**
-   * Gets the string rendered as the caret while the field is focused.
-   *
-   * @return the caret string
-   */
+  /// Gets the string rendered as the caret while the field is focused.
+  ///
+  /// @return the caret string
   public String getCursor() {
     return cursor;
   }
 
-  /**
-   * Sets the string rendered as the caret while the field is focused.
-   *
-   * @param newCursor the caret string
-   */
+  /// Sets the string rendered as the caret while the field is focused.
+  ///
+  /// @param newCursor the caret string
   public void setCursor(String newCursor) {
     this.cursor = newCursor;
   }
 
-  /**
-   * Gets the maximum number of characters allowed in the field, or {@code 0} if unlimited.
-   *
-   * @return the maximum length
-   */
+  /// Gets the maximum number of characters allowed in the field, or `0` if unlimited.
+  ///
+  /// @return the maximum length
   public int getMaxLength() {
     return maxLength;
   }
 
-  /**
-   * Sets the maximum number of characters allowed in the field.
-   *
-   * @param maxLength the maximum length, or {@code 0} for unlimited
-   */
+  /// Sets the maximum number of characters allowed in the field.
+  ///
+  /// @param maxLength the maximum length, or `0` for unlimited
   public void setMaxLength(final int maxLength) {
     this.maxLength = maxLength;
   }
@@ -142,11 +122,9 @@ public class TextFieldComponent extends ImageComponent {
         : super.getTextToRender(g) + "  ";
   }
 
-  /**
-   * Handles a key typed event by dispatching to the relevant editing routine (backspace, accept, or normal typing).
-   *
-   * @param event the key event
-   */
+  /// Handles a key typed event by dispatching to the relevant editing routine (backspace, accept, or normal typing).
+  ///
+  /// @param event the key event
   public void handleTypedKey(final KeyEvent event) {
     if (!canHandleInput()) {
       return;
@@ -159,21 +137,17 @@ public class TextFieldComponent extends ImageComponent {
   }
 
 
-  /**
-   * Returns whether this component is currently in a state in which it should accept user input.
-   *
-   * @return {@code true} if input can be handled
-   */
+  /// Returns whether this component is currently in a state in which it should accept user input.
+  ///
+  /// @return `true` if input can be handled
   public boolean canHandleInput() {
     return !isSuspended() && isSelected() && isVisible() && isEnabled();
   }
 
-  /**
-   * Registers a callback that is invoked with the current text whenever the user confirms the input (by pressing {@code ENTER}/{@code ESC} or
-   * clicking outside the component).
-   *
-   * @param cons the consumer to register
-   */
+  /// Registers a callback that is invoked with the current text whenever the user confirms the input (by pressing `ENTER`/`ESC` or
+  /// clicking outside the component).
+  ///
+  /// @param cons the consumer to register
   public void onChangeConfirmed(final Consumer<String> cons) {
     changeConfirmedConsumers.add(cons);
   }
@@ -187,11 +161,9 @@ public class TextFieldComponent extends ImageComponent {
     }
   }
 
-  /**
-   * Sets the delay (in milliseconds) between caret flicker toggles.
-   *
-   * @param flickerDelayMillis the flicker delay
-   */
+  /// Sets the delay (in milliseconds) between caret flicker toggles.
+  ///
+  /// @param flickerDelayMillis the flicker delay
   public void setFlickerDelay(int flickerDelayMillis) {
     this.flickerDelay = flickerDelayMillis;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/VerticalSlider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/VerticalSlider.java
@@ -7,11 +7,25 @@ import java.awt.event.KeyEvent;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 
+/// A [Slider] whose minimum value is at the top and maximum value is at the bottom.
+///
+/// Up/down arrow buttons and keyboard keys move between values using the configured step size.
 public class VerticalSlider extends Slider {
 
+  /// Icon used by the increment button below the slider.
   public static final FontIcon ARROW_DOWN = new FontIcon(ICON_FONT, "\uE804");
+  /// Icon used by the decrement button above the slider.
   public static final FontIcon ARROW_UP = new FontIcon(ICON_FONT, "\uE807");
 
+  /// Creates a vertical slider.
+  ///
+  /// @param x The horizontal screen coordinate.
+  /// @param y The vertical screen coordinate.
+  /// @param width The component width.
+  /// @param height The component height.
+  /// @param minValue The value at the top.
+  /// @param maxValue The value at the bottom.
+  /// @param stepSize The amount changed by one step.
   public VerticalSlider(final double x, final double y, final double width, final double height, final float minValue, final float maxValue,
     final float stepSize) {
     super(x, y, width, height, minValue, maxValue, stepSize);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/GameScreen.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/GameScreen.java
@@ -4,11 +4,9 @@ import de.gurkenlabs.litiengine.Game;
 import de.gurkenlabs.litiengine.environment.GameWorld;
 import java.awt.Graphics2D;
 
-/**
- * A default screen implementation that renders the game's current environment.
- *
- * @see GameWorld#environment()
- */
+/// A default screen implementation that renders the game's current environment.
+///
+/// @see GameWorld#environment()
 public class GameScreen extends Screen {
   public GameScreen() {
     super("GAME");

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/Resolution.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/Resolution.java
@@ -9,22 +9,17 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Represents the resolution of the game window consisting of the width and height and information about the ratio.
- *
- * <p>
- * This class also provides access to predefined known resolutions of the different aspect ratios which can be used to
- * set the resolution of the {@code GameWindow}.
- *
- * <ul>
- * <li>{@link Ratio4x3}
- * <li>{@link Ratio5x4}
- * <li>{@link Ratio16x9}
- * <li>{@link Ratio16x10}
- * </ul>
- *
- * @see GameWindow#setResolution(Resolution)
- */
+/// Represents the resolution of the game window consisting of the width and height and information about the ratio.
+///
+/// This class also provides access to predefined known resolutions of the different aspect ratios which can be used to
+/// set the resolution of the `GameWindow`.
+///
+/// - [Ratio4x3]
+/// - [Ratio5x4]
+/// - [Ratio16x9]
+/// - [Ratio16x10]
+///
+/// @see GameWindow#setResolution(Resolution)
 public class Resolution {
   private static final Logger log = Logger.getLogger(Resolution.class.getName());
 
@@ -40,60 +35,48 @@ public class Resolution {
     this.ratio = ratio;
   }
 
-  /**
-   * Creates a custom {@code Resolution} with the given dimensions and ratio name.
-   *
-   * @param width          the resolution width in pixels
-   * @param height         the resolution height in pixels
-   * @param resolutionName the display name of the ratio
-   * @return a new custom resolution
-   */
+  /// Creates a custom `Resolution` with the given dimensions and ratio name.
+  ///
+  /// @param width          the resolution width in pixels
+  /// @param height         the resolution height in pixels
+  /// @param resolutionName the display name of the ratio
+  /// @return a new custom resolution
   public static Resolution custom(int width, int height, String resolutionName) {
     return new Resolution(width, height, new Ratio(width, height, resolutionName));
   }
 
-  /**
-   * Gets the height of this resolution.
-   *
-   * @return The height of the resolution.
-   */
+  /// Gets the height of this resolution.
+  ///
+  /// @return The height of the resolution.
   public int getHeight() {
     return this.height;
   }
 
-  /**
-   * Gets the width of this resolution.
-   *
-   * @return The width of the resolution.
-   */
+  /// Gets the width of this resolution.
+  ///
+  /// @return The width of the resolution.
   public int getWidth() {
     return this.width;
   }
 
-  /**
-   * Gets the dimension of this resolution consisting of it's width and height.
-   *
-   * @return The dimension of the resolution.
-   */
+  /// Gets the dimension of this resolution consisting of it's width and height.
+  ///
+  /// @return The dimension of the resolution.
   public Dimension getDimension() {
     return this.dimension;
   }
 
-  /**
-   * Returns the resolution dimensions as a string using {@code "x"} as the delimiter (e.g. {@code "1920x1080"}).
-   *
-   * @return the dimension string
-   */
+  /// Returns the resolution dimensions as a string using `"x"` as the delimiter (e.g. `"1920x1080"`).
+  ///
+  /// @return the dimension string
   public String toDimensionString() {
     return this.toDimensionString("x");
   }
 
-  /**
-   * Returns the resolution dimensions as a string using the provided delimiter.
-   *
-   * @param delimiter the delimiter to place between width and height
-   * @return the dimension string
-   */
+  /// Returns the resolution dimensions as a string using the provided delimiter.
+  ///
+  /// @param delimiter the delimiter to place between width and height
+  /// @return the dimension string
   public String toDimensionString(String delimiter) {
     return this.getWidth() + delimiter + this.getHeight();
   }
@@ -103,166 +86,144 @@ public class Resolution {
     return this.toDimensionString();
   }
 
-  /**
-   * Gets the aspect ratio of this resolution.
-   *
-   * @return The aspect ratio of this resolution.
-   */
+  /// Gets the aspect ratio of this resolution.
+  ///
+  /// @return The aspect ratio of this resolution.
   public Ratio getRatio() {
     return this.ratio;
   }
 
-  /** Contains predefined {@code Resolutions} with an aspect ratio of 4:3. */
+  /// Contains predefined `Resolutions` with an aspect ratio of 4:3.
   public static class Ratio4x3 extends Ratio {
-    /**
-     * 4:3 resolution 640x480.
-     */
+    /// 4:3 resolution 640x480.
     public static final Resolution RES_640x480 = new Resolution(640, 480, new Ratio4x3());
-    /**
-     * 4:3 resolution 720x576.
-     */
+    /// 4:3 resolution 720x576.
     public static final Resolution RES_720x576 = new Resolution(720, 576, new Ratio4x3());
-    /** 4:3 resolution 800x600. */
+    /// 4:3 resolution 800x600.
     public static final Resolution RES_800x600 = new Resolution(800, 600, new Ratio4x3());
-    /** 4:3 resolution 1024x768. */
+    /// 4:3 resolution 1024x768.
     public static final Resolution RES_1024x768 = new Resolution(1024, 768, new Ratio4x3());
-    /** 4:3 resolution 1152x864. */
+    /// 4:3 resolution 1152x864.
     public static final Resolution RES_1152x864 = new Resolution(1152, 864, new Ratio4x3());
-    /** 4:3 resolution 1280x960. */
+    /// 4:3 resolution 1280x960.
     public static final Resolution RES_1280x960 = new Resolution(1280, 960, new Ratio4x3());
-    /** 4:3 resolution 1600x1200. */
+    /// 4:3 resolution 1600x1200.
     public static final Resolution RES_1600x1200 = new Resolution(1600, 1200, new Ratio4x3());
-    /** 4:3 resolution 1920x1440. */
+    /// 4:3 resolution 1920x1440.
     public static final Resolution RES_1920x1440 = new Resolution(1920, 1440, new Ratio4x3());
 
     private Ratio4x3() {
       super(4, 3);
     }
 
-    /**
-     * Gets all predefined resolutions with an aspect ratio of 4:3.
-     *
-     * @return All predefined resolutions with an aspect ratio of 4:3.
-     */
+    /// Gets all predefined resolutions with an aspect ratio of 4:3.
+    ///
+    /// @return All predefined resolutions with an aspect ratio of 4:3.
     public static List<Resolution> getAll() {
       return getAll(Ratio4x3.class);
     }
   }
 
-  /** Contains predefined {@code Resolutions} with an aspect ratio of 5:4. */
+  /// Contains predefined `Resolutions` with an aspect ratio of 5:4.
   public static class Ratio5x4 extends Ratio {
-    /** 5:4 resolution 1280x1024. */
+    /// 5:4 resolution 1280x1024.
     public static final Resolution RES_1280x1024 = new Resolution(1280, 1024, new Ratio5x4());
 
     private Ratio5x4() {
       super(5, 4);
     }
 
-    /**
-     * Gets all predefined resolutions with an aspect ratio of 5:4.
-     *
-     * @return All predefined resolutions with an aspect ratio of 5:4.
-     */
+    /// Gets all predefined resolutions with an aspect ratio of 5:4.
+    ///
+    /// @return All predefined resolutions with an aspect ratio of 5:4.
     public static List<Resolution> getAll() {
       return getAll(Ratio5x4.class);
     }
   }
 
-  /** Contains predefined {@code Resolutions} with an aspect ratio of 16:9. */
+  /// Contains predefined `Resolutions` with an aspect ratio of 16:9.
   public static class Ratio16x9 extends Ratio {
-    /** 16:9 resolution 1280x720 (HD). */
+    /// 16:9 resolution 1280x720 (HD).
     public static final Resolution RES_1280x720 = new Resolution(1280, 720, new Ratio16x9());
-    /** 16:9 resolution 1360x768. */
+    /// 16:9 resolution 1360x768.
     public static final Resolution RES_1360x768 = new Resolution(1360, 768, new Ratio16x9());
-    /** 16:9 resolution 1366x768. */
+    /// 16:9 resolution 1366x768.
     public static final Resolution RES_1366x768 = new Resolution(1366, 768, new Ratio16x9());
-    /** 16:9 resolution 1536x864. */
+    /// 16:9 resolution 1536x864.
     public static final Resolution RES_1536x864 = new Resolution(1536, 864, new Ratio16x9());
-    /** 16:9 resolution 1600x900. */
+    /// 16:9 resolution 1600x900.
     public static final Resolution RES_1600x900 = new Resolution(1600, 900, new Ratio16x9());
-    /** 16:9 resolution 1920x1080 (Full HD). */
+    /// 16:9 resolution 1920x1080 (Full HD).
     public static final Resolution RES_1920x1080 = new Resolution(1920, 1080, new Ratio16x9());
-    /** 16:9 resolution 2560x1440 (QHD). */
+    /// 16:9 resolution 2560x1440 (QHD).
     public static final Resolution RES_2560x1440 = new Resolution(2560, 1440, new Ratio16x9());
 
     private Ratio16x9() {
       super(16, 9);
     }
 
-    /**
-     * Gets all predefined resolutions with an aspect ratio of 16:9.
-     *
-     * @return All predefined resolutions with an aspect ratio of 16:9.
-     */
+    /// Gets all predefined resolutions with an aspect ratio of 16:9.
+    ///
+    /// @return All predefined resolutions with an aspect ratio of 16:9.
     public static List<Resolution> getAll() {
       return getAll(Ratio16x9.class);
     }
   }
 
-  /** Contains predefined {@code Resolutions} with an aspect ratio of 16:10. */
+  /// Contains predefined `Resolutions` with an aspect ratio of 16:10.
   public static class Ratio16x10 extends Ratio {
-    /** 16:10 resolution 720x480. */
+    /// 16:10 resolution 720x480.
     public static final Resolution RES_720x480 = new Resolution(720, 480, new Ratio16x10());
-    /** 16:10 resolution 1280x800. */
+    /// 16:10 resolution 1280x800.
     public static final Resolution RES_1280x800 = new Resolution(1280, 800, new Ratio16x10());
-    /** 16:10 resolution 1440x900. */
+    /// 16:10 resolution 1440x900.
     public static final Resolution RES_1440x900 = new Resolution(1440, 900, new Ratio16x10());
-    /** 16:10 resolution 1680x1050. */
+    /// 16:10 resolution 1680x1050.
     public static final Resolution RES_1680x1050 = new Resolution(1680, 1050, new Ratio16x10());
-    /** 16:10 resolution 1920x1200. */
+    /// 16:10 resolution 1920x1200.
     public static final Resolution RES_1920x1200 = new Resolution(1920, 1200, new Ratio16x10());
 
     private Ratio16x10() {
       super(16, 10);
     }
 
-    /**
-     * Gets all predefined resolutions with an aspect ratio of 16:10.
-     *
-     * @return All predefined resolutions with an aspect ratio of 16:10.
-     */
+    /// Gets all predefined resolutions with an aspect ratio of 16:10.
+    ///
+    /// @return All predefined resolutions with an aspect ratio of 16:10.
     public static List<Resolution> getAll() {
       return getAll(Ratio16x10.class);
     }
   }
 
-  /**
-   * Describes an aspect ratio used to categorize {@link Resolution} instances. The ratio consists of a name and the {@code x:y} components.
-   */
+  /// Describes an aspect ratio used to categorize [Resolution] instances. The ratio consists of a name and the `x:y` components.
   public static class Ratio {
     private final String name;
     private final int x;
     private final int y;
 
-    /**
-     * Constructs a new {@code Ratio} with the given components. The name defaults to {@code "x:y"}.
-     *
-     * @param x the x component of the ratio
-     * @param y the y component of the ratio
-     */
+    /// Constructs a new `Ratio` with the given components. The name defaults to `"x:y"`.
+    ///
+    /// @param x the x component of the ratio
+    /// @param y the y component of the ratio
     protected Ratio(int x, int y) {
       this(x, y, x + ":" + y);
     }
 
-    /**
-     * Constructs a new {@code Ratio} with the given components and explicit name.
-     *
-     * @param x    the x component of the ratio
-     * @param y    the y component of the ratio
-     * @param name the display name of the ratio
-     */
+    /// Constructs a new `Ratio` with the given components and explicit name.
+    ///
+    /// @param x    the x component of the ratio
+    /// @param y    the y component of the ratio
+    /// @param name the display name of the ratio
     protected Ratio(int x, int y, String name) {
       this.x = x;
       this.y = y;
       this.name = name;
     }
 
-    /**
-     * Collects all public static {@link Resolution} fields declared on the supplied class.
-     *
-     * @param clz the class whose declared {@code Resolution} fields will be returned
-     * @return all matching resolutions
-     */
+    /// Collects all public static [Resolution] fields declared on the supplied class.
+    ///
+    /// @param clz the class whose declared `Resolution` fields will be returned
+    /// @return all matching resolutions
     protected static List<Resolution> getAll(Class<?> clz) {
       List<Resolution> resolutions = new ArrayList<>();
 
@@ -281,29 +242,23 @@ public class Resolution {
       return resolutions;
     }
 
-    /**
-     * Gets the name of this aspect ratio
-     *
-     * @return The name of this aspect ratio.
-     */
+    /// Gets the name of this aspect ratio
+    ///
+    /// @return The name of this aspect ratio.
     public String getName() {
       return this.name;
     }
 
-    /**
-     * Gets the x-value of this aspect ratio.
-     *
-     * @return The x-value of this aspect ratio.
-     */
+    /// Gets the x-value of this aspect ratio.
+    ///
+    /// @return The x-value of this aspect ratio.
     public int getX() {
       return this.x;
     }
 
-    /**
-     * Gets the y-value of this aspect ratio.
-     *
-     * @return The y-value of this aspect ratio.
-     */
+    /// Gets the y-value of this aspect ratio.
+    ///
+    /// @return The y-value of this aspect ratio.
     public int getY() {
       return this.y;
     }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/Screen.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/Screen.java
@@ -2,35 +2,29 @@ package de.gurkenlabs.litiengine.gui.screens;
 
 import de.gurkenlabs.litiengine.gui.GuiComponent;
 
-/**
- * Screens are the containers that allow you to organize the visible contents of your game. They render the game's
- * Environment and are considered the parent of all GUI components you want to display in a particular state of your
- * game. The screen itself inherits from GuiComponent and thereby provides support to define an Appearance and listen to
- * all kinds of Input events (e.g. {@code onMouseMoved(…)}). Everything that should be visible to the player needs to be
- * rendered to the currently active screen.
- */
+/// Screens are the containers that allow you to organize the visible contents of your game. They render the game's
+/// Environment and are considered the parent of all GUI components you want to display in a particular state of your
+/// game. The screen itself inherits from GuiComponent and thereby provides support to define an Appearance and listen to
+/// all kinds of Input events (e.g. `onMouseMoved(…)`). Everything that should be visible to the player needs to be
+/// rendered to the currently active screen.
 public abstract class Screen extends GuiComponent {
   protected Screen(final String screenName) {
     super(0, 0);
     this.setName(screenName);
   }
-  /**
-   * Overrides the setX method from GuiComponent to prevent changing the x-coordinate.
-   * This method does nothing because screens always start at the coordinates (0, 0).
-   *
-   * @param x The new x-coordinate, which will be ignored.
-   */
+  /// Overrides the setX method from GuiComponent to prevent changing the x-coordinate.
+  /// This method does nothing because screens always start at the coordinates (0, 0).
+  ///
+  /// @param x The new x-coordinate, which will be ignored.
   @Override
   public void setX(final double x) {
     // do nothing because screens always start at 0/0
   }
 
-  /**
-   * Overrides the setY method from GuiComponent to prevent changing the y-coordinate.
-   * This method does nothing because screens always start at the coordinates (0, 0).
-   *
-   * @param y The new y-coordinate, which will be ignored.
-   */
+  /// Overrides the setY method from GuiComponent to prevent changing the y-coordinate.
+  /// This method does nothing because screens always start at the coordinates (0, 0).
+  ///
+  /// @param y The new y-coordinate, which will be ignored.
   @Override
   public void setY(final double y) {
     // do nothing because screens always start at 0/0

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/ScreenChangedEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/ScreenChangedEvent.java
@@ -3,40 +3,32 @@ package de.gurkenlabs.litiengine.gui.screens;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * This event is fired when the screen changes in the game.
- */
+/// This event is fired when the screen changes in the game.
 public class ScreenChangedEvent extends EventObject {
   @Serial private static final long serialVersionUID = 6145911214616836674L;
   private final transient Screen previous;
   private final transient Screen changed;
 
-  /**
-   * Constructs a new ScreenChangedEvent.
-   *
-   * @param changed  the new screen that has been changed to
-   * @param previous the previous screen that was displayed
-   */
+  /// Constructs a new ScreenChangedEvent.
+  ///
+  /// @param changed  the new screen that has been changed to
+  /// @param previous the previous screen that was displayed
   public ScreenChangedEvent(Screen changed, Screen previous) {
     super(changed);
     this.previous = previous;
     this.changed = changed;
   }
 
-  /**
-   * Gets the previous screen that was displayed.
-   *
-   * @return the previous screen
-   */
+  /// Gets the previous screen that was displayed.
+  ///
+  /// @return the previous screen
   public Screen getPrevious() {
     return this.previous;
   }
 
-  /**
-   * Gets the new screen that has been changed to.
-   *
-   * @return the new screen
-   */
+  /// Gets the new screen that has been changed to.
+  ///
+  /// @return the new screen
   public Screen getChanged() {
     return this.changed;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/ScreenChangedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/ScreenChangedListener.java
@@ -2,19 +2,15 @@ package de.gurkenlabs.litiengine.gui.screens;
 
 import java.util.EventListener;
 
-/**
- * Listener interface for receiving screen changed events.
- * The class that is interested in processing a screen changed event
- * implements this interface, and the object created with that class
- * is registered with a component using the component's
- * <code>addScreenChangedListener</code> method. When the screen changed
- * event occurs, that object's <code>changed</code> method is invoked.
- */
+/// Listener interface for receiving screen changed events.
+/// The class that is interested in processing a screen changed event
+/// implements this interface, and the object created with that class
+/// is registered with a component using the component's
+/// `addScreenChangedListener` method. When the screen changed
+/// event occurs, that object's `changed` method is invoked.
 public interface ScreenChangedListener extends EventListener {
-  /**
-   * Invoked when the screen has changed.
-   *
-   * @param event the event that contains information about the screen change
-   */
+  /// Invoked when the screen has changed.
+  ///
+  /// @param event the event that contains information about the screen change
   void changed(ScreenChangedEvent event);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/ScreenManager.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/gui/screens/ScreenManager.java
@@ -11,19 +11,17 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The {@code ScreenManager} holds instances of all available screens and handles whenever a different {@code Screen}
- * should be shown to the player. It provides the currently active Screen for the Game’s {@code RenderComponent} which
- * calls the {@code Screen.render(Graphics2D)} method on every tick of the {@code RenderLoop}. Overwriting this method
- * provides the ability to define a customized render pipeline that suits the need of a particular Screen
- * implementation. With the GameScreen, the LITIENGINE provides a simple default Screen implementation that renders the
- * current {@code Environment} and all its {@code GuiComponents}.
- *
- * @see Screen
- * @see RenderComponent
- * @see GameScreen
- * @see Screen#render(java.awt.Graphics2D)
- */
+/// The `ScreenManager` holds instances of all available screens and handles whenever a different `Screen`
+/// should be shown to the player. It provides the currently active Screen for the Game’s `RenderComponent` which
+/// calls the `Screen.render(Graphics2D)` method on every tick of the `RenderLoop`. Overwriting this method
+/// provides the ability to define a customized render pipeline that suits the need of a particular Screen
+/// implementation. With the GameScreen, the LITIENGINE provides a simple default Screen implementation that renders the
+/// current `Environment` and all its `GuiComponents`.
+///
+/// @see Screen
+/// @see RenderComponent
+/// @see GameScreen
+/// @see Screen#render(java.awt.Graphics2D)
 public final class ScreenManager {
   private static final Logger log = Logger.getLogger(ScreenManager.class.getName());
   private static final int DEFAULT_CHANGE_COOLDOWN = 200;
@@ -38,11 +36,9 @@ public final class ScreenManager {
   private long lastScreenChange = 0;
   private boolean resolutionListenerRegistered = false;
 
-  /**
-   * <b>You should never call this manually! Instead use the {@code Game.screens()} instance.</b>
-   *
-   * @see Game#screens()
-   */
+  /// **You should never call this manually! Instead use the `Game.screens()` instance.**
+  ///
+  /// @see Game#screens()
   public ScreenManager() {
     if (Game.screens() != null) {
       throw new UnsupportedOperationException(
@@ -53,32 +49,26 @@ public final class ScreenManager {
     this.screens = new CopyOnWriteArrayList<>();
   }
 
-  /**
-   * Adds the specified screen changed listener to receive events when the current screen was changed.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified screen changed listener to receive events when the current screen was changed.
+  ///
+  /// @param listener
+  /// The listener to add.
   public void addScreenChangedListener(ScreenChangedListener listener) {
     this.screenChangedListeners.add(listener);
   }
 
-  /**
-   * Removes the specified screen changed listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Removes the specified screen changed listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   public void removeScreenChangedListener(ScreenChangedListener listener) {
     this.screenChangedListeners.remove(listener);
   }
 
-  /**
-   * Adds the specified screen instance to the manager.
-   *
-   * @param screen
-   *          The screen to add.
-   */
+  /// Adds the specified screen instance to the manager.
+  ///
+  /// @param screen
+  /// The screen to add.
   public void add(final Screen screen) {
     screen.setWidth(Game.window().getWidth());
     screen.setHeight(Game.window().getHeight());
@@ -94,12 +84,10 @@ public final class ScreenManager {
     }
   }
 
-  /**
-   * Removes the specified screen instance from the manager.
-   *
-   * @param screen
-   *          The screen to remove.
-   */
+  /// Removes the specified screen instance from the manager.
+  ///
+  /// @param screen
+  /// The screen to remove.
   public void remove(Screen screen) {
     this.screens.remove(screen);
     if (this.current() == screen) {
@@ -111,12 +99,10 @@ public final class ScreenManager {
     }
   }
 
-  /**
-   * Displays the specified screen by setting
-   *
-   * @param screen
-   *          The screen to be displayed.
-   */
+  /// Displays the specified screen by setting
+  ///
+  /// @param screen
+  /// The screen to be displayed.
   public void display(final Screen screen) {
     if (Game.hasStarted() && Game.time().since(this.lastScreenChange) < this.getChangeCooldown()) {
       log.log(
@@ -148,12 +134,10 @@ public final class ScreenManager {
     }
   }
 
-  /**
-   * Displays the {@code Screen} with the specified name.
-   *
-   * @param screenName
-   *          The name of the screen to be displayed.
-   */
+  /// Displays the `Screen` with the specified name.
+  ///
+  /// @param screenName
+  /// The name of the screen to be displayed.
   public void display(final String screenName) {
     if (this.current() != null && this.current().getName().equalsIgnoreCase(screenName)) {
       log.log(
@@ -180,13 +164,11 @@ public final class ScreenManager {
     this.display(screen);
   }
 
-  /**
-   * Gets the screen by its name.
-   *
-   * @param screenName
-   *          The name of the screen.
-   * @return The
-   */
+  /// Gets the screen by its name.
+  ///
+  /// @param screenName
+  /// The name of the screen.
+  /// @return The
   public Screen get(String screenName) {
     Optional<Screen> opt =
         this.screens.stream()
@@ -195,45 +177,37 @@ public final class ScreenManager {
     return opt.orElse(null);
   }
 
-  /**
-   * Gets all screens of the game.
-   *
-   * @return All screens that have been previously added to this instance.
-   * @see #add(Screen)
-   */
+  /// Gets all screens of the game.
+  ///
+  /// @return All screens that have been previously added to this instance.
+  /// @see #add(Screen)
   public Collection<Screen> getAll() {
     return this.screens;
   }
 
-  /**
-   * Gets the currently active screen that is being rendered by the {@code RenderComponent}.
-   *
-   * @return The currently active screen.
-   * @see GameWindow#getRenderComponent()
-   * @see RenderComponent#render()
-   */
+  /// Gets the currently active screen that is being rendered by the `RenderComponent`.
+  ///
+  /// @return The currently active screen.
+  /// @see GameWindow#getRenderComponent()
+  /// @see RenderComponent#render()
   public Screen current() {
     return this.currentScreen;
   }
 
-  /**
-   * Gets the screen change cooldown which is used to ensure that screens cannot be switched too quickly while the game is
-   * running.
-   *
-   * @return The current change timeout for screens.
-   * @see #DEFAULT_CHANGE_COOLDOWN
-   * @see Game#hasStarted()
-   */
+  /// Gets the screen change cooldown which is used to ensure that screens cannot be switched too quickly while the game is
+  /// running.
+  ///
+  /// @return The current change timeout for screens.
+  /// @see #DEFAULT_CHANGE_COOLDOWN
+  /// @see Game#hasStarted()
   public int getChangeCooldown() {
     return this.changeCooldown;
   }
 
-  /**
-   * Sets the cooldown for changing screens.
-   *
-   * @param changeCooldown
-   *          The cooldown for changing screens.
-   */
+  /// Sets the cooldown for changing screens.
+  ///
+  /// @param changeCooldown
+  /// The cooldown for changing screens.
   public void setChangeCooldown(int changeCooldown) {
     this.changeCooldown = changeCooldown;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Gamepad.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Gamepad.java
@@ -12,10 +12,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * The {@code Gamepad} class is designed as a wrapper implementation for any gamepad input that provides events and
- * information about player input via gamepad.
- */
+/// The `Gamepad` class is designed as a wrapper implementation for any gamepad input that provides events and
+/// information about player input via gamepad.
 public final class Gamepad extends GamepadEvents implements IUpdateable, InputDeviceListener {
   private final InputDevice inputDevice;
 
@@ -42,65 +40,52 @@ public final class Gamepad extends GamepadEvents implements IUpdateable, InputDe
     this.type = inputDevice.getProductName();
   }
 
-  /**
-   * Gets the unique id of this gamepad by which it is identified.
-   *
-   * @return The unique id of this gamepad.
-   */
+  /// Gets the unique id of this gamepad by which it is identified.
+  ///
+  /// @return The unique id of this gamepad.
   public String getId() {
     return this.inputDevice.getID();
   }
 
-  /**
-   * Gets the name of this gamepad.
-   *
-   * @return The name of this gamepad.
-   */
+  /// Gets the name of this gamepad.
+  ///
+  /// @return The name of this gamepad.
   public String getName() {
     return this.inputDevice.getName();
   }
 
-  /**
-   * Gets the poll data for the specified component on this gamepad.
-   *
-   * <p>
-   * Returns the data from the last time the control has been polled.If this axis is a button, the value returned will be
-   * either 0.0f or 1.0f.If this axis is normalized, the value returned will be between -1.0f and1.0f.
-   *
-   * @param componentId The component to retrieve the poll data for.
-   * @return The data from the last time the specified component has been polled; 0 if this gamepad doesn't provide the
-   * requested component.
-   */
+  /// Gets the poll data for the specified component on this gamepad.
+  ///
+  /// Returns the data from the last time the control has been polled.If this axis is a button, the value returned will be
+  /// either 0.0f or 1.0f.If this axis is normalized, the value returned will be between -1.0f and1.0f.
+  ///
+  /// @param componentId The component to retrieve the poll data for.
+  /// @return The data from the last time the specified component has been polled; 0 if this gamepad doesn't provide the
+  /// requested component.
   public float getPollData(final InputComponent.ID componentId) {
     var component = this.inputDevice.getComponent(componentId);
     return component.map(InputComponent::getData).orElse(0F);
 
   }
 
-  /**
-   * Gets the deadzone for any axis components on this gamepad.
-   *
-   * <p>
-   * A deadzone defines the poll value at which the events of this gamepad are not being triggered. This is useful to
-   * smooth out controller input and not react to idle noise.
-   *
-   * @return The axis deadzone for this component.
-   * @see #setAxisDeadzone(float)
-   */
+  /// Gets the deadzone for any axis components on this gamepad.
+  ///
+  /// A deadzone defines the poll value at which the events of this gamepad are not being triggered. This is useful to
+  /// smooth out controller input and not react to idle noise.
+  ///
+  /// @return The axis deadzone for this component.
+  /// @see #setAxisDeadzone(float)
   public float getAxisDeadzone() {
     return this.axisDeadzone;
   }
 
-  /**
-   * Gets the deadzone for any trigger components on this gamepad.
-   *
-   * <p>
-   * A deadzone defines the poll value at which the events of this gamepad are not being triggered. This is useful to
-   * smooth out controller input and not react to idle noise.
-   *
-   * @return The trigger deadzone for this gamepad.
-   * @see #setTriggerDeadzone(float)
-   */
+  /// Gets the deadzone for any trigger components on this gamepad.
+  ///
+  /// A deadzone defines the poll value at which the events of this gamepad are not being triggered. This is useful to
+  /// smooth out controller input and not react to idle noise.
+  ///
+  /// @return The trigger deadzone for this gamepad.
+  /// @see #setTriggerDeadzone(float)
   public float getTriggerDeadzone() {
     return this.triggerDeadzone;
   }
@@ -123,22 +108,18 @@ public final class Gamepad extends GamepadEvents implements IUpdateable, InputDe
     return this.inputDevice.getComponent(gamepadComponent).isPresent();
   }
 
-  /**
-   * Sets the deadzone for any axis components on this gamepad.
-   *
-   * @param axisDeadzone The axis deadzone for this gamepad.
-   * @see #getAxisDeadzone()
-   */
+  /// Sets the deadzone for any axis components on this gamepad.
+  ///
+  /// @param axisDeadzone The axis deadzone for this gamepad.
+  /// @see #getAxisDeadzone()
   public void setAxisDeadzone(float axisDeadzone) {
     this.axisDeadzone = axisDeadzone;
   }
 
-  /**
-   * Sets the deadzone for any trigger components on this gamepad.
-   *
-   * @param triggerDeadzone The trigger deadzone for this gamepad.
-   * @see #getTriggerDeadzone()
-   */
+  /// Sets the deadzone for any trigger components on this gamepad.
+  ///
+  /// @param triggerDeadzone The trigger deadzone for this gamepad.
+  /// @see #getTriggerDeadzone()
   public void setTriggerDeadzone(float triggerDeadzone) {
     this.triggerDeadzone = triggerDeadzone;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/GamepadEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/GamepadEvent.java
@@ -23,49 +23,38 @@ public class GamepadEvent extends EventObject {
     this.relative = component.isRelative();
   }
 
-  /**
-   * Gets the data from the last time the component has been polled. If this axis is a button, the value returned will be
-   * either 0.0f or 1.0f. If this axis is normalized, the value returned will be between -1.0f and 1.0f.
-   *
-   * @return The last poll value of the component of this event.
-   */
+  /// Gets the data from the last time the component has been polled. If this axis is a button, the value returned will be
+  /// either 0.0f or 1.0f. If this axis is normalized, the value returned will be between -1.0f and 1.0f.
+  ///
+  /// @return The last poll value of the component of this event.
   public float getValue() {
     return this.value;
   }
 
-  /**
-   * Gets the identifier of the component that caused this event.
-   *
-   * @return The identifier of the component.
-   */
+  /// Gets the identifier of the component that caused this event.
+  ///
+  /// @return The identifier of the component.
   public String getComponentId() {
     return this.component;
   }
 
-  /**
-   * Gets the name of the component that caused this event.
-   *
-   * @return The human-readable name of the component.
-   */
+  /// Gets the name of the component that caused this event.
+  ///
+  /// @return The human-readable name of the component.
   public String getComponentName() {
     return this.componentName;
   }
 
-  /**
-   * Gets the gamepad that caused the event.
-   *
-   * @return The gamepad of this event.
-   */
+  /// Gets the gamepad that caused the event.
+  ///
+  /// @return The gamepad of this event.
   public Gamepad getGamepad() {
     return this.gamepad;
   }
 
-  /**
-   * Returns {@code true} if data returned from {@code poll} is relative to the last call, or {@code
-   * false} if data is absolute.
-   *
-   * @return True if the data is relative; otherwise false.
-   */
+  /// Returns `true` if data returned from `poll` is relative to the last call, or `false` if data is absolute.
+  ///
+  /// @return True if the data is relative; otherwise false.
   public boolean isRelative() {
     return this.relative;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/GamepadEvents.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/GamepadEvents.java
@@ -8,9 +8,7 @@ import java.util.EventListener;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * The {@code GamepadEvents} class is the engine's implementation for receiving gamepad input events.
- */
+/// The `GamepadEvents` class is the engine's implementation for receiving gamepad input events.
 public abstract class GamepadEvents {
   protected final Map<InputComponent.ID, Collection<GamepadValueChangedListener>> componentPollListeners;
   protected final Map<InputComponent.ID, Collection<GamepadButtonPressedListener>> componentPressedListeners;
@@ -28,164 +26,130 @@ public abstract class GamepadEvents {
     this.releasedListeners = ConcurrentHashMap.newKeySet();
   }
 
-  /**
-   * Adds the specified gamepad poll listener to receive events when the component with the defined identifier has been polled.
-   *
-   * @param id       The component identifier for which to add the listener.
-   * @param listener The listener to add.
-   */
+  /// Adds the specified gamepad poll listener to receive events when the component with the defined identifier has been polled.
+  ///
+  /// @param id       The component identifier for which to add the listener.
+  /// @param listener The listener to add.
   public void onValueChanged(InputComponent.ID id, GamepadValueChangedListener listener) {
     addComponentListener(this.componentPollListeners, id, listener);
   }
 
-  /**
-   * Adds the specified gamepad pressed listener to receive events when the component with the defined identifier has been pressed.
-   *
-   * @param identifier The component identifier for which to add the listener.
-   * @param listener   The listener to add.
-   */
+  /// Adds the specified gamepad pressed listener to receive events when the component with the defined identifier has been pressed.
+  ///
+  /// @param identifier The component identifier for which to add the listener.
+  /// @param listener   The listener to add.
   public void onButtonPressed(InputComponent.ID identifier, GamepadButtonPressedListener listener) {
     addComponentListener(this.componentPressedListeners, identifier, listener);
   }
 
-  /**
-   * Adds the specified gamepad pressed listener to receive events when the component with the defined identifier has been pressed.
-   *
-   * @param id The component identifier for which to add the listener.
-   * @param listener   The listener to add.
-   */
+  /// Adds the specified gamepad pressed listener to receive events when the component with the defined identifier has been pressed.
+  ///
+  /// @param id The component identifier for which to add the listener.
+  /// @param listener   The listener to add.
   public void onButtonPressed(int id, GamepadButtonPressedListener listener){
     this.onButtonPressed(InputComponent.ID.getButton(id), listener);
   }
 
-  /**
-   * Adds the specified gamepad released listener to receive events when the component with the defined identifier has been released.
-   *
-   * @param identifier The component identifier for which to add the listener.
-   * @param listener   The listener to add.
-   */
+  /// Adds the specified gamepad released listener to receive events when the component with the defined identifier has been released.
+  ///
+  /// @param identifier The component identifier for which to add the listener.
+  /// @param listener   The listener to add.
   public void onButtonReleased(InputComponent.ID identifier, GamepadButtonReleasedListener listener) {
     addComponentListener(this.componentReleasedListeners, identifier, listener);
   }
 
-  /**
-   * Adds the specified gamepad released listener to receive events when the component with the defined identifier has been released.
-   *
-   * @param id The component identifier for which to add the listener.
-   * @param listener   The listener to add.
-   */
+  /// Adds the specified gamepad released listener to receive events when the component with the defined identifier has been released.
+  ///
+  /// @param id The component identifier for which to add the listener.
+  /// @param listener   The listener to add.
   public void onButtonReleased(int id, GamepadButtonReleasedListener listener){
     this.onButtonReleased(InputComponent.ID.getButton(id), listener);
   }
 
-  /**
-   * Adds the specified gamepad poll listener to receive events when any component has been polled.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified gamepad poll listener to receive events when any component has been polled.
+  ///
+  /// @param listener The listener to add.
   public void onValueChanged(GamepadValueChangedListener listener) {
     this.pollListeners.add(listener);
   }
 
-  /**
-   * Adds the specified gamepad pressed listener to receive events when any component has been pressed.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified gamepad pressed listener to receive events when any component has been pressed.
+  ///
+  /// @param listener The listener to add.
   public void onButtonPressed(GamepadButtonPressedListener listener) {
     this.pressedListeners.add(listener);
   }
 
-  /**
-   * Adds the specified gamepad released listener to receive events when any component has been released.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified gamepad released listener to receive events when any component has been released.
+  ///
+  /// @param listener The listener to add.
   public void onButtonReleased(GamepadButtonReleasedListener listener) {
     this.releasedListeners.add(listener);
   }
 
-  /**
-   * Unregister the specified poll listener from gamepad events.
-   *
-   * @param identifier The component identifier for which to remove the listener.
-   * @param listener   The listener to remove.
-   */
+  /// Unregister the specified poll listener from gamepad events.
+  ///
+  /// @param identifier The component identifier for which to remove the listener.
+  /// @param listener   The listener to remove.
   public void removePollListener(InputComponent.ID identifier, GamepadValueChangedListener listener) {
     removeComponentListener(this.componentPollListeners, identifier, listener);
   }
 
 
-  /**
-   * Unregister the specified pressed listener from gamepad events.
-   *
-   * @param identifier The component identifier for which to remove the listener.
-   * @param listener   The listener to remove.
-   */
+  /// Unregister the specified pressed listener from gamepad events.
+  ///
+  /// @param identifier The component identifier for which to remove the listener.
+  /// @param listener   The listener to remove.
   public void removeButtonPressedListener(InputComponent.ID identifier, GamepadButtonPressedListener listener) {
     removeComponentListener(this.componentPressedListeners, identifier, listener);
   }
 
-  /**
-   * Unregister the specified released listener from gamepad events.
-   *
-   * @param id The component identifier for which to remove the listener.
-   * @param listener   The listener to remove.
-   */
+  /// Unregister the specified released listener from gamepad events.
+  ///
+  /// @param id The component identifier for which to remove the listener.
+  /// @param listener   The listener to remove.
   public void removeButtonPressedListener(int id, GamepadButtonPressedListener listener){
     this.removeButtonPressedListener(InputComponent.ID.getButton(id), listener);
   }
 
-  /**
-   * Unregister the specified released listener from gamepad events.
-   *
-   * @param identifier The component identifier for which to remove the listener.
-   * @param listener   The listener to remove.
-   */
+  /// Unregister the specified released listener from gamepad events.
+  ///
+  /// @param identifier The component identifier for which to remove the listener.
+  /// @param listener   The listener to remove.
   public void removeButtonReleasedListener(InputComponent.ID identifier, GamepadButtonReleasedListener listener) {
     removeComponentListener(this.componentReleasedListeners, identifier, listener);
   }
 
-  /**
-   * Unregister the specified released listener from gamepad events.
-   *
-   * @param id The component identifier for which to remove the listener.
-   * @param listener   The listener to remove.
-   */
+  /// Unregister the specified released listener from gamepad events.
+  ///
+  /// @param id The component identifier for which to remove the listener.
+  /// @param listener   The listener to remove.
   public void removeButtonReleasedListener(int id, GamepadButtonReleasedListener listener){
     this.removeButtonReleasedListener(InputComponent.ID.getButton(id), listener);
   }
 
-  /**
-   * Unregister the specified poll listener from gamepad events.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Unregister the specified poll listener from gamepad events.
+  ///
+  /// @param listener The listener to remove.
   public void removePollListener(GamepadValueChangedListener listener) {
     this.pollListeners.remove(listener);
   }
 
-  /**
-   * Unregister the specified pressed listener from gamepad events.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Unregister the specified pressed listener from gamepad events.
+  ///
+  /// @param listener The listener to remove.
   public void removeButtonPressedListener(GamepadButtonPressedListener listener) {
     this.pressedListeners.remove(listener);
   }
 
-  /**
-   * Unregister the specified released listener from gamepad events.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Unregister the specified released listener from gamepad events.
+  ///
+  /// @param listener The listener to remove.
   public void removeButtonReleasedListener(GamepadButtonReleasedListener listener) {
     this.releasedListeners.remove(listener);
   }
 
-  /**
-   * Removes all registered event listeners from the Gamepad instance.
-   */
+  /// Removes all registered event listeners from the Gamepad instance.
   public void clearEventListeners() {
     this.componentPollListeners.clear();
     this.componentPressedListeners.clear();
@@ -196,12 +160,10 @@ public abstract class GamepadEvents {
     this.releasedListeners.clear();
   }
 
-  /**
-   * Determines whether the specified Gamepad component is currently pressed. This is useful for button type components.
-   *
-   * @param buttonId The component to check against.
-   * @return True if the component is pressed, otherwise false.
-   */
+  /// Determines whether the specified Gamepad component is currently pressed. This is useful for button type components.
+  ///
+  /// @param buttonId The component to check against.
+  /// @return True if the component is pressed, otherwise false.
   public abstract boolean isButtonPressed(InputComponent.ID buttonId);
 
   public abstract boolean isButtonPressed(int buttonId);
@@ -219,51 +181,39 @@ public abstract class GamepadEvents {
     consumerList.get(identifier).remove(consumer);
   }
 
-  /**
-   * This listener interface receives poll events for a gamepad.
-   *
-   * @see GamepadEvents#onValueChanged(GamepadValueChangedListener)
-   * @see GamepadEvents#onValueChanged(de.gurkenlabs.input4j.InputComponent.ID, GamepadValueChangedListener)
-   */
+  /// This listener interface receives poll events for a gamepad.
+  ///
+  /// @see GamepadEvents#onValueChanged(GamepadValueChangedListener)
+  /// @see GamepadEvents#onValueChanged(de.gurkenlabs.input4j.InputComponent.ID, GamepadValueChangedListener)
   @FunctionalInterface
   public interface GamepadValueChangedListener extends EventListener {
-    /**
-     * Invoked when a gamepad component value was changed.
-     *
-     * @param event The gamepad event.
-     */
+    /// Invoked when a gamepad component value was changed.
+    ///
+    /// @param event The gamepad event.
     void valueChanged(GamepadEvent event);
   }
 
-  /**
-   * This listener interface receives pressed events for a gamepad.
-   *
-   * @see GamepadEvents#onButtonPressed(GamepadButtonPressedListener)
-   * @see GamepadEvents#onButtonPressed(de.gurkenlabs.input4j.InputComponent.ID, GamepadButtonPressedListener)
-   */
+  /// This listener interface receives pressed events for a gamepad.
+  ///
+  /// @see GamepadEvents#onButtonPressed(GamepadButtonPressedListener)
+  /// @see GamepadEvents#onButtonPressed(de.gurkenlabs.input4j.InputComponent.ID, GamepadButtonPressedListener)
   @FunctionalInterface
   public interface GamepadButtonPressedListener extends EventListener {
-    /**
-     * Invoked when a gamepad component has been pressed.
-     *
-     * @param event The gamepad event.
-     */
+    /// Invoked when a gamepad component has been pressed.
+    ///
+    /// @param event The gamepad event.
     void pressed(GamepadEvent event);
   }
 
-  /**
-   * This listener interface receives released events for a gamepad.
-   *
-   * @see GamepadEvents#onButtonReleased(GamepadButtonReleasedListener)
-   * @see GamepadEvents#onButtonReleased(de.gurkenlabs.input4j.InputComponent.ID, GamepadButtonReleasedListener)
-   */
+  /// This listener interface receives released events for a gamepad.
+  ///
+  /// @see GamepadEvents#onButtonReleased(GamepadButtonReleasedListener)
+  /// @see GamepadEvents#onButtonReleased(de.gurkenlabs.input4j.InputComponent.ID, GamepadButtonReleasedListener)
   @FunctionalInterface
   public interface GamepadButtonReleasedListener extends EventListener {
-    /**
-     * Invoked when a gamepad component has been released.
-     *
-     * @param event The gamepad event.
-     */
+    /// Invoked when a gamepad component has been released.
+    ///
+    /// @param event The gamepad event.
     void buttonReleased(GamepadEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/GamepadManager.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/GamepadManager.java
@@ -13,16 +13,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The {@code GamepadManager} provides access to all gamepad input devices.
- *
- * <p>
- * Gamepads don't need to be added explicitly, the manager supports hot-plugging at runtime and will auto-detect any
- * added/removed gamepads.
- *
- * @see #current()
- * @see #get(int)
- */
+/// The `GamepadManager` provides access to all gamepad input devices.
+///
+/// Gamepads don't need to be added explicitly, the manager supports hot-plugging at runtime and will auto-detect any
+/// added/removed gamepads.
+///
+/// @see #current()
+/// @see #get(int)
 public final class GamepadManager extends GamepadEvents {
   private static final Logger log = Logger.getLogger(GamepadManager.class.getName());
 
@@ -88,72 +85,58 @@ public final class GamepadManager extends GamepadEvents {
     }
   }
 
-  /**
-   * Adds the specified gamepad added listener to receive events when gamepads are added.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified gamepad added listener to receive events when gamepads are added.
+  ///
+  /// @param listener The listener to add.
   public void onAdded(final GamepadAddedListener listener) {
     this.gamepadAddedConsumer.add(listener);
   }
 
-  /**
-   * Unregister the specified added listener from this instance.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Unregister the specified added listener from this instance.
+  ///
+  /// @param listener The listener to remove.
   public void removeAddedListener(GamepadAddedListener listener) {
     this.gamepadAddedConsumer.remove(listener);
   }
 
-  /**
-   * Adds the specified gamepad removed listener to receive events when gamepads are removed.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds the specified gamepad removed listener to receive events when gamepads are removed.
+  ///
+  /// @param listener The listener to add.
   public void onRemoved(final GamepadRemovedListener listener) {
     this.gamepadRemovedConsumer.add(listener);
   }
 
-  /**
-   * Unregister the specified removed listener from this instance.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Unregister the specified removed listener from this instance.
+  ///
+  /// @param listener The listener to remove.
   public void removeRemovedListener(GamepadRemovedListener listener) {
     this.gamepadRemovedConsumer.remove(listener);
   }
 
-  /**
-   * Gets all gamepads that are currently available.
-   *
-   * @return All available gamepads.
-   * @see #get(int)
-   * @see #current()
-   */
+  /// Gets all gamepads that are currently available.
+  ///
+  /// @return All available gamepads.
+  /// @see #get(int)
+  /// @see #current()
   public List<Gamepad> getAll() {
     return this.gamePads;
   }
 
-  /**
-   * Gets the first gamepad that is currently available.
-   *
-   * @return The first available {@link Gamepad} instance
-   * @see #get(int)
-   * @see #getAll()
-   */
+  /// Gets the first gamepad that is currently available.
+  ///
+  /// @return The first available [Gamepad] instance
+  /// @see #get(int)
+  /// @see #getAll()
   public Gamepad current() {
     return get(0);
   }
 
-  /**
-   * Gets the gamepad by the index within the gamepad list.
-   *
-   * @param index The index of the {@link Gamepad}.
-   * @return The {@link Gamepad} with the specified index.
-   * @see #getAll()
-   * @see #current()
-   */
+  /// Gets the gamepad by the index within the gamepad list.
+  ///
+  /// @param index The index of the [Gamepad].
+  /// @return The [Gamepad] with the specified index.
+  /// @see #getAll()
+  /// @see #current()
   public Gamepad get(final int index) {
     if (this.gamePads.isEmpty()) {
       return null;
@@ -162,15 +145,13 @@ public final class GamepadManager extends GamepadEvents {
     return this.gamePads.get(index);
   }
 
-  /**
-   * Gets the gamepad with the specified id if it is still plugged in. After re-plugging a controller while the game is
-   * running, its id might change.
-   *
-   * @param id The id of the {@link Gamepad}.
-   * @return The {@link Gamepad} with the specified index.
-   * @see #getAll()
-   * @see #current()
-   */
+  /// Gets the gamepad with the specified id if it is still plugged in. After re-plugging a controller while the game is
+  /// running, its id might change.
+  ///
+  /// @param id The id of the [Gamepad].
+  /// @return The [Gamepad] with the specified index.
+  /// @see #getAll()
+  /// @see #current()
   public Gamepad getById(final String id) {
     for (final Gamepad gamepad : this.gamePads) {
       if (gamepad.getId().equals(id)) {
@@ -372,33 +353,25 @@ public final class GamepadManager extends GamepadEvents {
     }
   }
 
-  /**
-   * This listener interface receives events when gamepads gets added.
-   *
-   * @see GamepadManager#onAdded(GamepadAddedListener)
-   */
+  /// This listener interface receives events when gamepads gets added.
+  ///
+  /// @see GamepadManager#onAdded(GamepadAddedListener)
   @FunctionalInterface
   public interface GamepadAddedListener extends EventListener {
-    /**
-     * Invoked when a gamepad was added.
-     *
-     * @param gamepad The added gamepad.
-     */
+    /// Invoked when a gamepad was added.
+    ///
+    /// @param gamepad The added gamepad.
     void added(Gamepad gamepad);
   }
 
-  /**
-   * This listener interface receives events when gamepads gets removed.
-   *
-   * @see GamepadManager#onAdded(GamepadAddedListener)
-   */
+  /// This listener interface receives events when gamepads gets removed.
+  ///
+  /// @see GamepadManager#onAdded(GamepadAddedListener)
   @FunctionalInterface
   public interface GamepadRemovedListener extends EventListener {
-    /**
-     * Invoked when a gamepad was removed.
-     *
-     * @param gamepad The removed gamepad.
-     */
+    /// Invoked when a gamepad was removed.
+    ///
+    /// @param gamepad The removed gamepad.
     void removed(Gamepad gamepad);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/IKeyboard.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/IKeyboard.java
@@ -4,250 +4,198 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.EventListener;
 
-/** The {@code IKeyboard} interface is the engine's API for receiving keyboard input events. */
+/// The `IKeyboard` interface is the engine's API for receiving keyboard input events.
 public interface IKeyboard {
 
-  /**
-   * Specifies whether the engine should consume key events with the ALT modifier.
-   *
-   * <p>
-   * This is useful to prevent unintended behavior of the default key processing.
-   *
-   * @param consume
-   *          True if the events with the ALT modifier should be consumed.
-   * @see KeyEvent#consume()
-   * @see KeyEvent#isAltDown()
-   */
+  /// Specifies whether the engine should consume key events with the ALT modifier.
+  ///
+  /// This is useful to prevent unintended behavior of the default key processing.
+  ///
+  /// @param consume
+  /// True if the events with the ALT modifier should be consumed.
+  /// @see KeyEvent#consume()
+  /// @see KeyEvent#isAltDown()
   void consumeAlt(boolean consume);
 
-  /**
-   * Checks whether the key with the specified {@code keyCode} is currently being pressed.
-   *
-   * @param keyCode
-   *          The keyCode to check for.
-   * @return True if the key with the specified code is currently pressed.
-   * @see #onKeyPressed(KeyPressedListener)
-   * @see #onKeyPressed(int, KeyPressedListener)
-   */
+  /// Checks whether the key with the specified `keyCode` is currently being pressed.
+  ///
+  /// @param keyCode
+  /// The keyCode to check for.
+  /// @return True if the key with the specified code is currently pressed.
+  /// @see #onKeyPressed(KeyPressedListener)
+  /// @see #onKeyPressed(int, KeyPressedListener)
   boolean isPressed(int keyCode);
 
-  /**
-   * Checks whether the key with the specified {@code keyCode} was recently released.
-   *
-   * @param keyCode
-   *          The keyCode to check for.
-   * @return True if the key with the specified code was recently released.
-   * @see #onKeyReleased(KeyReleasedListener)
-   * @see #onKeyReleased(int, KeyReleasedListener)
-   */
+  /// Checks whether the key with the specified `keyCode` was recently released.
+  ///
+  /// @param keyCode
+  /// The keyCode to check for.
+  /// @return True if the key with the specified code was recently released.
+  /// @see #onKeyReleased(KeyReleasedListener)
+  /// @see #onKeyReleased(int, KeyReleasedListener)
   boolean wasReleased(int keyCode);
 
-  /**
-   * Adds the specified key pressed listener to receive events when the key with the defined {@code
-   * keyCode} has been pressed.
-   *
-   * @param keyCode
-   *          The keyCode to capture the key pressed event for.
-   * @param listener
-   *          The listener to add.
-   * @see KeyListener#keyPressed(KeyEvent)
-   * @see KeyEvent#KEY_PRESSED
-   */
+  /// Adds the specified key pressed listener to receive events when the key with the defined `keyCode` has been pressed.
+  ///
+  /// @param keyCode
+  /// The keyCode to capture the key pressed event for.
+  /// @param listener
+  /// The listener to add.
+  /// @see KeyListener#keyPressed(KeyEvent)
+  /// @see KeyEvent#KEY_PRESSED
   void onKeyPressed(int keyCode, KeyPressedListener listener);
 
-  /**
-   * Unregister the specified listener from key pressed events.
-   *
-   * @param keyCode
-   *          The keyCode for which to remove the listener.
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key pressed events.
+  ///
+  /// @param keyCode
+  /// The keyCode for which to remove the listener.
+  /// @param listener
+  /// The listener to remove.
   void removeKeyPressedListener(int keyCode, KeyPressedListener listener);
 
-  /**
-   * Adds the specified key released listener to receive events when the key with the defined {@code
-   * keyCode} has been released.
-   *
-   * @param keyCode
-   *          The keyCode to capture the key released event for.
-   * @param listener
-   *          The listener to add.
-   * @see KeyListener#keyReleased(KeyEvent)
-   * @see KeyEvent#KEY_RELEASED
-   */
+  /// Adds the specified key released listener to receive events when the key with the defined `keyCode` has been released.
+  ///
+  /// @param keyCode
+  /// The keyCode to capture the key released event for.
+  /// @param listener
+  /// The listener to add.
+  /// @see KeyListener#keyReleased(KeyEvent)
+  /// @see KeyEvent#KEY_RELEASED
   void onKeyReleased(int keyCode, KeyReleasedListener listener);
 
-  /**
-   * Unregister the specified listener from key released events.
-   *
-   * @param keyCode
-   *          The keyCode for which to remove the listener.
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key released events.
+  ///
+  /// @param keyCode
+  /// The keyCode for which to remove the listener.
+  /// @param listener
+  /// The listener to remove.
   void removeKeyReleasedListener(int keyCode, KeyReleasedListener listener);
 
-  /**
-   * Adds the specified key typed listener to receive events when the key with the defined {@code
-   * keyCode} has been typed.
-   *
-   * @param keyCode
-   *          The keyCode to capture the key typed event for.
-   * @param listener
-   *          The listener to add.
-   * @see KeyListener#keyTyped(KeyEvent)
-   * @see KeyEvent#KEY_TYPED
-   */
+  /// Adds the specified key typed listener to receive events when the key with the defined `keyCode` has been typed.
+  ///
+  /// @param keyCode
+  /// The keyCode to capture the key typed event for.
+  /// @param listener
+  /// The listener to add.
+  /// @see KeyListener#keyTyped(KeyEvent)
+  /// @see KeyEvent#KEY_TYPED
   void onKeyTyped(int keyCode, KeyTypedListener listener);
 
-  /**
-   * Unregister the specified listener from key typed events.
-   *
-   * @param keyCode
-   *          The keyCode for which to remove the listener.
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key typed events.
+  ///
+  /// @param keyCode
+  /// The keyCode for which to remove the listener.
+  /// @param listener
+  /// The listener to remove.
   void removeKeyTypedListener(int keyCode, KeyTypedListener listener);
 
-  /**
-   * Adds the specified key pressed listener to receive events when any key has been pressed.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see KeyListener#keyPressed(KeyEvent)
-   * @see KeyEvent#KEY_PRESSED
-   */
+  /// Adds the specified key pressed listener to receive events when any key has been pressed.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see KeyListener#keyPressed(KeyEvent)
+  /// @see KeyEvent#KEY_PRESSED
   void onKeyPressed(KeyPressedListener listener);
 
-  /**
-   * Unregister the specified listener from key pressed events.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key pressed events.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeKeyPressedListener(KeyPressedListener listener);
 
-  /**
-   * Adds the specified key released listener to receive events when any key has been released.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see KeyListener#keyReleased(KeyEvent)
-   * @see KeyEvent#KEY_RELEASED
-   */
+  /// Adds the specified key released listener to receive events when any key has been released.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see KeyListener#keyReleased(KeyEvent)
+  /// @see KeyEvent#KEY_RELEASED
   void onKeyReleased(KeyReleasedListener listener);
 
-  /**
-   * Unregister the specified listener from key released events.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key released events.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeKeyReleasedListener(KeyReleasedListener listener);
 
-  /**
-   * Adds the specified key typed listener to receive events when any key has been typed.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see KeyListener#keyTyped(KeyEvent)
-   * @see KeyEvent#KEY_TYPED
-   */
+  /// Adds the specified key typed listener to receive events when any key has been typed.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see KeyListener#keyTyped(KeyEvent)
+  /// @see KeyEvent#KEY_TYPED
   void onKeyTyped(KeyTypedListener listener);
 
-  /**
-   * Unregister the specified listener from key typed events.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key typed events.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeKeyTypedListener(KeyTypedListener listener);
 
-  /**
-   * Removes all registered event consumers from the Keyboard instance. This <b>does not affect</b> registered
-   * {@code KeyListener} instances.
-   *
-   * @see #onKeyPressed(KeyPressedListener)
-   * @see #onKeyPressed(int, KeyPressedListener)
-   * @see #onKeyReleased(KeyReleasedListener)
-   * @see #onKeyReleased(int, KeyReleasedListener)
-   * @see #onKeyTyped(KeyTypedListener)
-   * @see #onKeyTyped(int, KeyTypedListener)
-   */
+  /// Removes all registered event consumers from the Keyboard instance. This **does not affect** registered
+  /// `KeyListener` instances.
+  ///
+  /// @see #onKeyPressed(KeyPressedListener)
+  /// @see #onKeyPressed(int, KeyPressedListener)
+  /// @see #onKeyReleased(KeyReleasedListener)
+  /// @see #onKeyReleased(int, KeyReleasedListener)
+  /// @see #onKeyTyped(KeyTypedListener)
+  /// @see #onKeyTyped(int, KeyTypedListener)
   void clearExplicitListeners();
 
-  /**
-   * Register for key events.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Register for key events.
+  ///
+  /// @param listener
+  /// The listener to add.
   void addKeyListener(KeyListener listener);
 
-  /**
-   * Unregister the specified listener from key events.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregister the specified listener from key events.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeKeyListener(KeyListener listener);
 
-  /**
-   * This listener interface receives pressed events for the keyboard.
-   *
-   * @see IKeyboard#onKeyPressed(KeyPressedListener)
-   * @see IKeyboard#onKeyPressed(int, KeyPressedListener)
-   * @see KeyListener#keyPressed(KeyEvent)
-   */
+  /// This listener interface receives pressed events for the keyboard.
+  ///
+  /// @see IKeyboard#onKeyPressed(KeyPressedListener)
+  /// @see IKeyboard#onKeyPressed(int, KeyPressedListener)
+  /// @see KeyListener#keyPressed(KeyEvent)
   @FunctionalInterface
   interface KeyPressedListener extends EventListener {
-    /**
-     * Invoked when a key has been pressed. See the class description for {@link KeyEvent} for a definition of a key pressed
-     * event.
-     *
-     * @param event
-     *          The key event.
-     */
+    /// Invoked when a key has been pressed. See the class description for [KeyEvent] for a definition of a key pressed
+    /// event.
+    ///
+    /// @param event
+    /// The key event.
     void keyPressed(KeyEvent event);
   }
 
-  /**
-   * This listener interface receives released events for the keyboard.
-   *
-   * @see IKeyboard#onKeyReleased(KeyReleasedListener)
-   * @see IKeyboard#onKeyReleased(int, KeyReleasedListener)
-   * @see KeyListener#keyReleased(KeyEvent)
-   */
+  /// This listener interface receives released events for the keyboard.
+  ///
+  /// @see IKeyboard#onKeyReleased(KeyReleasedListener)
+  /// @see IKeyboard#onKeyReleased(int, KeyReleasedListener)
+  /// @see KeyListener#keyReleased(KeyEvent)
   @FunctionalInterface
   interface KeyReleasedListener extends EventListener {
-    /**
-     * Invoked when a key has been released. See the class description for {@link KeyEvent} for a definition of a key
-     * released event.
-     *
-     * @param event
-     *          The key event.
-     */
+    /// Invoked when a key has been released. See the class description for [KeyEvent] for a definition of a key
+    /// released event.
+    ///
+    /// @param event
+    /// The key event.
     void keyReleased(KeyEvent event);
   }
 
-  /**
-   * This listener interface receives typed events for the keyboard.
-   *
-   * @see IKeyboard#onKeyTyped(KeyTypedListener)
-   * @see IKeyboard#onKeyTyped(int, KeyTypedListener)
-   * @see KeyListener#keyTyped(KeyEvent)
-   */
+  /// This listener interface receives typed events for the keyboard.
+  ///
+  /// @see IKeyboard#onKeyTyped(KeyTypedListener)
+  /// @see IKeyboard#onKeyTyped(int, KeyTypedListener)
+  /// @see KeyListener#keyTyped(KeyEvent)
   @FunctionalInterface
   interface KeyTypedListener extends EventListener {
-    /**
-     * Invoked when a key has been typed. See the class description for {@link KeyEvent} for a definition of a key typed
-     * event.
-     *
-     * @param event
-     *          The key event.
-     */
+    /// Invoked when a key has been typed. See the class description for [KeyEvent] for a definition of a key typed
+    /// event.
+    ///
+    /// @param event
+    /// The key event.
     void keyTyped(KeyEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/IMouse.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/IMouse.java
@@ -12,389 +12,300 @@ import java.awt.event.MouseWheelListener;
 import java.awt.geom.Point2D;
 import java.util.EventListener;
 
-/** The {@code IMouse} interface is the engine's API for receiving mouse input events. */
+/// The `IMouse` interface is the engine's API for receiving mouse input events.
 public interface IMouse {
-  /**
-   * Adds the specified mouse clicked listener to receive events when the mouse has been clicked.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see MouseListener#mouseClicked(MouseEvent)
-   * @see MouseEvent#MOUSE_CLICKED
-   */
+  /// Adds the specified mouse clicked listener to receive events when the mouse has been clicked.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see MouseListener#mouseClicked(MouseEvent)
+  /// @see MouseEvent#MOUSE_CLICKED
   void onClicked(MouseClickedListener listener);
 
-  /**
-   * Unregisters the specified mouse clicked listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse clicked listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMouseClickedListener(MouseClickedListener listener);
 
-  /**
-   * Adds the specified mouse dragged listener to receive events when the mouse has been dragged.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see MouseDraggedListener#mouseDragged(MouseEvent)
-   * @see MouseMotionListener#mouseDragged(MouseEvent)
-   * @see MouseEvent#MOUSE_DRAGGED
-   */
+  /// Adds the specified mouse dragged listener to receive events when the mouse has been dragged.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see MouseDraggedListener#mouseDragged(MouseEvent)
+  /// @see MouseMotionListener#mouseDragged(MouseEvent)
+  /// @see MouseEvent#MOUSE_DRAGGED
   void onDragged(MouseDraggedListener listener);
 
-  /**
-   * Unregisters the specified mouse dragged listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse dragged listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMouseDraggedListener(MouseDraggedListener listener);
 
-  /**
-   * Adds the specified mouse moved listener to receive events when the mouse has been moved.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see MouseMotionListener#mouseMoved(MouseEvent)
-   * @see MouseEvent#MOUSE_MOVED
-   */
+  /// Adds the specified mouse moved listener to receive events when the mouse has been moved.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see MouseMotionListener#mouseMoved(MouseEvent)
+  /// @see MouseEvent#MOUSE_MOVED
   void onMoved(MouseMovedListener listener);
 
-  /**
-   * Unregisters the specified mouse moved listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse moved listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMouseMovedListener(MouseMovedListener listener);
 
-  /**
-   * Adds the specified mouse pressed listener to receive events when the mouse has been pressed.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see MouseListener#mousePressed(MouseEvent)
-   * @see MouseEvent#MOUSE_PRESSED
-   */
+  /// Adds the specified mouse pressed listener to receive events when the mouse has been pressed.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see MouseListener#mousePressed(MouseEvent)
+  /// @see MouseEvent#MOUSE_PRESSED
   void onPressed(MousePressedListener listener);
 
-  /**
-   * Unregisters the specified mouse pressed listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse pressed listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMousePressedListener(MousePressedListener listener);
 
-  /**
-   * Adds the specified mouse pressing listener to receive continuous events while the mouse is being pressed.
-   *
-   * @param listener
-   *          The listener to add.
-   */
+  /// Adds the specified mouse pressing listener to receive continuous events while the mouse is being pressed.
+  ///
+  /// @param listener
+  /// The listener to add.
   void onPressing(MousePressingListener listener);
 
-  /**
-   * Unregisters the specified mouse pressing listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse pressing listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMousePressingListener(MousePressingListener listener);
 
-  /**
-   * Adds the specified mouse released listener to receive events when the mouse has been released.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see MouseListener#mouseReleased(MouseEvent)
-   * @see MouseEvent#MOUSE_RELEASED
-   */
+  /// Adds the specified mouse released listener to receive events when the mouse has been released.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see MouseListener#mouseReleased(MouseEvent)
+  /// @see MouseEvent#MOUSE_RELEASED
   void onReleased(MouseReleasedListener listener);
 
-  /**
-   * Unregisters the specified mouse released listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse released listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMouseReleasedListener(MouseReleasedListener listener);
 
-  /**
-   * Adds the specified mouse wheel listener to receive events when the mouse wheel has been moved.
-   *
-   * @param listener
-   *          The listener to add.
-   * @see MouseWheelListener#mouseWheelMoved(java.awt.event.MouseWheelEvent)
-   * @see MouseWheelEvent
-   */
+  /// Adds the specified mouse wheel listener to receive events when the mouse wheel has been moved.
+  ///
+  /// @param listener
+  /// The listener to add.
+  /// @see MouseWheelListener#mouseWheelMoved(java.awt.event.MouseWheelEvent)
+  /// @see MouseWheelEvent
   void onWheelMoved(MouseWheelListener listener);
 
-  /**
-   * Unregisters the specified mouse wheel listener.
-   *
-   * @param listener
-   *          The listener to remove.
-   */
+  /// Unregisters the specified mouse wheel listener.
+  ///
+  /// @param listener
+  /// The listener to remove.
   void removeMouseWheelListener(MouseWheelListener listener);
 
-  /**
-   * Register mouse listener.
-   *
-   * @param listener
-   *          the listener
-   */
+  /// Register mouse listener.
+  ///
+  /// @param listener
+  /// the listener
   void addMouseListener(MouseListener listener);
 
-  /**
-   * Unregister mouse listener.
-   *
-   * @param listener
-   *          the listener
-   */
+  /// Unregister mouse listener.
+  ///
+  /// @param listener
+  /// the listener
   void removeMouseListener(MouseListener listener);
 
-  /**
-   * Register mouse motion listener.
-   *
-   * @param listener
-   *          the listener
-   */
+  /// Register mouse motion listener.
+  ///
+  /// @param listener
+  /// the listener
   void addMouseMotionListener(MouseMotionListener listener);
 
-  /**
-   * Unregister mouse motion listener.
-   *
-   * @param listener
-   *          the listener
-   */
+  /// Unregister mouse motion listener.
+  ///
+  /// @param listener
+  /// the listener
   void removeMouseMotionListener(MouseMotionListener listener);
 
-  /**
-   * Removes all registered event listeners from the Mouse instance. This <b>does not affect</b> registered
-   * {@code MouseListener}, {@code MouseMotionListener} or {@code MouseWheelListener} instances.
-   *
-   * @see #onClicked(MouseClickedListener)
-   * @see #onDragged(MouseDraggedListener)
-   * @see #onMoved(MouseMovedListener)
-   * @see #onPressed(MousePressedListener)
-   * @see #onPressing(MousePressingListener)
-   * @see #onReleased(MouseReleasedListener)
-   */
+  /// Removes all registered event listeners from the Mouse instance. This **does not affect** registered
+  /// `MouseListener`, `MouseMotionListener` or `MouseWheelListener` instances.
+  ///
+  /// @see #onClicked(MouseClickedListener)
+  /// @see #onDragged(MouseDraggedListener)
+  /// @see #onMoved(MouseMovedListener)
+  /// @see #onPressed(MousePressedListener)
+  /// @see #onPressing(MousePressingListener)
+  /// @see #onReleased(MouseReleasedListener)
   void clearExplicitListeners();
 
-  /**
-   * Gets the current location of the mouse within the game window.
-   *
-   * <p>
-   * The coordinates are relative to the game window and don't reflect coordinates on the game world. <br>
-   * Use {@link #getMapLocation()} to get a translated position for the current environment.
-   *
-   * @return The current location of the mouse within the game window.
-   * @see #getMapLocation()
-   */
+  /// Gets the current location of the mouse within the game window.
+  ///
+  /// The coordinates are relative to the game window and don't reflect coordinates on the game world.
+  ///
+  /// Use [#getMapLocation()] to get a translated position for the current environment.
+  ///
+  /// @return The current location of the mouse within the game window.
+  /// @see #getMapLocation()
   Point2D getLocation();
 
-  /**
-   * Gets the location of the mouse on the current map.
-   *
-   * <p>
-   * This translates the current mouse locations to the location on the map by using the current camera. <br>
-   * Use {@link #getLocation()} to get the location within the game window.
-   *
-   * @return The location of the mouse on the current map.
-   * @see IMouse#getLocation()
-   */
+  /// Gets the location of the mouse on the current map.
+  ///
+  /// This translates the current mouse locations to the location on the map by using the current camera.
+  ///
+  /// Use [#getLocation()] to get the location within the game window.
+  ///
+  /// @return The location of the mouse on the current map.
+  /// @see IMouse#getLocation()
   Point2D getMapLocation();
 
-  /**
-   * Gets the coordinates of the tile on the map on which the mouse is currently located at.
-   *
-   * @return The tile on which the mouse is currently located at.
-   */
+  /// Gets the coordinates of the tile on the map on which the mouse is currently located at.
+  ///
+  /// @return The tile on which the mouse is currently located at.
   Point getTile();
 
-  /**
-   * A flag indicating whether the mouse should be grabbed by the game's window.
-   *
-   * @return True if the mouse is locked to the game window; otherwise false.
-   */
+  /// A flag indicating whether the mouse should be grabbed by the game's window.
+  ///
+  /// @return True if the mouse is locked to the game window; otherwise false.
   boolean isGrabMouse();
 
-  /**
-   * A flag indicating whether any mouse button is currently pressed.
-   *
-   * @return True if any mouse button is currently pressed; otherwise false.
-   */
+  /// A flag indicating whether any mouse button is currently pressed.
+  ///
+  /// @return True if any mouse button is currently pressed; otherwise false.
   boolean isPressed();
 
-  /**
-   * A flag indicating whether the left mouse button is currently pressed.
-   *
-   * @return True if the left mouse button is currently pressed; otherwise false.
-   */
+  /// A flag indicating whether the left mouse button is currently pressed.
+  ///
+  /// @return True if the left mouse button is currently pressed; otherwise false.
   boolean isLeftButtonPressed();
 
-  /**
-   * A flag indicating whether the right mouse button is currently pressed.
-   *
-   * @return True if the right mouse button is currently pressed; otherwise false.
-   */
+  /// A flag indicating whether the right mouse button is currently pressed.
+  ///
+  /// @return True if the right mouse button is currently pressed; otherwise false.
   boolean isRightButtonPressed();
 
-  /**
-   * Returns true if the mouse event specifies the left mouse button.
-   *
-   * @param event
-   *          The MouseEvent object
-   * @return true if the left mouse button was active.
-   */
+  /// Returns true if the mouse event specifies the left mouse button.
+  ///
+  /// @param event
+  /// The MouseEvent object
+  /// @return true if the left mouse button was active.
   boolean isLeftButton(MouseEvent event);
 
-  /**
-   * Returns true if the mouse event specifies the right mouse button.
-   *
-   * @param event
-   *          The MouseEvent object
-   * @return true if the right mouse button was active.
-   */
+  /// Returns true if the mouse event specifies the right mouse button.
+  ///
+  /// @param event
+  /// The MouseEvent object
+  /// @return true if the right mouse button was active.
   boolean isRightButton(MouseEvent event);
 
-  /**
-   * If set to true, the mouse will be locked to the render component of the game.
-   *
-   * <p>
-   * If this is set to true, the default cursor cannot be used anymore and instead a virtual cursor should be set.
-   *
-   * @param grab
-   *          True if the mouse should be grabbed to the game's window, otherwise false.
-   * @see MouseCursor#set(java.awt.Image)
-   * @see GameWindow#cursor()
-   * @see Game#window()
-   */
+  /// If set to true, the mouse will be locked to the render component of the game.
+  ///
+  /// If this is set to true, the default cursor cannot be used anymore and instead a virtual cursor should be set.
+  ///
+  /// @param grab
+  /// True if the mouse should be grabbed to the game's window, otherwise false.
+  /// @see MouseCursor#set(java.awt.Image)
+  /// @see GameWindow#cursor()
+  /// @see Game#window()
   void setGrabMouse(boolean grab);
 
-  /**
-   * Sets the current mouse location to the specified location in the game window.
-   *
-   * <p>
-   * <b>The location is not a location on the map but a location relative to the game window.</b>
-   *
-   * @param newLocation
-   *          The location to which the mouse will be moved.
-   * @see #getLocation()
-   */
+  /// Sets the current mouse location to the specified location in the game window.
+  ///
+  /// **The location is not a location on the map but a location relative to the game window.**
+  ///
+  /// @param newLocation
+  /// The location to which the mouse will be moved.
+  /// @see #getLocation()
   void setLocation(Point2D newLocation);
 
-  /**
-   * Sets the current mouse location to the specified location in the game window.
-   *
-   * <p>
-   * <b>The location is not a location on the map but a location relative to the game window.</b>
-   *
-   * @param x
-   *          The x-coordinate to which the mouse will be moved.
-   * @param y
-   *          The y-coordinate to which the mouse will be moved.
-   * @see #getLocation()
-   */
+  /// Sets the current mouse location to the specified location in the game window.
+  ///
+  /// **The location is not a location on the map but a location relative to the game window.**
+  ///
+  /// @param x
+  /// The x-coordinate to which the mouse will be moved.
+  /// @param y
+  /// The y-coordinate to which the mouse will be moved.
+  /// @see #getLocation()
   void setLocation(double x, double y);
 
-  /**
-   * This listener interface receives clicked events for the mouse.
-   *
-   * @see IMouse#onClicked(MouseClickedListener)
-   */
+  /// This listener interface receives clicked events for the mouse.
+  ///
+  /// @see IMouse#onClicked(MouseClickedListener)
   @FunctionalInterface
   interface MouseClickedListener extends EventListener {
-    /**
-     * Invoked when the mouse button has been clicked (pressed and released) on the game window.
-     *
-     * @param event
-     *          The mouse event.
-     */
+    /// Invoked when the mouse button has been clicked (pressed and released) on the game window.
+    ///
+    /// @param event
+    /// The mouse event.
     void mouseClicked(MouseEvent event);
   }
 
-  /**
-   * This listener interface receives dragged events for the mouse.
-   *
-   * @see IMouse#onDragged(MouseDraggedListener)
-   */
+  /// This listener interface receives dragged events for the mouse.
+  ///
+  /// @see IMouse#onDragged(MouseDraggedListener)
   @FunctionalInterface
   interface MouseDraggedListener extends EventListener {
-    /**
-     * Invoked when a mouse button is pressed on the game window and then dragged. {@code
-     * MOUSE_DRAGGED} events will continue to be delivered to the component where the drag originated until the mouse button
-     * is released (regardless of whether the mouse position is within the bounds of the component).
-     *
-     * <p>
-     * Due to platform-dependent Drag&amp;Drop implementations, {@code MOUSE_DRAGGED} events may not be delivered during a
-     * native Drag&amp;Drop operation.
-     *
-     * @param event
-     *          The mouse event.
-     */
+    /// Invoked when a mouse button is pressed on the game window and then dragged. `MOUSE_DRAGGED` events will continue to be delivered to the component where the drag originated until the mouse button
+    /// is released (regardless of whether the mouse position is within the bounds of the component).
+    ///
+    /// Due to platform-dependent Drag&amp;Drop implementations, `MOUSE_DRAGGED` events may not be delivered during a
+    /// native Drag&amp;Drop operation.
+    ///
+    /// @param event
+    /// The mouse event.
     void mouseDragged(MouseEvent event);
   }
 
-  /**
-   * This listener interface receives moved events for the mouse.
-   *
-   * @see IMouse#onMoved(MouseMovedListener)
-   */
+  /// This listener interface receives moved events for the mouse.
+  ///
+  /// @see IMouse#onMoved(MouseMovedListener)
   @FunctionalInterface
   interface MouseMovedListener extends EventListener {
-    /**
-     * Invoked when the mouse cursor has been moved on the game window but no buttons have been pushed.
-     *
-     * @param event
-     *          The mouse event.
-     */
+    /// Invoked when the mouse cursor has been moved on the game window but no buttons have been pushed.
+    ///
+    /// @param event
+    /// The mouse event.
     void mouseMoved(MouseEvent event);
   }
 
-  /**
-   * This listener interface receives pressed events for the mouse.
-   *
-   * @see IMouse#onPressed(MousePressedListener)
-   */
+  /// This listener interface receives pressed events for the mouse.
+  ///
+  /// @see IMouse#onPressed(MousePressedListener)
   @FunctionalInterface
   interface MousePressedListener extends EventListener {
-    /**
-     * Invoked when a mouse button has been pressed on the game window.
-     *
-     * @param event
-     *          The mouse event.
-     */
+    /// Invoked when a mouse button has been pressed on the game window.
+    ///
+    /// @param event
+    /// The mouse event.
     void mousePressed(MouseEvent event);
   }
 
-  /**
-   * This listener interface receives pressing events for the mouse.
-   *
-   * @see IMouse#onPressing(MousePressingListener)
-   */
+  /// This listener interface receives pressing events for the mouse.
+  ///
+  /// @see IMouse#onPressing(MousePressingListener)
   @FunctionalInterface
   interface MousePressingListener extends EventListener {
-    /** Invoked continuously while a mouse button is being pressed on the game window. */
+    /// Invoked continuously while a mouse button is being pressed on the game window.
     void mousePressing();
   }
 
-  /**
-   * This listener interface receives released events for the mouse.
-   *
-   * @see IMouse#onReleased(MouseReleasedListener)
-   */
+  /// This listener interface receives released events for the mouse.
+  ///
+  /// @see IMouse#onReleased(MouseReleasedListener)
   @FunctionalInterface
   interface MouseReleasedListener extends EventListener {
-    /**
-     * Invoked when a mouse button has been released on the game window.
-     *
-     * @param event
-     *          The mouse event.
-     */
+    /// Invoked when a mouse button has been released on the game window.
+    ///
+    /// @param event
+    /// The mouse event.
     void mouseReleased(MouseEvent event);
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Input.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Input.java
@@ -6,15 +6,13 @@ import java.awt.AWTException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The static {@code Input} class is the LITIENGINE's access point to devices that capture physical player input. It
- * manages input from different devices, i.e. keyboard, mouse or gamepad, and provides a unified API to access this
- * information.
- *
- * @see #mouse()
- * @see #keyboard()
- * @see #gamepads()
- */
+/// The static `Input` class is the LITIENGINE's access point to devices that capture physical player input. It
+/// manages input from different devices, i.e. keyboard, mouse or gamepad, and provides a unified API to access this
+/// information.
+///
+/// @see #mouse()
+/// @see #keyboard()
+/// @see #gamepads()
 public final class Input {
   private static final Logger log = Logger.getLogger(Input.class.getName());
 
@@ -26,21 +24,17 @@ public final class Input {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Gets the manager for all gamepad input devices.
-   *
-   * <p>
-   * The manager provides easy access to the default controller as well as access by gamepad index for mulitplayer games.
-   * Gamepads don't need to be added explicitly, the manager supports hot-plugging at runtime and will auto-detect any
-   * added/removed gamepads.
-   *
-   * <p>
-   * <b>This returns null if {@code Game.config().input().isGamepadSupport()} is set to false.</b>
-   *
-   * @return The gamepad manager.
-   * @see GamepadManager#current()
-   * @see GamepadManager#get(int)
-   */
+  /// Gets the manager for all gamepad input devices.
+  ///
+  /// The manager provides easy access to the default controller as well as access by gamepad index for mulitplayer games.
+  /// Gamepads don't need to be added explicitly, the manager supports hot-plugging at runtime and will auto-detect any
+  /// added/removed gamepads.
+  ///
+  /// **This returns null if `Game.config().input().isGamepadSupport()` is set to false.**
+  ///
+  /// @return The gamepad manager.
+  /// @see GamepadManager#current()
+  /// @see GamepadManager#get(int)
   public static GamepadManager gamepads() {
     if (!Game.config().input().isGamepadSupport()) {
       log.log(
@@ -51,20 +45,16 @@ public final class Input {
     return gamePadManager;
   }
 
-  /**
-   * Gets the keyboard input device.
-   *
-   * @return The keyboard input device.
-   */
+  /// Gets the keyboard input device.
+  ///
+  /// @return The keyboard input device.
   public static IKeyboard keyboard() {
     return keyboard;
   }
 
-  /**
-   * Gets the mouse input device.
-   *
-   * @return The mouse input device.
-   */
+  /// Gets the mouse input device.
+  ///
+  /// @return The mouse input device.
   public static IMouse mouse() {
     return mouse;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Keyboard.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Keyboard.java
@@ -197,12 +197,10 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
     this.executeTypedKeys();
   }
 
-  /**
-   * Adds the pressed key.
-   *
-   * @param keyCode
-   *          the key code
-   */
+  /// Adds the pressed key.
+  ///
+  /// @param keyCode
+  /// the key code
   private void addPressedKey(final KeyEvent keyCode) {
     if (this.pressedKeys.stream().anyMatch(key -> key.getKeyCode() == keyCode.getKeyCode())) {
       return;
@@ -211,12 +209,10 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
     this.pressedKeys.add(keyCode);
   }
 
-  /**
-   * Adds the released key.
-   *
-   * @param keyCode
-   *          the key code
-   */
+  /// Adds the released key.
+  ///
+  /// @param keyCode
+  /// the key code
   private void addReleasedKey(final KeyEvent keyCode) {
     if (this.releasedKeys.stream().anyMatch(key -> key.getKeyCode() == keyCode.getKeyCode())) {
       return;
@@ -225,12 +221,10 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
     this.releasedKeys.add(keyCode);
   }
 
-  /**
-   * Adds the typed key.
-   *
-   * @param keyCode
-   *          the key code
-   */
+  /// Adds the typed key.
+  ///
+  /// @param keyCode
+  /// the key code
   private void addTypedKey(final KeyEvent keyCode) {
     if (this.typedKeys.stream().anyMatch(key -> key.getKeyCode() == keyCode.getKeyCode())) {
       return;
@@ -239,7 +233,7 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
     this.typedKeys.add(keyCode);
   }
 
-  /** Execute pressed keys. */
+  /// Execute pressed keys.
   private void executePressedKeys() {
     // called at the rate of the updaterate
     this.pressedKeys.forEach(
@@ -253,7 +247,7 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
         });
   }
 
-  /** Execute released keys. */
+  /// Execute released keys.
   private void executeReleasedKeys() {
     this.releasedKeys.forEach(
         key -> {
@@ -268,7 +262,7 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
     this.releasedKeys.clear();
   }
 
-  /** Execute typed keys. */
+  /// Execute typed keys.
   private void executeTypedKeys() {
     this.typedKeys.forEach(
         key -> {
@@ -283,12 +277,10 @@ public final class Keyboard implements KeyEventDispatcher, IKeyboard, IUpdateabl
     this.typedKeys.clear();
   }
 
-  /**
-   * Removes the pressed key.
-   *
-   * @param keyCode
-   *          the key code
-   */
+  /// Removes the pressed key.
+  ///
+  /// @param keyCode
+  /// the key code
   private void removePressedKey(final KeyEvent keyCode) {
     for (final KeyEvent removeKey : this.pressedKeys) {
       if (removeKey.getKeyCode() == keyCode.getKeyCode()) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/KeyboardEntityController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/KeyboardEntityController.java
@@ -7,35 +7,29 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * A controller that allows an entity to be controlled via keyboard input.
- *
- * @param <T> the type of the mobile entity to be controlled
- */
+/// A controller that allows an entity to be controlled via keyboard input.
+///
+/// @param <T> the type of the mobile entity to be controlled
 public class KeyboardEntityController<T extends IMobileEntity> extends MovementController<T> {
   private final List<Integer> up;
   private final List<Integer> down;
   private final List<Integer> left;
   private final List<Integer> right;
 
-  /**
-   * Constructs a new KeyboardEntityController for the specified entity.
-   *
-   * @param entity the entity to be controlled by the keyboard
-   */
+  /// Constructs a new KeyboardEntityController for the specified entity.
+  ///
+  /// @param entity the entity to be controlled by the keyboard
   public KeyboardEntityController(final T entity) {
     this(entity, KeyEvent.VK_W, KeyEvent.VK_S, KeyEvent.VK_A, KeyEvent.VK_D);
   }
 
-  /**
-   * Constructs a new KeyboardEntityController for the specified entity.
-   *
-   * @param entity the entity to be controlled by the keyboard
-   * @param up     the key code for moving up
-   * @param down   the key code for moving down
-   * @param left   the key code for moving left
-   * @param right  the key code for moving right
-   */
+  /// Constructs a new KeyboardEntityController for the specified entity.
+  ///
+  /// @param entity the entity to be controlled by the keyboard
+  /// @param up     the key code for moving up
+  /// @param down   the key code for moving down
+  /// @param left   the key code for moving left
+  /// @param right  the key code for moving right
   public KeyboardEntityController(
     final T entity, final int up, final int down, final int left, final int right) {
     super(entity);
@@ -51,11 +45,9 @@ public class KeyboardEntityController<T extends IMobileEntity> extends MovementC
     Input.keyboard().onKeyPressed(this::handlePressedKey);
   }
 
-  /**
-   * Handles the key pressed event and updates the entity's movement direction based on the key code.
-   *
-   * @param keyCode the key event containing the key code that was pressed
-   */
+  /// Handles the key pressed event and updates the entity's movement direction based on the key code.
+  ///
+  /// @param keyCode the key event containing the key code that was pressed
   public void handlePressedKey(final KeyEvent keyCode) {
     if (this.up.contains(keyCode.getKeyCode())) {
       this.setDy(this.getDy() - 1);
@@ -68,11 +60,9 @@ public class KeyboardEntityController<T extends IMobileEntity> extends MovementC
     }
   }
 
-  /**
-   * Adds a key code to the list of keys for moving up.
-   *
-   * @param keyCode the key code to add for moving up
-   */
+  /// Adds a key code to the list of keys for moving up.
+  ///
+  /// @param keyCode the key code to add for moving up
   public void addUpKey(int keyCode) {
     if (this.up.contains(keyCode)) {
       return;
@@ -81,11 +71,9 @@ public class KeyboardEntityController<T extends IMobileEntity> extends MovementC
     this.up.add(keyCode);
   }
 
-  /**
-   * Adds a key code to the list of keys for moving down.
-   *
-   * @param keyCode the key code to add for moving down
-   */
+  /// Adds a key code to the list of keys for moving down.
+  ///
+  /// @param keyCode the key code to add for moving down
   public void addDownKey(int keyCode) {
     if (this.down.contains(keyCode)) {
       return;
@@ -94,11 +82,9 @@ public class KeyboardEntityController<T extends IMobileEntity> extends MovementC
     this.down.add(keyCode);
   }
 
-  /**
-   * Adds a key code to the list of keys for moving left.
-   *
-   * @param keyCode the key code to add for moving left
-   */
+  /// Adds a key code to the list of keys for moving left.
+  ///
+  /// @param keyCode the key code to add for moving left
   public void addLeftKey(int keyCode) {
     if (this.left.contains(keyCode)) {
       return;
@@ -107,11 +93,9 @@ public class KeyboardEntityController<T extends IMobileEntity> extends MovementC
     this.left.add(keyCode);
   }
 
-  /**
-   * Adds a key code to the list of keys for moving right.
-   *
-   * @param keyCode the key code to add for moving right
-   */
+  /// Adds a key code to the list of keys for moving right.
+  ///
+  /// @param keyCode the key code to add for moving right
   public void addRightKey(int keyCode) {
     if (this.right.contains(keyCode)) {
       return;
@@ -120,120 +104,94 @@ public class KeyboardEntityController<T extends IMobileEntity> extends MovementC
     this.right.add(keyCode);
   }
 
-  /**
-   * Gets the list of key codes for moving up.
-   *
-   * @return the list of key codes for moving up
-   */
+  /// Gets the list of key codes for moving up.
+  ///
+  /// @return the list of key codes for moving up
   public List<Integer> getUpKeys() {
     return this.up;
   }
 
-  /**
-   * Gets the list of key codes for moving down.
-   *
-   * @return the list of key codes for moving down
-   */
+  /// Gets the list of key codes for moving down.
+  ///
+  /// @return the list of key codes for moving down
   public List<Integer> getDownKeys() {
     return this.down;
   }
 
-  /**
-   * Gets the list of key codes for moving left.
-   *
-   * @return the list of key codes for moving left
-   */
+  /// Gets the list of key codes for moving left.
+  ///
+  /// @return the list of key codes for moving left
   public List<Integer> getLeftKeys() {
     return this.left;
   }
 
-  /**
-   * Gets the list of key codes for moving right.
-   *
-   * @return the list of key codes for moving right
-   */
+  /// Gets the list of key codes for moving right.
+  ///
+  /// @return the list of key codes for moving right
   public List<Integer> getRightKeys() {
     return this.right;
   }
 
-  /**
-   * Sets the key codes for moving up.
-   *
-   * @param up the key codes for moving up
-   */
+  /// Sets the key codes for moving up.
+  ///
+  /// @param up the key codes for moving up
   public void setUpKeys(int... up) {
     this.setUpKeys(ListUtilities.getIntList(up));
   }
 
-  /**
-   * Sets the key codes for moving up.
-   *
-   * @param up the list of key codes for moving up
-   */
+  /// Sets the key codes for moving up.
+  ///
+  /// @param up the list of key codes for moving up
   public void setUpKeys(List<Integer> up) {
     set(this.up, up);
   }
 
-  /**
-   * Sets the key codes for moving down.
-   *
-   * @param down the key codes for moving down
-   */
+  /// Sets the key codes for moving down.
+  ///
+  /// @param down the key codes for moving down
   public void setDownKeys(int... down) {
     this.setDownKeys(ListUtilities.getIntList(down));
   }
 
-  /**
-   * Sets the key codes for moving down.
-   *
-   * @param down the list of key codes for moving down
-   */
+  /// Sets the key codes for moving down.
+  ///
+  /// @param down the list of key codes for moving down
   public void setDownKeys(List<Integer> down) {
     set(this.down, down);
   }
 
-  /**
-   * Sets the key codes for moving left.
-   *
-   * @param left the key codes for moving left
-   */
+  /// Sets the key codes for moving left.
+  ///
+  /// @param left the key codes for moving left
   public void setLeftKeys(int... left) {
     this.setLeftKeys(ListUtilities.getIntList(left));
   }
 
-  /**
-   * Sets the key codes for moving left.
-   *
-   * @param left the list of key codes for moving left
-   */
+  /// Sets the key codes for moving left.
+  ///
+  /// @param left the list of key codes for moving left
   public void setLeftKeys(List<Integer> left) {
     set(this.left, left);
   }
 
-  /**
-   * Sets the key codes for moving right.
-   *
-   * @param right the key codes for moving right
-   */
+  /// Sets the key codes for moving right.
+  ///
+  /// @param right the key codes for moving right
   public void setRightKeys(int... right) {
     this.setRightKeys(ListUtilities.getIntList(right));
   }
 
-  /**
-   * Sets the key codes for moving right.
-   *
-   * @param right the list of key codes for moving right
-   */
+  /// Sets the key codes for moving right.
+  ///
+  /// @param right the list of key codes for moving right
   public void setRightKeys(List<Integer> right) {
     set(this.right, right);
   }
 
-  /**
-   * Sets the key codes for a specified direction.
-   *
-   * @param keyList the list of key codes for the direction
-   * @param keys    the new key codes for the direction
-   */
+  /// Sets the key codes for a specified direction.
+  ///
+  /// @param keyList the list of key codes for the direction
+  /// @param keys    the new key codes for the direction
   private static void set(List<Integer> keyList, List<Integer> keys) {
     keyList.clear();
     keyList.addAll(keys);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Mouse.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/Mouse.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.SwingUtilities;
 
-/** This implementation provides information about the mouse input in the LITIENGINE. */
+/// This implementation provides information about the mouse input in the LITIENGINE.
 public final class Mouse
   implements MouseListener, MouseMotionListener, MouseWheelListener, IMouse, IUpdateable {
   private static final Logger log = Logger.getLogger(Mouse.class.getName());
@@ -56,12 +56,10 @@ public final class Mouse
   private MouseEvent updateLocation;
   private boolean updatingLocation;
 
-  /**
-   * Instantiates a new mouse.
-   *
-   * @throws AWTException
-   *   In case the {@link Robot} class could not be initialized.
-   */
+  /// Instantiates a new mouse.
+  ///
+  /// @throws AWTException
+  /// In case the [Robot] class could not be initialized.
   Mouse() throws AWTException {
     try {
       this.robot = new Robot();
@@ -449,12 +447,10 @@ public final class Mouse
       original.getPreciseWheelRotation());
   }
 
-  /**
-   * Calculates the location of the ingame mouse by the position diff and locks the original mouse to the center of the screen.
-   *
-   * @param e
-   *   The event containing information about the original mouse.
-   */
+  /// Calculates the location of the ingame mouse by the position diff and locks the original mouse to the center of the screen.
+  ///
+  /// @param e
+  /// The event containing information about the original mouse.
   private void setLocation(final MouseEvent e) {
     if (this.grabMouse && !Game.window().isFocusOwner()) {
       return;
@@ -497,12 +493,10 @@ public final class Mouse
     this.location = new Point2D.Double(newX, newY);
   }
 
-  /**
-   * Sets the pressed.
-   *
-   * @param pressed
-   *   the new pressed
-   */
+  /// Sets the pressed.
+  ///
+  /// @param pressed
+  /// the new pressed
   private void setPressed(final boolean pressed) {
     this.pressed = pressed;
   }
@@ -515,11 +509,9 @@ public final class Mouse
     this.updateLocation = mouseEvent;
   }
 
-  /**
-   * Calculates the center screen position where the mouse should be locked when grab mouse is enabled.
-   *
-   * @return The screen coordinates where the mouse should be centered.
-   */
+  /// Calculates the center screen position where the mouse should be locked when grab mouse is enabled.
+  ///
+  /// @return The screen coordinates where the mouse should be centered.
   private Point getGrabPosition() {
     final double screenCenterX = Game.window().getResolution().getWidth() * 0.5;
     final double screenCenterY = Game.window().getResolution().getHeight() * 0.5;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/MousePathController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/MousePathController.java
@@ -4,39 +4,31 @@ import de.gurkenlabs.litiengine.entities.IMobileEntity;
 import de.gurkenlabs.litiengine.entities.behavior.EntityNavigator;
 import de.gurkenlabs.litiengine.physics.MovementController;
 
-/**
- * A controller that allows an entity to be controlled via mouse path input.
- */
+/// A controller that allows an entity to be controlled via mouse path input.
 public class MousePathController extends MovementController<IMobileEntity> {
-  /** Indicates whether the player is navigating. */
+  /// Indicates whether the player is navigating.
   private boolean navigating;
 
-  /** The navigator used to control the entity's movement. */
+  /// The navigator used to control the entity's movement.
   private final EntityNavigator navigator;
 
-  /**
-   * Constructs a new MousePathController for the specified entity and navigator.
-   *
-   * @param navigator the navigator to control the entity's movement
-   * @param entity the entity to be controlled by the mouse path
-   */
+  /// Constructs a new MousePathController for the specified entity and navigator.
+  ///
+  /// @param navigator the navigator to control the entity's movement
+  /// @param entity the entity to be controlled by the mouse path
   public MousePathController(final EntityNavigator navigator, final IMobileEntity entity) {
     super(entity);
     this.navigator = navigator;
   }
 
-  /**
-   * Gets the navigator used to control the entity's movement.
-   *
-   * @return the navigator
-   */
+  /// Gets the navigator used to control the entity's movement.
+  ///
+  /// @return the navigator
   public EntityNavigator getNavigator() {
     return this.navigator;
   }
 
-  /**
-   * Updates the controller, handling the entity's movement based on mouse input.
-   */
+  /// Updates the controller, handling the entity's movement based on mouse input.
   @Override
   public void update() {
     super.update();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/input/PlatformingMovementController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/input/PlatformingMovementController.java
@@ -8,48 +8,38 @@ import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * A movement controller that supports keyboard input for horizontal entity movement.
- *
- * @param <T>
- *          The type of the controlled entity.
- */
+/// A movement controller that supports keyboard input for horizontal entity movement.
+///
+/// @param <T>
+/// The type of the controlled entity.
 public class PlatformingMovementController<T extends IMobileEntity>
     extends KeyboardEntityController<T> {
-  /**
-   * The identifier that is used by this controller to execute the jumping {@code EntityAction} on the related entity.
-   *
-   * <p>
-   * <i>Note that the entity needs to either specify a method with an {@code Action} annotation that corresponds to this
-   * identifier or it needs to explicitly register an {@code
-   * EntityAction}.</i>
-   *
-   * @see IEntity#register(String, Runnable)
-   * @see Action
-   */
+  /// The identifier that is used by this controller to execute the jumping `EntityAction` on the related entity.
+  ///
+  /// *Note that the entity needs to either specify a method with an `Action` annotation that corresponds to this
+  /// identifier or it needs to explicitly register an `EntityAction`.*
+  ///
+  /// @see IEntity#register(String, Runnable)
+  /// @see Action
   public static final String JUMP_ACTION = "jump";
 
-  /** The list of jump keys, represented by their integer values. */
+  /// The list of jump keys, represented by their integer values.
   private final List<Integer> jump;
 
-  /**
-   * Instantiates a new platforming movement controller.
-   *
-   * @param entity
-   *          the entity
-   */
+  /// Instantiates a new platforming movement controller.
+  ///
+  /// @param entity
+  /// the entity
   public PlatformingMovementController(final T entity) {
     this(entity, KeyEvent.VK_SPACE);
   }
 
-  /**
-   * Instantiates a new platforming movement controller.
-   *
-   * @param entity
-   *          the entity
-   * @param jump
-   *          the jump
-   */
+  /// Instantiates a new platforming movement controller.
+  ///
+  /// @param entity
+  /// the entity
+  /// @param jump
+  /// the jump
   public PlatformingMovementController(T entity, final int jump) {
     super(entity);
     this.getUpKeys().clear();
@@ -67,12 +57,10 @@ public class PlatformingMovementController<T extends IMobileEntity>
     }
   }
 
-  /**
-   * Adds a jump key.
-   *
-   * @param keyCode
-   *          the key code for the newly added jump key
-   */
+  /// Adds a jump key.
+  ///
+  /// @param keyCode
+  /// the key code for the newly added jump key
   public void addJumpKey(int keyCode) {
     if (this.jump.contains(keyCode)) {
       return;
@@ -81,21 +69,17 @@ public class PlatformingMovementController<T extends IMobileEntity>
     this.jump.add(keyCode);
   }
 
-  /**
-   * Gets the list of jump key codes in this controller.
-   *
-   * @return the jump keys
-   */
+  /// Gets the list of jump key codes in this controller.
+  ///
+  /// @return the jump keys
   public List<Integer> getJumpKeys() {
     return this.jump;
   }
 
-  /**
-   * Initializes the jump keys with a given array of key codes.
-   *
-   * @param jump
-   *          the new jump keys
-   */
+  /// Initializes the jump keys with a given array of key codes.
+  ///
+  /// @param jump
+  /// the new jump keys
   public void setJumpKeys(int... jump) {
     this.setUpKeys(ListUtilities.getIntList(jump));
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/launch/GameLauncher.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/launch/GameLauncher.java
@@ -18,7 +18,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-/** Standalone launcher to bootstrap and run LITIengine games and script-based projects without custom Java entry points. */
+/// Standalone launcher to bootstrap and run LITIengine games and script-based projects without custom Java entry points.
 public final class GameLauncher {
   private static final Logger log = Logger.getLogger(GameLauncher.class.getName());
   private static final java.util.regex.Pattern PACKAGE_DECLARATION = java.util.regex.Pattern.compile(
@@ -189,15 +189,12 @@ public final class GameLauncher {
     }
   }
 
-  /**
-   * Strips comments from Java source while preserving string and character literal contents.
-   * Uses a simple lexical state machine rather than regexes so that:
-   * <ul>
-   *   <li>Multi-line block comments ({@code /* ... * /}) are removed even across newlines</li>
-   *   <li>Comment-like sequences inside string literals ({@code "https://..."}) are preserved</li>
-   *   <li>Character literals ({@code '/'}) do not trigger comment detection</li>
-   * </ul>
-   */
+  /// Strips comments from Java source while preserving string and character literal contents.
+  /// Uses a simple lexical state machine rather than regexes so that:
+  ///
+  /// - Multi-line block comments (`/* ... * /`) are removed even across newlines
+  /// - Comment-like sequences inside string literals (`"https://..."`) are preserved
+  /// - Character literals (`'/'`) do not trigger comment detection
   static String stripComments(String content) {
     StringBuilder out = new StringBuilder(content.length());
     int i = 0;
@@ -267,25 +264,21 @@ public final class GameLauncher {
       host.find() ? ScriptHostType.valueOf(host.group(1)) : ScriptHostType.ENTITY, targetType));
   }
 
-  /**
-   * Resolves a simple type name from {@code @ScriptInfo(target = Foo.class)} to a fully qualified
-   * class name using only source-level heuristics.
-   *
-   * <p>Supported resolution paths:
-   * <ul>
-   *   <li>Fully qualified names ({@code com.example.Player.class}) — returned as-is</li>
-   *   <li>Explicit single-type imports ({@code import com.example.Player;})</li>
-   *   <li>Engine entity types ({@code Prop}, {@code Creature}, etc. from {@code de.gurkenlabs.litiengine.entities})</li>
-   *   <li>Same-package types (inferred from the source file's {@code package} declaration)</li>
-   * </ul>
-   *
-   * <p><strong>Not supported</strong> (use a fully qualified name instead):
-   * <ul>
-   *   <li>Wildcard imports ({@code import foo.bar.*;})</li>
-   *   <li>Nested/inner types ({@code Types.Player.class})</li>
-   *   <li>Static imports</li>
-   * </ul>
-   */
+  /// Resolves a simple type name from `@ScriptInfo(target = Foo.class)` to a fully qualified
+  /// class name using only source-level heuristics.
+  ///
+  /// Supported resolution paths:
+  ///
+  /// - Fully qualified names (`com.example.Player.class`) — returned as-is
+  /// - Explicit single-type imports (`import com.example.Player;`)
+  /// - Engine entity types (`Prop`, `Creature`, etc. from `de.gurkenlabs.litiengine.entities`)
+  /// - Same-package types (inferred from the source file's `package` declaration)
+  ///
+  /// **Not supported** (use a fully qualified name instead):
+  ///
+  /// - Wildcard imports (`import foo.bar.*;`)
+  /// - Nested/inner types (`Types.Player.class`)
+  /// - Static imports
   private static String resolveTypeName(String content, String typeName) {
     if ("Object".equals(typeName) || "java.lang.Object".equals(typeName)) return null;
     if (typeName.contains(".")) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/Collision.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/Collision.java
@@ -1,26 +1,16 @@
 package de.gurkenlabs.litiengine.physics;
 
-/**
- * Enum representing different types of collision behaviors.
- */
+/// Enum representing different types of collision behaviors.
 public enum Collision {
-  /**
-   * No collision behavior.
-   */
+  /// No collision behavior.
   NONE,
 
-  /**
-   * Dynamic collision behavior, typically for moving objects.
-   */
+  /// Dynamic collision behavior, typically for moving objects.
   DYNAMIC,
 
-  /**
-   * Static collision behavior, typically for immovable objects.
-   */
+  /// Static collision behavior, typically for immovable objects.
   STATIC,
 
-  /**
-   * Any type of collision behavior.
-   */
+  /// Any type of collision behavior.
   ANY
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/CollisionEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/CollisionEvent.java
@@ -7,30 +7,24 @@ import java.util.Collections;
 import java.util.EventObject;
 import java.util.List;
 
-/**
- * This event is fired when a collision occurs between entities.
- */
+/// This event is fired when a collision occurs between entities.
 public class CollisionEvent extends EventObject {
   @Serial private static final long serialVersionUID = 1916709290207855154L;
 
   private final transient List<ICollisionEntity> involved;
 
-  /**
-   * Constructs a new CollisionEvent.
-   *
-   * @param source   the source entity of the collision
-   * @param involved the entities involved in the collision
-   */
+  /// Constructs a new CollisionEvent.
+  ///
+  /// @param source   the source entity of the collision
+  /// @param involved the entities involved in the collision
   public CollisionEvent(ICollisionEntity source, ICollisionEntity... involved) {
     super(source);
     this.involved = Collections.unmodifiableList(Arrays.asList(involved));
   }
 
-  /**
-   * Gets the list of entities involved in the collision.
-   *
-   * @return an unmodifiable list of involved entities
-   */
+  /// Gets the list of entities involved in the collision.
+  ///
+  /// @return an unmodifiable list of involved entities
   public List<ICollisionEntity> getInvolvedEntities() {
     return this.involved;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/Force.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/Force.java
@@ -4,9 +4,7 @@ import de.gurkenlabs.litiengine.entities.ICollisionEntity;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 
-/**
- * Represents a force in the physics engine. A force has a location, strength, size, and various properties that determine its behavior.
- */
+/// Represents a force in the physics engine. A force has a location, strength, size, and various properties that determine its behavior.
 public class Force {
   private boolean cancelOnCollision;
   private boolean cancelOnReached;
@@ -16,13 +14,11 @@ public class Force {
   private float strength;
   private String identifier;
 
-  /**
-   * Instantiates a new force.
-   *
-   * @param location The location where the force is originating from
-   * @param strength The strength/intensity of this force instance
-   * @param size     The size of this force (used to determine if/when an entity has reached the force)
-   */
+  /// Instantiates a new force.
+  ///
+  /// @param location The location where the force is originating from
+  /// @param strength The strength/intensity of this force instance
+  /// @param size     The size of this force (used to determine if/when an entity has reached the force)
   public Force(final Point2D location, final float strength, final float size) {
     this.location = location;
     this.strength = strength;
@@ -31,73 +27,57 @@ public class Force {
     this.cancelOnReached = true;
   }
 
-  /**
-   * Checks if the force should be canceled on collision.
-   *
-   * @return true if the force should be canceled on collision, false otherwise
-   */
+  /// Checks if the force should be canceled on collision.
+  ///
+  /// @return true if the force should be canceled on collision, false otherwise
   public boolean cancelOnCollision() {
     return cancelOnCollision;
   }
 
-  /**
-   * Checks if the force should be canceled when the target is reached.
-   *
-   * @return true if the force should be canceled when the target is reached, false otherwise
-   */
+  /// Checks if the force should be canceled when the target is reached.
+  ///
+  /// @return true if the force should be canceled when the target is reached, false otherwise
   public boolean cancelOnReached() {
     return cancelOnReached;
   }
 
-  /**
-   * Ends the force, marking it as ended.
-   */
+  /// Ends the force, marking it as ended.
   public void end() {
     this.hasEnded = true;
   }
 
-  /**
-   * Gets the location.
-   *
-   * @return the location
-   */
+  /// Gets the location.
+  ///
+  /// @return the location
   public Point2D getLocation() {
     return this.location;
   }
 
-  /**
-   * Gets the strength in pixels per second.
-   *
-   * @return the strength in pixels per seconds
-   */
+  /// Gets the strength in pixels per second.
+  ///
+  /// @return the strength in pixels per seconds
   public float getStrength() {
     return this.strength;
   }
 
-  /**
-   * Gets the identifier for the force.
-   *
-   * @return the identifier of the force
-   */
+  /// Gets the identifier for the force.
+  ///
+  /// @return the identifier of the force
   public String getIdentifier() {
     return this.identifier;
   }
 
-  /**
-   * Checks if the force has ended.
-   *
-   * @return true if the force has ended, false otherwise
-   */
+  /// Checks if the force has ended.
+  ///
+  /// @return true if the force has ended, false otherwise
   public boolean hasEnded() {
     return this.hasEnded;
   }
 
-  /**
-   * Checks if the force has reached the specified entity.
-   *
-   * @param entity the entity to check against
-   * @return true if the force has reached the entity, false otherwise
-   */
+  /// Checks if the force has reached the specified entity.
+  ///
+  /// @param entity the entity to check against
+  /// @return true if the force has reached the entity, false otherwise
   public boolean hasReached(final ICollisionEntity entity) {
     return new Ellipse2D.Double(
       this.getLocation().getX() - this.size * 0.5,
@@ -107,57 +87,45 @@ public class Force {
       .intersects(entity.getCollisionBox());
   }
 
-  /**
-   * Sets whether the force should be canceled on collision.
-   *
-   * @param cancelOnCollision true if the force should be canceled on collision, false otherwise
-   */
+  /// Sets whether the force should be canceled on collision.
+  ///
+  /// @param cancelOnCollision true if the force should be canceled on collision, false otherwise
   public void setCancelOnCollision(final boolean cancelOnCollision) {
     this.cancelOnCollision = cancelOnCollision;
   }
 
-  /**
-   * Sets whether the force should be canceled when the target is reached.
-   *
-   * @param cancelOnReached true if the force should be canceled when the target is reached, false otherwise
-   */
+  /// Sets whether the force should be canceled when the target is reached.
+  ///
+  /// @param cancelOnReached true if the force should be canceled when the target is reached, false otherwise
   public void setCancelOnReached(final boolean cancelOnReached) {
     this.cancelOnReached = cancelOnReached;
   }
 
-  /**
-   * Sets the location of the force.
-   *
-   * @param location the new location of the force
-   */
+  /// Sets the location of the force.
+  ///
+  /// @param location the new location of the force
   public void setLocation(final Point2D location) {
     this.location = location;
   }
 
-  /**
-   * Sets the strength of the force in pixels per second.
-   *
-   * @param strength the new strength of the force
-   */
+  /// Sets the strength of the force in pixels per second.
+  ///
+  /// @param strength the new strength of the force
   public void setStrength(float strength) {
     this.strength = strength;
   }
 
-  /**
-   * Sets the identifier for the force.
-   *
-   * @param identifier the new identifier for the force
-   */
+  /// Sets the identifier for the force.
+  ///
+  /// @param identifier the new identifier for the force
   public void setIdentifier(String identifier) {
     this.identifier = identifier;
   }
 
-  /**
-   * Returns a string representation of the Force object. The string includes the identifier (if available), strength in pixels per second, and
-   * location.
-   *
-   * @return a string representation of the Force object
-   */
+  /// Returns a string representation of the Force object. The string includes the identifier (if available), strength in pixels per second, and
+  /// location.
+  ///
+  /// @return a string representation of the Force object
   @Override
   public String toString() {
     return (this.identifier != null && !this.identifier.isEmpty() ? this.identifier : "Force")

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/GravityForce.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/GravityForce.java
@@ -5,39 +5,29 @@ import de.gurkenlabs.litiengine.entities.IEntity;
 import de.gurkenlabs.litiengine.util.geom.GeometricUtilities;
 import java.awt.geom.Point2D;
 
-/**
- * GravityForce is a gravitational force pulling entities towards a given direction or angle.
- */
+/// GravityForce is a gravitational force pulling entities towards a given direction or angle.
 public class GravityForce extends Force {
 
-  /**
-   * The angle at which the gravitational force is applied.
-   */
+  /// The angle at which the gravitational force is applied.
   private final float directionAngle;
 
-  /**
-   * The entity on which the gravitational force is acting.
-   */
+  /// The entity on which the gravitational force is acting.
   private final IEntity forceEntity;
 
-  /**
-   * Instantiates a new GravityForce.
-   *
-   * @param forceEntity The entity on which the gravitational force is applied.
-   * @param strength    The strength of the gravitational force.
-   * @param direction   The direction of the gravitational force.
-   */
+  /// Instantiates a new GravityForce.
+  ///
+  /// @param forceEntity The entity on which the gravitational force is applied.
+  /// @param strength    The strength of the gravitational force.
+  /// @param direction   The direction of the gravitational force.
   public GravityForce(final IEntity forceEntity, final float strength, final Direction direction) {
     this(forceEntity, strength, direction.toAngle());
   }
 
-  /**
-   * Instantiates a new GravityForce.
-   *
-   * @param forceEntity The entity on which the gravitational force is applied.
-   * @param strength    The strength of the gravitational force.
-   * @param angle       The angle at which the gravitational force is applied.
-   */
+  /// Instantiates a new GravityForce.
+  ///
+  /// @param forceEntity The entity on which the gravitational force is applied.
+  /// @param strength    The strength of the gravitational force.
+  /// @param angle       The angle at which the gravitational force is applied.
   public GravityForce(final IEntity forceEntity, final float strength, final float angle) {
     super(forceEntity.getCenter(), strength, 0);
     this.forceEntity = forceEntity;
@@ -46,22 +36,18 @@ public class GravityForce extends Force {
     setCancelOnReached(false);
   }
 
-  /**
-   * Gets the entity on which the gravitational force is applied.
-   *
-   * @return The force entity.
-   */
+  /// Gets the entity on which the gravitational force is applied.
+  ///
+  /// @return The force entity.
   public IEntity getForceEntity() {
     return this.forceEntity;
   }
 
-  /**
-   * Calculates and returns the location where the gravitational force is applied. This location is
-   * calculated by projecting the force onto a point based on the entity's center, angle, and
-   * strength.
-   *
-   * @return The location where the gravitational force is applied.
-   */
+  /// Calculates and returns the location where the gravitational force is applied. This location is
+  /// calculated by projecting the force onto a point based on the entity's center, angle, and
+  /// strength.
+  ///
+  /// @return The location where the gravitational force is applied.
   @Override
   public Point2D getLocation() {
     return GeometricUtilities.project(

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/IMovementController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/IMovementController.java
@@ -5,89 +5,67 @@ import de.gurkenlabs.litiengine.entities.IMobileEntity;
 import java.util.List;
 import java.util.function.Predicate;
 
-/** The Interface IMovementController is used for moving entities by applying forces to them. */
+/// The Interface IMovementController is used for moving entities by applying forces to them.
 public interface IMovementController extends IEntityController {
 
-  /**
-   * Gets the delta x for each horizontal movement.
-   *
-   * @return the dx
-   */
+  /// Gets the delta x for each horizontal movement.
+  ///
+  /// @return the dx
   float getDx();
 
-  /**
-   * Gets the delta x for each horizontal movement.
-   *
-   * @param dx
-   *          the new dx
-   */
+  /// Gets the delta x for each horizontal movement.
+  ///
+  /// @param dx
+  /// the new dx
   void setDx(float dx);
 
-  /**
-   * Sets the delta y for each vertical movement.
-   *
-   * @return the dy
-   */
+  /// Sets the delta y for each vertical movement.
+  ///
+  /// @return the dy
   float getDy();
 
-  /**
-   * Sets the delta y for each vertical movement.
-   *
-   * @param dy
-   *          the new dy
-   */
+  /// Sets the delta y for each vertical movement.
+  ///
+  /// @param dy
+  /// the new dy
   void setDy(float dy);
 
-  /**
-   * Get the current velocity.
-   *
-   * @return The current velocity.
-   */
+  /// Get the current velocity.
+  ///
+  /// @return The current velocity.
   double getVelocity();
 
-  /**
-   * Sets the current velocity.
-   *
-   * @param velocity
-   *          The velocity to set.
-   */
+  /// Sets the current velocity.
+  ///
+  /// @param velocity
+  /// The velocity to set.
   void setVelocity(double velocity);
 
-  /**
-   * Apply the force to the entity.
-   *
-   * @param force
-   *          the force being applied to the entity
-   */
+  /// Apply the force to the entity.
+  ///
+  /// @param force
+  /// the force being applied to the entity
   void apply(Force force);
 
-  /**
-   * Gets the active forces.
-   *
-   * @return the active forces
-   */
+  /// Gets the active forces.
+  ///
+  /// @return the active forces
   List<Force> getActiveForces();
 
-  /**
-   * Gets the force with the specified identifier.
-   *
-   * @param identifier the identifier of the force to retrieve
-   * @return the force with the specified identifier
-   */
+  /// Gets the force with the specified identifier.
+  ///
+  /// @param identifier the identifier of the force to retrieve
+  /// @return the force with the specified identifier
   Force getForce(String identifier);
 
-  /**
-   * Gets the angle of movement.
-   *
-   * @return the angle of movement
-   */
+  /// Gets the angle of movement.
+  ///
+  /// @return the angle of movement
   double getMoveAngle();
 
-  /**
-   * Checks given conditions before moving.
-   *
-   * @param predicate
-   *          the conditions that need to apply before moving. If they don't apply, the entity won't be moved.
-   */
+  /// Checks given conditions before moving.
+  ///
+  /// @param predicate
+  /// the conditions that need to apply before moving. If they don't apply, the entity won't be moved.
   void onMovementCheck(Predicate<IMobileEntity> predicate);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/MovementController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/MovementController.java
@@ -87,10 +87,8 @@ public class MovementController<T extends IMobileEntity> implements IMovementCon
     handleMovement();
   }
 
-  /**
-   * Handles the movement of the entity. This method calculates the new velocity and direction of the entity based on the current forces and movement
-   * predicates. It also updates the entity's position accordingly.
-   */
+  /// Handles the movement of the entity. This method calculates the new velocity and direction of the entity based on the current forces and movement
+  /// predicates. It also updates the entity's position accordingly.
   public void handleMovement() {
     if (!isMovementAllowed()) {
       this.velocity = 0;
@@ -161,11 +159,9 @@ public class MovementController<T extends IMobileEntity> implements IMovementCon
     Game.physics().move(getEntity(), this.moveAngle, getVelocity());
   }
 
-  /**
-   * Checks if the movement is allowed based on the movement predicates.
-   *
-   * @return true if all movement predicates allow movement, false otherwise
-   */
+  /// Checks if the movement is allowed based on the movement predicates.
+  ///
+  /// @return true if all movement predicates allow movement, false otherwise
   protected boolean isMovementAllowed() {
     return movementPredicates.stream().allMatch(p -> p.test(getEntity()));
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/PhysicsEngine.java
@@ -21,15 +21,13 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-/**
- * This class is used to hold all collision aware instances and static collision boxes. It is
- * responsible for resolving movement that respects the collision boxes in the game. This is
- * achieved by the <b>{@code move}</b> method group.
- * <br>
- * The <b>{@code collides}</b> method group can detect a collision at a certain location, for
- * rectangles, or collision aware entities. Also, there's an overload that takes a {@code Line2D} to
- * perform a basic raycast check.
- */
+/// This class is used to hold all collision aware instances and static collision boxes. It is
+/// responsible for resolving movement that respects the collision boxes in the game. This is
+/// achieved by the **`move`** method group.
+///
+/// The **`collides`** method group can detect a collision at a certain location, for
+/// rectangles, or collision aware entities. Also, there's an overload that takes a `Line2D` to
+/// perform a basic raycast check.
 public final class PhysicsEngine implements IUpdateable {
 
   private Rectangle2D environmentBounds;
@@ -38,11 +36,9 @@ public final class PhysicsEngine implements IUpdateable {
   private final Map<Collision, List<ICollisionEntity>> collisionEntities = new ConcurrentHashMap<>();
   private final Map<Collision, List<Rectangle2D>> collisionBoxes = new ConcurrentHashMap<>();
 
-  /**
-   * <b>You should never call this manually! Instead use the {@code Game.physics()} instance.</b>
-   *
-   * @see Game#physics()
-   */
+  /// **You should never call this manually! Instead use the `Game.physics()` instance.**
+  ///
+  /// @see Game#physics()
   public PhysicsEngine() {
     if (Game.physics() != null) {
       throw new UnsupportedOperationException(
@@ -56,18 +52,15 @@ public final class PhysicsEngine implements IUpdateable {
     collisionBoxes.put(Collision.STATIC, new CopyOnWriteArrayList<>());
   }
 
-  /**
-   * Adds the specified collision aware entity to the physics engine which will make it respect the
-   * entity's collision box for upcoming calls.
-   *
-   * <p>
-   * <i>If you add a {@code ICollisionEntiy} to your Environment, it will automatically be added to
-   * the PhysicsEngine. There is typically no need to call this explicitly.</i>
-   *
-   * @param entity The collision entity to be added.
-   * @see ICollisionEntity#getCollisionBox()
-   * @see PhysicsEngine#remove(ICollisionEntity)
-   */
+  /// Adds the specified collision aware entity to the physics engine which will make it respect the
+  /// entity's collision box for upcoming calls.
+  ///
+  /// *If you add a `ICollisionEntiy` to your Environment, it will automatically be added to
+  /// the PhysicsEngine. There is typically no need to call this explicitly.*
+  ///
+  /// @param entity The collision entity to be added.
+  /// @see ICollisionEntity#getCollisionBox()
+  /// @see PhysicsEngine#remove(ICollisionEntity)
   public void add(final ICollisionEntity entity) {
     if (entity.getCollisionType() == null) {
       return;
@@ -75,12 +68,10 @@ public final class PhysicsEngine implements IUpdateable {
     collisionEntities.get(entity.getCollisionType()).add(entity);
   }
 
-  /**
-   * Removes the specified entity from any collision processing. Typically this method is implicitly
-   * called when an entity is removed from the current environment.
-   *
-   * @param entity The entity that is about to be removed.
-   */
+  /// Removes the specified entity from any collision processing. Typically this method is implicitly
+  /// called when an entity is removed from the current environment.
+  ///
+  /// @param entity The entity that is about to be removed.
   public void remove(final ICollisionEntity entity) {
     if (entity.getCollisionType() == null || !collisionEntities.containsKey(entity.getCollisionType())) {
       return;
@@ -89,10 +80,8 @@ public final class PhysicsEngine implements IUpdateable {
     collisionEntities.get(entity.getCollisionType()).remove(entity);
   }
 
-  /**
-   * Clears all previously registered participants in the collision process from this instance. This
-   * includes all entities, static collision boxes and the map boundaries.
-   */
+  /// Clears all previously registered participants in the collision process from this instance. This
+  /// includes all entities, static collision boxes and the map boundaries.
   public void clear() {
     for (Collision type : Collision.values()) {
       if (type == Collision.NONE || type == Collision.ANY) {
@@ -104,24 +93,20 @@ public final class PhysicsEngine implements IUpdateable {
     setBounds(null);
   }
 
-  /**
-   * Gets all {@code CollisionBoxes}, regardless of their {@code Collision} type.
-   *
-   * @return A {@code Collection} of all {@code CollisionBox}es registered on the
-   * {@code PhysicsEngine}.
-   */
+  /// Gets all `CollisionBoxes`, regardless of their `Collision` type.
+  ///
+  /// @return A `Collection` of all `CollisionBox`es registered on the
+  /// `PhysicsEngine`.
   public Collection<Rectangle2D> getCollisionBoxes() {
     return getCollisionBoxes(Collision.ANY);
   }
 
-  /**
-   * Gets all {@code CollisionBoxes} with the given {@code Collision} type.
-   *
-   * @param type The {@code Collision} type by which the {@code CollisionBoxes} are selected.
-   * @return If the {@code Collision} type is {@code NONE}, return an empty set. Otherwise, a
-   * {@code Collection} of all {@code CollisionBoxes} registered on the {@code PhysicsEngine} that
-   * have the given {@code Collision} type.
-   */
+  /// Gets all `CollisionBoxes` with the given `Collision` type.
+  ///
+  /// @param type The `Collision` type by which the `CollisionBoxes` are selected.
+  /// @return If the `Collision` type is `NONE`, return an empty set. Otherwise, a
+  /// `Collection` of all `CollisionBoxes` registered on the `PhysicsEngine` that
+  /// have the given `Collision` type.
   public Collection<Rectangle2D> getCollisionBoxes(Collision type) {
     switch (type) {
       case NONE -> {
@@ -138,24 +123,20 @@ public final class PhysicsEngine implements IUpdateable {
     }
   }
 
-  /**
-   * Gets all {@code ICollisionEntities}, regardless of their {@code Collision} type.
-   *
-   * @return A {@code Collection} of all {@code ICollisionEntities} registered on the
-   * {@code PhysicsEngine}.
-   */
+  /// Gets all `ICollisionEntities`, regardless of their `Collision` type.
+  ///
+  /// @return A `Collection` of all `ICollisionEntities` registered on the
+  /// `PhysicsEngine`.
   public Collection<ICollisionEntity> getCollisionEntities() {
     return getCollisionEntities(Collision.ANY);
   }
 
-  /**
-   * Gets all {@code ICollisionEntities} with the given {@code Collision} type.
-   *
-   * @param type The {@code Collision} type by which the {@code ICollisionEntities} are selected.
-   * @return If the {@code Collision} type is {@code NONE}, return an empty set. Otherwise, a
-   * {@code Collection} of all {@code ICollisionEntities} registered on the {@code PhysicsEngine}
-   * that have the given {@code Collision} type.
-   */
+  /// Gets all `ICollisionEntities` with the given `Collision` type.
+  ///
+  /// @param type The `Collision` type by which the `ICollisionEntities` are selected.
+  /// @return If the `Collision` type is `NONE`, return an empty set. Otherwise, a
+  /// `Collection` of all `ICollisionEntities` registered on the `PhysicsEngine`
+  /// that have the given `Collision` type.
   public Collection<ICollisionEntity> getCollisionEntities(Collision type) {
     switch (type) {
       case NONE -> {
@@ -172,75 +153,63 @@ public final class PhysicsEngine implements IUpdateable {
     }
   }
 
-  /**
-   * Gets the environment bounds that confine the operation area of the {@code PhysicsEngine}.
-   *
-   * @return The {@code Rectangle2D} confining the operation area of the {@code PhysicsEngine}.
-   */
+  /// Gets the environment bounds that confine the operation area of the `PhysicsEngine`.
+  ///
+  /// @return The `Rectangle2D` confining the operation area of the `PhysicsEngine`.
   public Rectangle2D getBounds() {
     return this.environmentBounds;
   }
 
-  /**
-   * Sets the environment bounds that confine the operation area of the {@code PhysicsEngine}.
-   *
-   * @param environmentBounds The {@code Rectangle2D} confining the operation area of the
-   *                          {@code PhysicsEngine}.
-   */
+  /// Sets the environment bounds that confine the operation area of the `PhysicsEngine`.
+  ///
+  /// @param environmentBounds The `Rectangle2D` confining the operation area of the
+  /// `PhysicsEngine`.
   public void setBounds(final Rectangle2D environmentBounds) {
     this.environmentBounds = environmentBounds;
   }
 
-  /**
-   * Checks if a given line collides with anything registered in the {@code PhysicsEngine}.
-   *
-   * @param line The {@code Line2D} to check for collision.
-   * @return {@code true} if the line collides with anything. {@code false} otherwise.
-   */
+  /// Checks if a given line collides with anything registered in the `PhysicsEngine`.
+  ///
+  /// @param line The `Line2D` to check for collision.
+  /// @return `true` if the line collides with anything. `false` otherwise.
   public boolean collides(Line2D line) {
     return this.collides(line, Collision.ANY, null);
   }
 
-  /**
-   * Checks if a line collides with anything of the given {@code Collision} type.
-   *
-   * @param line      The {@code Line2D} to check for collision.
-   * @param collision The {@code Collision} type to check for collisions.
-   * @return {@code true} if the line collides with anything of the given {@code Collision} type.
-   * {@code false} otherwise.
-   * @see Collision
-   */
+  /// Checks if a line collides with anything of the given `Collision` type.
+  ///
+  /// @param line      The `Line2D` to check for collision.
+  /// @param collision The `Collision` type to check for collisions.
+  /// @return `true` if the line collides with anything of the given `Collision` type.
+  /// `false` otherwise.
+  /// @see Collision
   public boolean collides(Line2D line, Collision collision) {
     return this.collides(line, collision, null);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with anything that intersects a specific
-   * line.
-   *
-   * @param line   The {@code Line2D} to check for collision.
-   * @param entity The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if any {@code ICollisionEntity} intersecting the line collides with the
-   * given {@code ICollisionEntity}. {@code false} otherwise.
-   * @see Collision
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with anything that intersects a specific
+  /// line.
+  ///
+  /// @param line   The `Line2D` to check for collision.
+  /// @param entity The `ICollisionEntity` to check for collision.
+  /// @return `true` if any `ICollisionEntity` intersecting the line collides with the
+  /// given `ICollisionEntity`. `false` otherwise.
+  /// @see Collision
+  /// @see ICollisionEntity
   public boolean collides(Line2D line, ICollisionEntity entity) {
     return this.collides(line, Collision.ANY, entity);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with any {@code ICollisionEntities} of a
-   * given {@code Collision} type that intersect a specific line.
-   *
-   * @param line      The {@code Line2D} to check for collision.
-   * @param collision The {@code Collision} type to check for collision.
-   * @param entity    The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any {@code ICollisionEntity} on the given
-   * line. {@code false} otherwise.
-   * @see Collision
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with any `ICollisionEntities` of a
+  /// given `Collision` type that intersect a specific line.
+  ///
+  /// @param line      The `Line2D` to check for collision.
+  /// @param collision The `Collision` type to check for collision.
+  /// @param entity    The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any `ICollisionEntity` on the given
+  /// line. `false` otherwise.
+  /// @see Collision
+  /// @see ICollisionEntity
   public boolean collides(final Line2D line, Collision collision, ICollisionEntity entity) {
     return this.collides(
       entity,
@@ -248,55 +217,47 @@ public final class PhysicsEngine implements IUpdateable {
       e -> GeometricUtilities.getIntersectionPoint(line, e.getCollisionBox()) != null);
   }
 
-  /**
-   * Checks if a given rectangle collides with anything registered in the {@code PhysicsEngine}.
-   *
-   * @param rect The {@code Rectangle2D} to check for collision.
-   * @return {@code true} if the rectangle collides with anything. {@code false} otherwise.
-   */
+  /// Checks if a given rectangle collides with anything registered in the `PhysicsEngine`.
+  ///
+  /// @param rect The `Rectangle2D` to check for collision.
+  /// @return `true` if the rectangle collides with anything. `false` otherwise.
   public boolean collides(final Rectangle2D rect) {
     return this.collides(rect, Collision.ANY);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with anything that intersects a specific
-   * rectangle.
-   *
-   * @param rect   The {@code Rectangle2D} to check for collision.
-   * @param entity The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any {@code ICollisionEntity} in the given
-   * rectangle. {@code false} otherwise.
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with anything that intersects a specific
+  /// rectangle.
+  ///
+  /// @param rect   The `Rectangle2D` to check for collision.
+  /// @param entity The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any `ICollisionEntity` in the given
+  /// rectangle. `false` otherwise.
+  /// @see ICollisionEntity
   public boolean collides(Rectangle2D rect, ICollisionEntity entity) {
     return this.collides(rect, Collision.ANY, entity);
   }
 
-  /**
-   * Checks if a rectangle collides with anything of the given {@code Collision} type.
-   *
-   * @param rect      The {@code Rectangle2D} to check for collision.
-   * @param collision The {@code Collision} type to check for collisions.
-   * @return {@code true} if the rectangle collides with anything of the given {@code Collision}
-   * type. {@code false} otherwise.
-   * @see Collision
-   */
+  /// Checks if a rectangle collides with anything of the given `Collision` type.
+  ///
+  /// @param rect      The `Rectangle2D` to check for collision.
+  /// @param collision The `Collision` type to check for collisions.
+  /// @return `true` if the rectangle collides with anything of the given `Collision`
+  /// type. `false` otherwise.
+  /// @see Collision
   public boolean collides(Rectangle2D rect, Collision collision) {
     return collides(rect, collision, null);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with any {@code ICollisionEntities} of a
-   * given {@code Collision} type that intersect a specific rectangle.
-   *
-   * @param rect      The {@code Rectangle2D} to check for collision.
-   * @param collision The {@code Collision} type to check for collision.
-   * @param entity    The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any {@code ICollisionEntity} in the given
-   * rectangle. {@code false} otherwise.
-   * @see Collision
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with any `ICollisionEntities` of a
+  /// given `Collision` type that intersect a specific rectangle.
+  ///
+  /// @param rect      The `Rectangle2D` to check for collision.
+  /// @param collision The `Collision` type to check for collision.
+  /// @param entity    The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any `ICollisionEntity` in the given
+  /// rectangle. `false` otherwise.
+  /// @see Collision
+  /// @see ICollisionEntity
   public boolean collides(Rectangle2D rect, Collision collision, ICollisionEntity entity) {
     if (this.environmentBounds != null && !this.environmentBounds.intersects(rect)) {
       return true;
@@ -308,55 +269,47 @@ public final class PhysicsEngine implements IUpdateable {
       otherEntity -> GeometricUtilities.intersects(otherEntity.getCollisionBox(), rect));
   }
 
-  /**
-   * Checks if a given point collides with anything registered in the {@code PhysicsEngine}.
-   *
-   * @param location The {@code Point2D} to check for collision.
-   * @return {@code true} if the point collides with anything. {@code false} otherwise.
-   */
+  /// Checks if a given point collides with anything registered in the `PhysicsEngine`.
+  ///
+  /// @param location The `Point2D` to check for collision.
+  /// @return `true` if the point collides with anything. `false` otherwise.
   public boolean collides(final Point2D location) {
     return this.collides(location, Collision.ANY);
   }
 
-  /**
-   * Checks if a point collides with anything of the given {@code Collision} type.
-   *
-   * @param location  The {@code Point2D} to check for collision.
-   * @param collision The {@code Collision} type to check for collisions.
-   * @return {@code true} if the point collides with anything of the given {@code Collision} type.
-   * {@code false} otherwise.
-   * @see Collision
-   */
+  /// Checks if a point collides with anything of the given `Collision` type.
+  ///
+  /// @param location  The `Point2D` to check for collision.
+  /// @param collision The `Collision` type to check for collisions.
+  /// @return `true` if the point collides with anything of the given `Collision` type.
+  /// `false` otherwise.
+  /// @see Collision
   public boolean collides(Point2D location, Collision collision) {
     return collides(location, collision, null);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with anything that intersects a specific
-   * point.
-   *
-   * @param location The {@code Point2D} to check for collision.
-   * @param entity   The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any {@code ICollisionEntity} on the given
-   * point. {@code false} otherwise.
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with anything that intersects a specific
+  /// point.
+  ///
+  /// @param location The `Point2D` to check for collision.
+  /// @param entity   The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any `ICollisionEntity` on the given
+  /// point. `false` otherwise.
+  /// @see ICollisionEntity
   public boolean collides(Point2D location, ICollisionEntity entity) {
     return this.collides(location, Collision.ANY, entity);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with any {@code ICollisionEntities} of a
-   * given {@code Collision} type that intersect a specific point.
-   *
-   * @param location  The {@code Point2D} to check for collision.
-   * @param collision The {@code Collision} type to check for collision.
-   * @param entity    The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any {@code ICollisionEntity} on the given
-   * point. {@code false} otherwise.
-   * @see Collision
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with any `ICollisionEntities` of a
+  /// given `Collision` type that intersect a specific point.
+  ///
+  /// @param location  The `Point2D` to check for collision.
+  /// @param collision The `Collision` type to check for collision.
+  /// @param entity    The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any `ICollisionEntity` on the given
+  /// point. `false` otherwise.
+  /// @see Collision
+  /// @see ICollisionEntity
   public boolean collides(Point2D location, Collision collision, ICollisionEntity entity) {
     if (this.environmentBounds != null && !this.environmentBounds.contains(location)) {
       return true;
@@ -366,163 +319,139 @@ public final class PhysicsEngine implements IUpdateable {
       entity, collision, otherEntity -> otherEntity.getCollisionBox().contains(location));
   }
 
-  /**
-   * Checks if the point at the given coordinates collides with anything registered in the
-   * {@code PhysicsEngine}.
-   *
-   * @param x The x coordinate to check for collision.
-   * @param y The y coordinate to check for collision.
-   * @return {@code true} if the coordinates collide with anything. {@code false} otherwise.
-   */
+  /// Checks if the point at the given coordinates collides with anything registered in the
+  /// `PhysicsEngine`.
+  ///
+  /// @param x The x coordinate to check for collision.
+  /// @param y The y coordinate to check for collision.
+  /// @return `true` if the coordinates collide with anything. `false` otherwise.
   public boolean collides(final double x, final double y) {
     return this.collides(new Point2D.Double(x, y));
   }
 
-  /**
-   * Checks if the point at the given coordinates collides with anything of the given
-   * {@code Collision} type.
-   *
-   * @param x         The x coordinate to check for collision.
-   * @param y         The y coordinate to check for collision.
-   * @param collision The {@code Collision} type to check for collisions.
-   * @return {@code true} if the coordinates collide with anything of the given {@code Collision}
-   * type. {@code false} otherwise.
-   * @see Collision
-   */
+  /// Checks if the point at the given coordinates collides with anything of the given
+  /// `Collision` type.
+  ///
+  /// @param x         The x coordinate to check for collision.
+  /// @param y         The y coordinate to check for collision.
+  /// @param collision The `Collision` type to check for collisions.
+  /// @return `true` if the coordinates collide with anything of the given `Collision`
+  /// type. `false` otherwise.
+  /// @see Collision
   public boolean collides(double x, double y, Collision collision) {
     return this.collides(new Point2D.Double(x, y), collision);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with anything that intersects specific
-   * coordinates.
-   *
-   * @param x      The x coordinate to check for collision.
-   * @param y      The y coordinate to check for collision.
-   * @param entity The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any {@code ICollisionEntity} on the given
-   * coordinates. {@code false} otherwise.
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with anything that intersects specific
+  /// coordinates.
+  ///
+  /// @param x      The x coordinate to check for collision.
+  /// @param y      The y coordinate to check for collision.
+  /// @param entity The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any `ICollisionEntity` on the given
+  /// coordinates. `false` otherwise.
+  /// @see ICollisionEntity
   public boolean collides(double x, double y, ICollisionEntity entity) {
     return collides(new Point2D.Double(x, y), entity);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with anything registered in the
-   * {@code PhysicsEngine}.
-   *
-   * @param entity The {@code ICollisionEntity} to check for collision.
-   * @return {@code true} if the entity collides with any other {@code ICollisionEntity}.
-   * {@code false} otherwise.
-   * @see ICollisionEntity
-   */
+  /// Checks if a given `ICollisionEntity` collides with anything registered in the
+  /// `PhysicsEngine`.
+  ///
+  /// @param entity The `ICollisionEntity` to check for collision.
+  /// @return `true` if the entity collides with any other `ICollisionEntity`.
+  /// `false` otherwise.
+  /// @see ICollisionEntity
   public boolean collides(ICollisionEntity entity) {
     return this.collides(entity, Collision.ANY);
   }
 
-  /**
-   * Checks if a given {@code ICollisionEntity} collides with anything of the given
-   * {@code Collision} type.
-   *
-   * @param entity    The {@code ICollisionEntity} to check for collision.
-   * @param collision The {@code Collision} type to check for collisions.
-   * @return {@code true} if the entity collides with anything of the given {@code Collision} type.
-   * {@code false} otherwise.
-   * @see Collision
-   */
+  /// Checks if a given `ICollisionEntity` collides with anything of the given
+  /// `Collision` type.
+  ///
+  /// @param entity    The `ICollisionEntity` to check for collision.
+  /// @param collision The `Collision` type to check for collisions.
+  /// @return `true` if the entity collides with anything of the given `Collision` type.
+  /// `false` otherwise.
+  /// @see Collision
   public boolean collides(ICollisionEntity entity, Collision collision) {
     return this.collides(entity.getCollisionBox(), collision, entity);
   }
 
-  /**
-   * From a given point, cast a ray of indefinite length with the given angle and see if it hits
-   * anything.
-   *
-   * @param start The start point of the raycast.
-   * @param angle The angle in degrees.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}, if the ray hit something.
-   */
+  /// From a given point, cast a ray of indefinite length with the given angle and see if it hits
+  /// anything.
+  ///
+  /// @param start The start point of the raycast.
+  /// @param angle The angle in degrees.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`, if the ray hit something.
   public RaycastHit raycast(Point2D start, double angle) {
     double diameter = GeometricUtilities.getDiagonal(this.environmentBounds);
     return raycast(start, GeometricUtilities.project(start, angle, diameter));
   }
 
-  /**
-   * From a given point, cast a ray to another point and see if it hits anything.
-   *
-   * @param start  The start point of the raycast.
-   * @param target The end point of the raycast.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}, if the ray hit something.
-   */
+  /// From a given point, cast a ray to another point and see if it hits anything.
+  ///
+  /// @param start  The start point of the raycast.
+  /// @param target The end point of the raycast.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`, if the ray hit something.
   public RaycastHit raycast(Point2D start, Point2D target) {
     return raycast(start, target, Collision.ANY);
   }
 
-  /**
-   * From a given point, cast a ray to another point and see if it hits anything with the given
-   * {@code Collision} type.
-   *
-   * @param start     The start point of the raycast.
-   * @param target    The end point of the raycast.
-   * @param collision The {@code Collision} type to check for collision.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}, if the ray hit something.
-   */
+  /// From a given point, cast a ray to another point and see if it hits anything with the given
+  /// `Collision` type.
+  ///
+  /// @param start     The start point of the raycast.
+  /// @param target    The end point of the raycast.
+  /// @param collision The `Collision` type to check for collision.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`, if the ray hit something.
   public RaycastHit raycast(Point2D start, Point2D target, Collision collision) {
     final Line2D line = new Line2D.Double(start.getX(), start.getY(), target.getX(), target.getY());
     return raycast(line, collision, null);
   }
 
-  /**
-   * Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits anything.
-   *
-   * @param line The line along which the ray is cast.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}, if the ray hit something.
-   */
+  /// Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits anything.
+  ///
+  /// @param line The line along which the ray is cast.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`, if the ray hit something.
   public RaycastHit raycast(Line2D line) {
     return raycast(line, Collision.ANY, null);
   }
 
-  /**
-   * Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits anything with the
-   * given {@code Collision} type.
-   *
-   * @param line      The line along which the ray is cast.
-   * @param collision The {@code Collision} type to check for collision.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}, if the ray hit something.
-   */
+  /// Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits anything with the
+  /// given `Collision` type.
+  ///
+  /// @param line      The line along which the ray is cast.
+  /// @param collision The `Collision` type to check for collision.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`, if the ray hit something.
   public RaycastHit raycast(Line2D line, Collision collision) {
     return raycast(line, collision, null);
   }
 
-  /**
-   * Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits a given
-   * {@code ICollisionEntity}.
-   *
-   * @param line   The line along which the ray is cast.
-   * @param entity The {@code ICollisionEntity} type to check for collision.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}.
-   */
+  /// Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits a given
+  /// `ICollisionEntity`.
+  ///
+  /// @param line   The line along which the ray is cast.
+  /// @param entity The `ICollisionEntity` type to check for collision.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`.
   public RaycastHit raycast(Line2D line, ICollisionEntity entity) {
     return raycast(line, Collision.ANY, entity);
   }
 
-  /**
-   * Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits anything with a
-   * certain {@code Collision} type that collides with the given {@code ICollisionEntity}.
-   *
-   * @param line      The line along which the ray is cast.
-   * @param collision The {@code Collision} type to check for collision.
-   * @param entity    The {@code ICollisionEntity} type to check for collision.
-   * @return A {@code RaycastHit} determining the hit point, ray length, and corresponding
-   * {@code ICollisionEntity}.
-   */
+  /// Cast a ray along a given line [from (x1,y1) to (x2,y2)] and see if it hits anything with a
+  /// certain `Collision` type that collides with the given `ICollisionEntity`.
+  ///
+  /// @param line      The line along which the ray is cast.
+  /// @param collision The `Collision` type to check for collision.
+  /// @param entity    The `ICollisionEntity` type to check for collision.
+  /// @return A `RaycastHit` determining the hit point, ray length, and corresponding
+  /// `ICollisionEntity`.
   public RaycastHit raycast(Line2D line, Collision collision, ICollisionEntity entity) {
     final Point2D rayCastSource = new Point2D.Double(line.getX1(), line.getY1());
 
@@ -550,70 +479,60 @@ public final class PhysicsEngine implements IUpdateable {
     return null;
   }
 
-  /**
-   * Moves the specified entity by a given distance and angle.
-   *
-   * @param entity   The entity which is moved
-   * @param angle    The angle in degrees
-   * @param distance The distance to move the entity
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   * @see GeometricUtilities#project(Point2D, double, double)
-   */
+  /// Moves the specified entity by a given distance and angle.
+  ///
+  /// @param entity   The entity which is moved
+  /// @param angle    The angle in degrees
+  /// @param distance The distance to move the entity
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
+  /// @see GeometricUtilities#project(Point2D, double, double)
   public boolean move(final IMobileEntity entity, final double angle, final double distance) {
     final Point2D newLocation = GeometricUtilities.project(entity.getLocation(), angle, distance);
     return move(entity, newLocation);
   }
 
-  /**
-   * Moves the specified entity by a given distance and angle.
-   *
-   * @param entity    The {@code IMobileEntity} which is moved
-   * @param direction The {@code Direction} in which the entity is moved
-   * @param distance  The distance to move the entity
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   * @see Direction
-   */
+  /// Moves the specified entity by a given distance and angle.
+  ///
+  /// @param entity    The `IMobileEntity` which is moved
+  /// @param direction The `Direction` in which the entity is moved
+  /// @param distance  The distance to move the entity
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
+  /// @see Direction
   public boolean move(IMobileEntity entity, Direction direction, double distance) {
     return move(entity, direction.toAngle(), distance);
   }
 
-  /**
-   * Moves the specified entity by a given distance towards the target coordinates.
-   *
-   * @param entity   The {@code IMobileEntity} which is moved
-   * @param x        The target x coordinate
-   * @param y        The target y coordinate
-   * @param distance The distance to move the entity
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   */
+  /// Moves the specified entity by a given distance towards the target coordinates.
+  ///
+  /// @param entity   The `IMobileEntity` which is moved
+  /// @param x        The target x coordinate
+  /// @param y        The target y coordinate
+  /// @param distance The distance to move the entity
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
   public boolean move(
     final IMobileEntity entity, final double x, final double y, final float distance) {
     return move(entity, new Point2D.Double(x, y), distance);
   }
 
-  /**
-   * Moves the specified entity by a given distance and the entity's angle.
-   *
-   * @param entity   The {@code IMobileEntity} which is moved
-   * @param distance The distance to move the entity
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   * @see Direction
-   */
+  /// Moves the specified entity by a given distance and the entity's angle.
+  ///
+  /// @param entity   The `IMobileEntity` which is moved
+  /// @param distance The distance to move the entity
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
+  /// @see Direction
   public boolean move(final IMobileEntity entity, final float distance) {
     return move(entity, entity.getAngle(), distance);
   }
 
-  /**
-   * Moves the specified entity to a target point. If {@code turnTowardsTarget} is {@code true}, set
-   * the entity's angle towards the target.
-   *
-   * @param entity            The {@code IMobileEntity} which is moved
-   * @param target            The target point
-   * @param turnTowardsTarget Boolean that determines whether the movement should turn the entity
-   *                          towards the target point.
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   * @see #resolveCollisionForNewLocation
-   */
+  /// Moves the specified entity to a target point. If `turnTowardsTarget` is `true`, set
+  /// the entity's angle towards the target.
+  ///
+  /// @param entity            The `IMobileEntity` which is moved
+  /// @param target            The target point
+  /// @param turnTowardsTarget Boolean that determines whether the movement should turn the entity
+  /// towards the target point.
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
+  /// @see #resolveCollisionForNewLocation
   public boolean move(final IMobileEntity entity, Point2D target, boolean turnTowardsTarget) {
     if (turnTowardsTarget) {
       entity.setAngle(
@@ -652,30 +571,26 @@ public final class PhysicsEngine implements IUpdateable {
 
   }
 
-  /**
-   * Moves the specified entity to a target point. If {@code entity.turnOnMove()} is {@code true},
-   * set the entity's angle towards the target.
-   *
-   * @param entity The {@code IMobileEntity} which is moved
-   * @param target The target point
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   * @see #resolveCollisionForNewLocation
-   */
+  /// Moves the specified entity to a target point. If `entity.turnOnMove()` is `true`,
+  /// set the entity's angle towards the target.
+  ///
+  /// @param entity The `IMobileEntity` which is moved
+  /// @param target The target point
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
+  /// @see #resolveCollisionForNewLocation
   public boolean move(final IMobileEntity entity, Point2D target) {
     return move(entity, target, entity.turnOnMove());
   }
 
 
-  /**
-   * Moves the specified entity by a given distance towards the target coordinates. If
-   * {@code entity.turnOnMove()} is {@code true}, set the entity's angle towards the target.
-   *
-   * @param entity   The {@code IMobileEntity} which is moved
-   * @param target   The target point
-   * @param distance The distance to move the entity
-   * @return {@code true}, if the entity can be moved without colliding, otherwise {@code false}.
-   * @see #resolveCollisionForNewLocation
-   */
+  /// Moves the specified entity by a given distance towards the target coordinates. If
+  /// `entity.turnOnMove()` is `true`, set the entity's angle towards the target.
+  ///
+  /// @param entity   The `IMobileEntity` which is moved
+  /// @param target   The target point
+  /// @param distance The distance to move the entity
+  /// @return `true`, if the entity can be moved without colliding, otherwise `false`.
+  /// @see #resolveCollisionForNewLocation
   public boolean move(final IMobileEntity entity, final Point2D target, final float distance) {
     final Point2D newLocation = GeometricUtilities.project(entity.getLocation(), target, distance);
     return move(entity, newLocation);
@@ -689,10 +604,8 @@ public final class PhysicsEngine implements IUpdateable {
     this.enabled = enabled;
   }
 
-  /**
-   * Clears all collision boxes registered on the {@code PhysicsEngine} once per tick and re-adds
-   * them with their updated positions.
-   */
+  /// Clears all collision boxes registered on the `PhysicsEngine` once per tick and re-adds
+  /// them with their updated positions.
   @Override
   public void update() {
     if (!this.enabled) {
@@ -709,13 +622,11 @@ public final class PhysicsEngine implements IUpdateable {
     }
   }
 
-  /**
-   * Checks if two entities can collide
-   *
-   * @param entity      The first entity to check for collision
-   * @param otherEntity The second entity to check for collision
-   * @return {@code true} if the entities can collide, {@code false} otherwise.
-   */
+  /// Checks if two entities can collide
+  ///
+  /// @param entity      The first entity to check for collision
+  /// @param otherEntity The second entity to check for collision
+  /// @return `true` if the entities can collide, `false` otherwise.
   private static boolean canCollide(ICollisionEntity entity, ICollisionEntity otherEntity) {
     if (otherEntity == null || !otherEntity.hasCollision()) {
       return false;
@@ -736,14 +647,12 @@ public final class PhysicsEngine implements IUpdateable {
     return entity.canCollideWith(otherEntity);
   }
 
-  /**
-   * Gets the intersection between an entity's collision box and all {@code ICollisionEntities} in a
-   * given rectangle.
-   *
-   * @param entity The {@code ICollisionEntity} to check for intersection.
-   * @param rect   The {@code Rectangle2D} to check for intersection.
-   * @return The {@code Intersection} area.
-   */
+  /// Gets the intersection between an entity's collision box and all `ICollisionEntities` in a
+  /// given rectangle.
+  ///
+  /// @param entity The `ICollisionEntity` to check for intersection.
+  /// @param rect   The `Rectangle2D` to check for intersection.
+  /// @return The `Intersection` area.
   private Intersection getIntersection(final ICollisionEntity entity, final Rectangle2D rect) {
     Intersection result = null;
     for (final ICollisionEntity otherEntity : getCollisionEntities()) {
@@ -782,12 +691,10 @@ public final class PhysicsEngine implements IUpdateable {
     return false;
   }
 
-  /**
-   * Checks if is in map.
-   *
-   * @param collisionBox the collision box
-   * @return true, if is in map
-   */
+  /// Checks if is in map.
+  ///
+  /// @param collisionBox the collision box
+  /// @return true, if is in map
   private boolean isInMap(final Shape collisionBox) {
     if (environmentBounds == null) {
       return true;
@@ -796,15 +703,13 @@ public final class PhysicsEngine implements IUpdateable {
     return environmentBounds.contains(collisionBox.getBounds());
   }
 
-  /**
-   * With the current physics implementation is is possible to glitch through other entities, if
-   * their collisionbox is smaller than the velocity of the moving entity and they also move towards
-   * the currently moving entity.
-   *
-   * @param entity         The entity to resolve the collision for.
-   * @param targetLocation The target location to which the entity should be moved to.
-   * @return The position to which the entity should be moved after resolving the collision.
-   */
+  /// With the current physics implementation is is possible to glitch through other entities, if
+  /// their collisionbox is smaller than the velocity of the moving entity and they also move towards
+  /// the currently moving entity.
+  ///
+  /// @param entity         The entity to resolve the collision for.
+  /// @param targetLocation The target location to which the entity should be moved to.
+  /// @return The position to which the entity should be moved after resolving the collision.
   private Point2D resolveCollision(final ICollisionEntity entity, final Point2D targetLocation) {
     // first resolve x-axis movement
     Point2D resolvedLocation = new Point2D.Double(targetLocation.getX(), entity.getY());
@@ -922,10 +827,8 @@ public final class PhysicsEngine implements IUpdateable {
     }
   }
 
-  /**
-   * A helper class that contains the intersection of a collision event and the involved entities.
-   * This is basically just a {@link Rectangle2D} with some additional information.
-   */
+  /// A helper class that contains the intersection of a collision event and the involved entities.
+  /// This is basically just a [Rectangle2D] with some additional information.
   private static class Intersection extends Rectangle2D.Double {
 
     private final transient ICollisionEntity[] involvedEntities;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/RaycastHit.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/RaycastHit.java
@@ -3,13 +3,11 @@ package de.gurkenlabs.litiengine.physics;
 import de.gurkenlabs.litiengine.entities.ICollisionEntity;
 import java.awt.geom.Point2D;
 
-/**
- * Represents the result of a raycast in the physics engine. A RaycastHit contains the point of impact, the entity hit, and the distance to the impact
- * point.
- *
- * @param point    the point of impact
- * @param entity   the entity hit by the raycast
- * @param distance the distance to the point of impact
- */
+/// Represents the result of a raycast in the physics engine. A RaycastHit contains the point of impact, the entity hit, and the distance to the impact
+/// point.
+///
+/// @param point    the point of impact
+/// @param entity   the entity hit by the raycast
+/// @param distance the distance to the point of impact
 public record RaycastHit(Point2D point, ICollisionEntity entity, double distance) {
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/StickyForce.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/physics/StickyForce.java
@@ -3,45 +3,35 @@ package de.gurkenlabs.litiengine.physics;
 import de.gurkenlabs.litiengine.entities.IEntity;
 import java.awt.geom.Point2D;
 
-/**
- * The Force implementation sticks to an entity in terms of its location.
- */
+/// The Force implementation sticks to an entity in terms of its location.
 public class StickyForce extends Force {
 
-  /**
-   * The force entiy.
-   */
+  /// The force entiy.
   private final IEntity forceEntity;
 
-  /**
-   * Instantiates a new sticky force.
-   *
-   * @param forceEntity The entity to which this force will be bound
-   * @param strength    The strength/intensity of this force
-   * @param size        The size of this force
-   */
+  /// Instantiates a new sticky force.
+  ///
+  /// @param forceEntity The entity to which this force will be bound
+  /// @param strength    The strength/intensity of this force
+  /// @param size        The size of this force
   public StickyForce(final IEntity forceEntity, final float strength, final float size) {
     super(forceEntity.getCenter(), strength, size);
     this.forceEntity = forceEntity;
   }
 
-  /**
-   * Instantiates a new sticky force.
-   *
-   * @param center   The center point to which this force will be bound
-   * @param strength The strength/intensity of this force
-   * @param size     The size of this force
-   */
+  /// Instantiates a new sticky force.
+  ///
+  /// @param center   The center point to which this force will be bound
+  /// @param strength The strength/intensity of this force
+  /// @param size     The size of this force
   public StickyForce(final Point2D center, final float strength, final float size) {
     super(center, strength, size);
     this.forceEntity = null;
   }
 
-  /**
-   * Gets the force entity.
-   *
-   * @return the force entity
-   */
+  /// Gets the force entity.
+  ///
+  /// @return the force entity
   public IEntity getForceEntity() {
     return this.forceEntity;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Animations.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Animations.java
@@ -16,28 +16,22 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 
-/**
- * Resource container for {@link Animation} resources.
- *
- * <p>
- * The container can import animations from the JSON format exported by
- * <a href="https://www.aseprite.org/docs/cli/#filename-format">Aseprite</a> and export existing
- * animations back to that format. This makes it possible to author animations in Aseprite and load
- * them directly at runtime via {@link Resources#animations()}.
- * </p>
- *
- * <p>
- * Aseprite exports a sprite sheet image together with a JSON sidecar describing each frame's
- * location and display duration. When loading, the container expects the sprite sheet image to live
- * next to the JSON file (as referenced by the {@code meta.image} field). All frames must have the
- * same width and height; the engine's {@link Spritesheet} model is grid-based and does not support
- * frames of arbitrary sizes.
- * </p>
- */
+/// Resource container for [Animation] resources.
+///
+/// The container can import animations from the JSON format exported by
+/// [Aseprite](https://www.aseprite.org/docs/cli/#filename-format) and export existing
+/// animations back to that format. This makes it possible to author animations in Aseprite and load
+/// them directly at runtime via [Resources#animations()].
+///
+/// Aseprite exports a sprite sheet image together with a JSON sidecar describing each frame's
+/// location and display duration. When loading, the container expects the sprite sheet image to live
+/// next to the JSON file (as referenced by the `meta.image` field). All frames must have the
+/// same width and height; the engine's [Spritesheet] model is grid-based and does not support
+/// frames of arbitrary sizes.
 public final class Animations extends ResourcesContainer<Animation> {
   private static final Logger log = Logger.getLogger(Animations.class.getName());
 
-  /** File extension recognised for Aseprite JSON sidecar files. */
+  /// File extension recognised for Aseprite JSON sidecar files.
   public static final String ASEPRITE_FILE_EXTENSION = "json";
 
   Animations() {
@@ -56,19 +50,15 @@ public final class Animations extends ResourcesContainer<Animation> {
     return fromAseprite(format, animationName, resourceName);
   }
 
-  /**
-   * Imports an Aseprite-exported animation from the given JSON file.
-   *
-   * <p>
-   * The loaded animation is registered with this container under the file name (without extension)
-   * of the JSON file. The associated sprite sheet is registered with {@link Resources#spritesheets()}.
-   * </p>
-   *
-   * @param asepriteJsonPath The path to the Aseprite JSON sidecar file.
-   * @return The imported animation.
-   * @throws IOException If the file cannot be read or parsed, or if the referenced image cannot be
-   *                     loaded.
-   */
+  /// Imports an Aseprite-exported animation from the given JSON file.
+  ///
+  /// The loaded animation is registered with this container under the file name (without extension)
+  /// of the JSON file. The associated sprite sheet is registered with [Resources#spritesheets()].
+  ///
+  /// @param asepriteJsonPath The path to the Aseprite JSON sidecar file.
+  /// @return The imported animation.
+  /// @throws IOException If the file cannot be read or parsed, or if the referenced image cannot be
+  /// loaded.
   public Animation importAseprite(Path asepriteJsonPath) throws IOException {
     AsepriteFormat format = AsepriteFormat.read(asepriteJsonPath);
     String animationName = FileUtilities.getFileName(asepriteJsonPath.getFileName().toString());
@@ -78,20 +68,16 @@ public final class Animations extends ResourcesContainer<Animation> {
     return animation;
   }
 
-  /**
-   * Exports the specified animation to the Aseprite JSON format.
-   *
-   * <p>
-   * The sprite sheet image referenced by the animation is written next to the JSON file using the
-   * sprite sheet's {@link Spritesheet#getName() name} and the {@code .png} file extension. The
-   * resulting {@code .json} file follows the layout produced by the Aseprite CLI when exported with
-   * the {@code --format json-hash} option.
-   * </p>
-   *
-   * @param animation     The animation to export.
-   * @param destinationJson The path of the JSON file to write.
-   * @return {@code true} if the export was successful; {@code false} otherwise.
-   */
+  /// Exports the specified animation to the Aseprite JSON format.
+  ///
+  /// The sprite sheet image referenced by the animation is written next to the JSON file using the
+  /// sprite sheet's [name][Spritesheet#getName()] and the `.png` file extension. The
+  /// resulting `.json` file follows the layout produced by the Aseprite CLI when exported with
+  /// the `--format json-hash` option.
+  ///
+  /// @param animation     The animation to export.
+  /// @param destinationJson The path of the JSON file to write.
+  /// @return `true` if the export was successful; `false` otherwise.
   public boolean exportAseprite(Animation animation, Path destinationJson) {
     if (animation == null) {
       return false;
@@ -119,12 +105,10 @@ public final class Animations extends ResourcesContainer<Animation> {
     }
   }
 
-  /**
-   * Builds an Aseprite JSON model from the given animation.
-   *
-   * @param animation The animation to describe.
-   * @return The Aseprite JSON model.
-   */
+  /// Builds an Aseprite JSON model from the given animation.
+  ///
+  /// @param animation The animation to describe.
+  /// @return The Aseprite JSON model.
   public static AsepriteFormat toAseprite(Animation animation) {
     AsepriteFormat result = new AsepriteFormat();
     Spritesheet sheet = animation.getSpritesheet();
@@ -156,22 +140,18 @@ public final class Animations extends ResourcesContainer<Animation> {
     return result;
   }
 
-  /**
-   * Builds an {@link Animation} (and its backing {@link Spritesheet}) from the given Aseprite model.
-   *
-   * <p>
-   * The image referenced by {@link AsepriteFormat#getImage()} is resolved relative to the supplied
-   * {@code baseUrl} and loaded via the engine's image resource container.
-   * </p>
-   *
-   * @param format        The Aseprite model to convert.
-   * @param animationName The name to assign to the resulting animation.
-   * @param baseUrl       The URL used to resolve the referenced image. May be {@code null} if the
-   *                      image is referenced by an absolute path.
-   * @return The created animation.
-   * @throws IOException If the referenced image cannot be loaded or if the frames are not uniform in
-   *                     size.
-   */
+  /// Builds an [Animation] (and its backing [Spritesheet]) from the given Aseprite model.
+  ///
+  /// The image referenced by [AsepriteFormat#getImage()] is resolved relative to the supplied
+  /// `baseUrl` and loaded via the engine's image resource container.
+  ///
+  /// @param format        The Aseprite model to convert.
+  /// @param animationName The name to assign to the resulting animation.
+  /// @param baseUrl       The URL used to resolve the referenced image. May be `null` if the
+  /// image is referenced by an absolute path.
+  /// @return The created animation.
+  /// @throws IOException If the referenced image cannot be loaded or if the frames are not uniform in
+  /// size.
   public static Animation fromAseprite(AsepriteFormat format, String animationName, URL baseUrl) throws IOException {
     List<AsepriteFormat.Frame> frames = format.getFrames();
     if (frames.isEmpty()) {
@@ -258,11 +238,9 @@ public final class Animations extends ResourcesContainer<Animation> {
     return new URL(parent + image);
   }
 
-  /**
-   * Convenience method: returns all loaded animations indexed by name.
-   *
-   * @return An ordered map of loaded animation name to {@link Animation} instance.
-   */
+  /// Convenience method: returns all loaded animations indexed by name.
+  ///
+  /// @return An ordered map of loaded animation name to [Animation] instance.
   public Map<String, Animation> getAllByName() {
     LinkedHashMap<String, Animation> map = new LinkedHashMap<>();
     for (Map.Entry<String, Animation> e : getResources().entrySet()) {
@@ -271,14 +249,12 @@ public final class Animations extends ResourcesContainer<Animation> {
     return map;
   }
 
-  /**
-   * Convenience overload that loads an Aseprite JSON file from the runtime classpath or file system.
-   *
-   * @param asepriteJsonPath The path to the Aseprite JSON sidecar file.
-   * @return The imported animation.
-   * @throws IOException If the file cannot be read or parsed, or if the referenced image cannot be
-   *                     loaded.
-   */
+  /// Convenience overload that loads an Aseprite JSON file from the runtime classpath or file system.
+  ///
+  /// @param asepriteJsonPath The path to the Aseprite JSON sidecar file.
+  /// @return The imported animation.
+  /// @throws IOException If the file cannot be read or parsed, or if the referenced image cannot be
+  /// loaded.
   public Animation importAseprite(String asepriteJsonPath) throws IOException {
     URL location = Resources.getLocation(asepriteJsonPath);
     if (location == null) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/AsepriteFormat.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/AsepriteFormat.java
@@ -20,31 +20,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Java representation of the JSON export format produced by <a href="https://www.aseprite.org">Aseprite</a>.
- *
- * <p>
- * The Aseprite CLI can export a sprite sheet image together with a JSON sidecar that describes how
- * each frame of the sprite sheet is laid out and how long it should be displayed. See the
- * <a href="https://www.aseprite.org/docs/cli/#filename-format">Aseprite CLI documentation</a> for
- * details.
- * </p>
- *
- * <p>
- * This class supports both the "hash" (frames as an object map) and the "array" (frames as a JSON
- * array) layouts. When writing, the engine emits the "hash" form, which is the Aseprite default.
- * </p>
- *
- * <p>
- * Serialization is delegated to {@link JsonUtilities}, which is backed by the Jakarta JSON
- * Processing and Jakarta JSON Binding APIs.
- * </p>
- */
+/// Java representation of the JSON export format produced by [Aseprite](https://www.aseprite.org).
+///
+/// The Aseprite CLI can export a sprite sheet image together with a JSON sidecar that describes how
+/// each frame of the sprite sheet is laid out and how long it should be displayed. See the
+/// [Aseprite CLI documentation](https://www.aseprite.org/docs/cli/#filename-format) for
+/// details.
+///
+/// This class supports both the "hash" (frames as an object map) and the "array" (frames as a JSON
+/// array) layouts. When writing, the engine emits the "hash" form, which is the Aseprite default.
+///
+/// Serialization is delegated to [JsonUtilities], which is backed by the Jakarta JSON
+/// Processing and Jakarta JSON Binding APIs.
 public final class AsepriteFormat {
 
-  /**
-   * Describes a single rectangular region within an Aseprite sprite sheet.
-   */
+  /// Describes a single rectangular region within an Aseprite sprite sheet.
   public static final class Frame {
     private final String name;
     private final int x;
@@ -53,16 +43,14 @@ public final class AsepriteFormat {
     private final int height;
     private final int duration;
 
-    /**
-     * Creates a new frame entry.
-     *
-     * @param name     Name of the frame, typically of the form {@code "<animation> <index>.png"}.
-     * @param x        X position of the frame within the sprite sheet, in pixels.
-     * @param y        Y position of the frame within the sprite sheet, in pixels.
-     * @param width    Width of the frame, in pixels.
-     * @param height   Height of the frame, in pixels.
-     * @param duration Display duration of the frame, in milliseconds.
-     */
+    /// Creates a new frame entry.
+    ///
+    /// @param name     Name of the frame, typically of the form `"<animation> <index>.png"`.
+    /// @param x        X position of the frame within the sprite sheet, in pixels.
+    /// @param y        Y position of the frame within the sprite sheet, in pixels.
+    /// @param width    Width of the frame, in pixels.
+    /// @param height   Height of the frame, in pixels.
+    /// @param duration Display duration of the frame, in milliseconds.
     public Frame(String name, int x, int y, int width, int height, int duration) {
       this.name = name;
       this.x = x;
@@ -105,17 +93,15 @@ public final class AsepriteFormat {
   private String app = "https://litiengine.com";
   private String version = "1.0";
 
-  /** Creates an empty Aseprite format instance. */
+  /// Creates an empty Aseprite format instance.
   public AsepriteFormat() {
   }
 
-  /**
-   * Reads an Aseprite JSON document from the given URL.
-   *
-   * @param url The URL of the JSON file.
-   * @return The parsed Aseprite format.
-   * @throws IOException If the file cannot be read or parsed.
-   */
+  /// Reads an Aseprite JSON document from the given URL.
+  ///
+  /// @param url The URL of the JSON file.
+  /// @return The parsed Aseprite format.
+  /// @throws IOException If the file cannot be read or parsed.
   public static AsepriteFormat read(URL url) throws IOException {
     try (InputStream in = url.openStream(); Reader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
       return fromTree(JsonUtilities.readTree(reader));
@@ -124,13 +110,11 @@ public final class AsepriteFormat {
     }
   }
 
-  /**
-   * Reads an Aseprite JSON document from the given path.
-   *
-   * @param path The path to the JSON file.
-   * @return The parsed Aseprite format.
-   * @throws IOException If the file cannot be read or parsed.
-   */
+  /// Reads an Aseprite JSON document from the given path.
+  ///
+  /// @param path The path to the JSON file.
+  /// @return The parsed Aseprite format.
+  /// @throws IOException If the file cannot be read or parsed.
   public static AsepriteFormat read(Path path) throws IOException {
     try {
       return fromTree(JsonUtilities.readTree(path));
@@ -139,13 +123,11 @@ public final class AsepriteFormat {
     }
   }
 
-  /**
-   * Parses an Aseprite JSON document from the given JSON string.
-   *
-   * @param json The JSON text.
-   * @return The parsed Aseprite format.
-   * @throws IOException If the JSON is malformed or does not represent an Aseprite document.
-   */
+  /// Parses an Aseprite JSON document from the given JSON string.
+  ///
+  /// @param json The JSON text.
+  /// @return The parsed Aseprite format.
+  /// @throws IOException If the JSON is malformed or does not represent an Aseprite document.
   public static AsepriteFormat parse(String json) throws IOException {
     try (Reader reader = new java.io.StringReader(json)) {
       return fromTree(JsonUtilities.readTree(reader));
@@ -259,24 +241,20 @@ public final class AsepriteFormat {
     return value == null ? "" : value;
   }
 
-  /**
-   * Writes this Aseprite document to the given path as a (pretty-printed) JSON file.
-   *
-   * @param path The destination path.
-   * @throws IOException If writing fails.
-   */
+  /// Writes this Aseprite document to the given path as a (pretty-printed) JSON file.
+  ///
+  /// @param path The destination path.
+  /// @throws IOException If writing fails.
   public void write(Path path) throws IOException {
     if (JsonUtilities.saveTree(toJsonTree(), path, true) == null) {
       throw new IOException("Could not write Aseprite JSON to " + path);
     }
   }
 
-  /**
-   * Writes this Aseprite document as a JSON string.
-   *
-   * @param pretty Whether to format the output with indentation and line breaks.
-   * @return The JSON representation.
-   */
+  /// Writes this Aseprite document as a JSON string.
+  ///
+  /// @param pretty Whether to format the output with indentation and line breaks.
+  /// @return The JSON representation.
   public String writeToString(boolean pretty) {
     return JsonUtilities.writeTreeToString(toJsonTree(), pretty);
   }
@@ -337,12 +315,12 @@ public final class AsepriteFormat {
     return root.build();
   }
 
-  /** @return The list of frames defined by this document. */
+  /// @return The list of frames defined by this document.
   public List<Frame> getFrames() {
     return frames;
   }
 
-  /** @return The image filename referenced in the document's meta block (may be {@code null}). */
+  /// @return The image filename referenced in the document's meta block (may be `null`).
   public String getImage() {
     return image;
   }
@@ -351,7 +329,7 @@ public final class AsepriteFormat {
     this.image = image;
   }
 
-  /** @return The width of the referenced sprite sheet image, in pixels. */
+  /// @return The width of the referenced sprite sheet image, in pixels.
   public int getImageWidth() {
     return imageWidth;
   }
@@ -360,7 +338,7 @@ public final class AsepriteFormat {
     this.imageWidth = imageWidth;
   }
 
-  /** @return The height of the referenced sprite sheet image, in pixels. */
+  /// @return The height of the referenced sprite sheet image, in pixels.
   public int getImageHeight() {
     return imageHeight;
   }
@@ -369,7 +347,7 @@ public final class AsepriteFormat {
     this.imageHeight = imageHeight;
   }
 
-  /** @return The pixel format string from the document's meta block. */
+  /// @return The pixel format string from the document's meta block.
   public String getFormat() {
     return format;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Blueprints.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Blueprints.java
@@ -9,35 +9,27 @@ import de.gurkenlabs.litiengine.environment.tilemap.xml.TmxException;
 import de.gurkenlabs.litiengine.util.io.FileUtilities;
 import de.gurkenlabs.litiengine.util.io.XmlUtilities;
 
-/**
- * A class that manages the loading and handling of Blueprint resources.
- */
+/// A class that manages the loading and handling of Blueprint resources.
 public class Blueprints extends ResourcesContainer<Blueprint> {
 
-  /**
-   * Constructs a new Blueprints container.
-   */
+  /// Constructs a new Blueprints container.
   Blueprints() {}
 
-  /**
-   * Checks if the given file name is supported by this container.
-   *
-   * @param fileName The name of the file to check.
-   * @return true if the file is supported, false otherwise.
-   */
+  /// Checks if the given file name is supported by this container.
+  ///
+  /// @param fileName The name of the file to check.
+  /// @return true if the file is supported, false otherwise.
   public static boolean isSupported(String fileName) {
     String extension = FileUtilities.getExtension(fileName);
     return !extension.isEmpty() && (extension.equalsIgnoreCase(Blueprint.BLUEPRINT_FILE_EXTENSION) || extension.equalsIgnoreCase(
       Blueprint.TEMPLATE_FILE_EXTENSION));
   }
 
-  /**
-   * Loads a Blueprint resource from the specified URL.
-   *
-   * @param resourceName The URL of the resource to load.
-   * @return The loaded Blueprint resource.
-   * @throws Exception if an error occurs while loading the resource.
-   */
+  /// Loads a Blueprint resource from the specified URL.
+  ///
+  /// @param resourceName The URL of the resource to load.
+  /// @return The loaded Blueprint resource.
+  /// @throws Exception if an error occurs while loading the resource.
   @Override
   protected Blueprint load(URL resourceName) throws Exception {
     Blueprint blueprint;
@@ -50,13 +42,11 @@ public class Blueprints extends ResourcesContainer<Blueprint> {
     return blueprint;
   }
 
-  /**
-   * Gets the alias for the specified resource.
-   *
-   * @param resourceName The name of the resource.
-   * @param resource The resource to get the alias for.
-   * @return The alias of the resource, or null if no alias is available.
-   */
+  /// Gets the alias for the specified resource.
+  ///
+  /// @param resourceName The name of the resource.
+  /// @param resource The resource to get the alias for.
+  /// @return The alias of the resource, or null if no alias is available.
   @Override
   protected String getAlias(String resourceName, Blueprint resource) {
     if (resource == null || resource.getName() == null || resource.getName().isEmpty() || resource.getName().equalsIgnoreCase(resourceName)) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/DataFormat.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/DataFormat.java
@@ -3,22 +3,18 @@ package de.gurkenlabs.litiengine.resources;
 import de.gurkenlabs.litiengine.util.io.FileUtilities;
 import java.util.ArrayList;
 
-/**
- * Some common implementations that are used by different kinds of file classes (e.g. {@code SoundFormat}, {@code ImageFormat}.
- */
+/// Some common implementations that are used by different kinds of file classes (e.g. `SoundFormat`, `ImageFormat`.
 final class DataFormat {
   private DataFormat() {
   }
 
-  /**
-   * Retrieves the enum value corresponding to the given format string.
-   *
-   * @param <T>          The type of the enum.
-   * @param format       The format string to match.
-   * @param values       The array of enum values to search.
-   * @param defaultValue The default value to return if no match is found.
-   * @return The matching enum value, or the default value if no match is found.
-   */
+  /// Retrieves the enum value corresponding to the given format string.
+  ///
+  /// @param <T>          The type of the enum.
+  /// @param format       The format string to match.
+  /// @param values       The array of enum values to search.
+  /// @param defaultValue The default value to return if no match is found.
+  /// @return The matching enum value, or the default value if no match is found.
   static <T extends Enum<T>> T get(String format, T[] values, T defaultValue) {
     if (format == null || format.isEmpty()) {
       return defaultValue;
@@ -38,15 +34,13 @@ final class DataFormat {
     return defaultValue;
   }
 
-  /**
-   * Checks if the given file name is supported by the specified enum values.
-   *
-   * @param <T>          The type of the enum.
-   * @param fileName     The name of the file to check.
-   * @param values       The array of enum values to search.
-   * @param defaultValue The default value to use for comparison.
-   * @return true if the file is supported, false otherwise.
-   */
+  /// Checks if the given file name is supported by the specified enum values.
+  ///
+  /// @param <T>          The type of the enum.
+  /// @param fileName     The name of the file to check.
+  /// @param values       The array of enum values to search.
+  /// @param defaultValue The default value to use for comparison.
+  /// @return true if the file is supported, false otherwise.
   static <T extends Enum<T>> boolean isSupported(String fileName, T[] values, T defaultValue) {
     String extension = FileUtilities.getExtension(fileName);
     if (extension.isEmpty()) {
@@ -62,14 +56,12 @@ final class DataFormat {
     return false;
   }
 
-  /**
-   * Retrieves all extensions for the specified enum values.
-   *
-   * @param <T>          The type of the enum.
-   * @param values       The array of enum values to search.
-   * @param defaultValue The default value to exclude from the result.
-   * @return An array of strings representing all extensions.
-   */
+  /// Retrieves all extensions for the specified enum values.
+  ///
+  /// @param <T>          The type of the enum.
+  /// @param values       The array of enum values to search.
+  /// @param defaultValue The default value to exclude from the result.
+  /// @return An array of strings representing all extensions.
   static <T extends Enum<T>> String[] getAllExtensions(T[] values, T defaultValue) {
     ArrayList<String> arrList = new ArrayList<>();
     for (T format : values) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Fonts.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Fonts.java
@@ -8,22 +8,18 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * A container class for managing font resources. This class extends the ResourcesContainer class, specifically for Font objects.
- */
+/// A container class for managing font resources. This class extends the ResourcesContainer class, specifically for Font objects.
 public final class Fonts extends ResourcesContainer<Font> {
   private static final Logger log = Logger.getLogger(Fonts.class.getName());
 
   Fonts() {
   }
 
-  /**
-   * Retrieves a font with the specified name and size.
-   *
-   * @param name The name of the font.
-   * @param size The size of the font.
-   * @return The derived font with the specified size, or null if the font is not found.
-   */
+  /// Retrieves a font with the specified name and size.
+  ///
+  /// @param name The name of the font.
+  /// @param size The size of the font.
+  /// @return The derived font with the specified size, or null if the font is not found.
   public Font get(String name, float size) {
     Font font = this.get(name);
     if (font == null) {
@@ -33,13 +29,11 @@ public final class Fonts extends ResourcesContainer<Font> {
     return font.deriveFont(size);
   }
 
-  /**
-   * Retrieves a font with the specified name and style.
-   *
-   * @param name  The name of the font.
-   * @param style The style of the font (e.g., Font.PLAIN, Font.BOLD).
-   * @return The derived font with the specified style, or null if the font is not found.
-   */
+  /// Retrieves a font with the specified name and style.
+  ///
+  /// @param name  The name of the font.
+  /// @param style The style of the font (e.g., Font.PLAIN, Font.BOLD).
+  /// @return The derived font with the specified style, or null if the font is not found.
   public Font get(String name, int style) {
     Font font = this.get(name);
     if (font == null) {
@@ -49,14 +43,12 @@ public final class Fonts extends ResourcesContainer<Font> {
     return font.deriveFont(style);
   }
 
-  /**
-   * Retrieves a font with the specified name, style, and size.
-   *
-   * @param name  The name of the font.
-   * @param style The style of the font (e.g., Font.PLAIN, Font.BOLD).
-   * @param size  The size of the font.
-   * @return The derived font with the specified style and size, or null if the font is not found.
-   */
+  /// Retrieves a font with the specified name, style, and size.
+  ///
+  /// @param name  The name of the font.
+  /// @param style The style of the font (e.g., Font.PLAIN, Font.BOLD).
+  /// @param size  The size of the font.
+  /// @return The derived font with the specified style and size, or null if the font is not found.
   public Font get(String name, int style, float size) {
     Font font = this.get(name);
     if (font == null) {
@@ -66,17 +58,15 @@ public final class Fonts extends ResourcesContainer<Font> {
     return font.deriveFont(style, size);
   }
 
-  /***
-   * Loads a custom font with the specified name from game's resources. As a fallback, when no font could be found by the
-   * specified {@code fontName}, it tries to get the font from the environment by calling.
-   *
-   * @param resourceName
-   *          The name of the font
-   * @return The loaded font.
-   *
-   * @see Font#createFont(int, java.io.File)
-   * @see Font#getFont(String)
-   */
+  /// Loads a custom font with the specified name from game's resources. As a fallback, when no font could be found by the
+  /// specified `fontName`, it tries to get the font from the environment by calling.
+  ///
+  /// @param resourceName
+  /// The name of the font
+  /// @return The loaded font.
+  ///
+  /// @see Font#createFont(int, java.io.File)
+  /// @see Font#getFont(String)
   @Override
   protected Font load(URL resourceName) {
     try (final InputStream fontStream = Resources.get(resourceName)) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ImageFormat.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ImageFormat.java
@@ -2,11 +2,9 @@ package de.gurkenlabs.litiengine.resources;
 
 import java.nio.file.Path;
 
-/**
- * Contains all known image file-formats supported by the engine.
- *
- * @see SoundFormat
- */
+/// Contains all known image file-formats supported by the engine.
+///
+/// @see SoundFormat
 public enum ImageFormat {
   UNSUPPORTED,
   PNG,
@@ -14,37 +12,31 @@ public enum ImageFormat {
   BMP,
   JPG;
 
-  /**
-   * Gets the {@code ImageFormat} of the specified format string.
-   *
-   * @param imageFormat
-   *          The format string from which to extract the format.
-   * @return The format of the specified string or {@code UNDEFINED} if not supported.
-   */
+  /// Gets the `ImageFormat` of the specified format string.
+  ///
+  /// @param imageFormat
+  /// The format string from which to extract the format.
+  /// @return The format of the specified string or `UNDEFINED` if not supported.
   public static ImageFormat get(String imageFormat) {
     return DataFormat.get(imageFormat, values(), UNSUPPORTED);
   }
 
-  /**
-   * Determines whether the extension of the specified file is supported by the engine.
-   *
-   * @param file
-   *          The file to check for.
-   *
-   * @return True if the extension is part of this enum; otherwise false.
-   */
+  /// Determines whether the extension of the specified file is supported by the engine.
+  ///
+  /// @param file
+  /// The file to check for.
+  ///
+  /// @return True if the extension is part of this enum; otherwise false.
   public static boolean isSupported(Path file) {
     return isSupported(file.toString());
   }
 
-  /**
-   * Determines whether the extension of the specified file is supported by the engine.
-   *
-   * @param fileName
-   *          The name of the file to check for.
-   *
-   * @return True if the extension is part of this enum; otherwise false.
-   */
+  /// Determines whether the extension of the specified file is supported by the engine.
+  ///
+  /// @param fileName
+  /// The name of the file to check for.
+  ///
+  /// @return True if the extension is part of this enum; otherwise false.
   public static boolean isSupported(String fileName) {
     return DataFormat.isSupported(fileName, values(), UNSUPPORTED);
   }
@@ -53,12 +45,11 @@ public enum ImageFormat {
     return DataFormat.getAllExtensions(values(), UNSUPPORTED);
   }
 
-  /**
-   * Converts this format instance to a file format string that can be used as an extension (e.g. .png).<br>
-   * It adds a leading '.' to the lower-case string representation of this instance.
-   *
-   * @return The file extension string for this instance.
-   */
+  /// Converts this format instance to a file format string that can be used as an extension (e.g. .png).
+  ///
+  /// It adds a leading '.' to the lower-case string representation of this instance.
+  ///
+  /// @return The file extension string for this instance.
   public String toFileExtension() {
     return "." + this.name().toLowerCase();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Images.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Images.java
@@ -7,18 +7,14 @@ import java.io.IOException;
 import java.net.URL;
 import javax.imageio.ImageIO;
 
-/**
- * A container class for managing image resources. This class extends the ResourcesContainer class, specifically for BufferedImage objects.
- */
+/// A container class for managing image resources. This class extends the ResourcesContainer class, specifically for BufferedImage objects.
 public final class Images extends ResourcesContainer<BufferedImage> {
   Images() {
   }
 
-  /**
-   * Loads all images from the specified texture atlas.
-   *
-   * @param textureAtlas The texture atlas that contains all the images.
-   */
+  /// Loads all images from the specified texture atlas.
+  ///
+  /// @param textureAtlas The texture atlas that contains all the images.
   public void load(TextureAtlas textureAtlas) {
     BufferedImage atlasImage = Resources.images().get(textureAtlas.getAbsoluteImagePath());
     if (atlasImage == null || atlasImage.getWidth() == 0 || atlasImage.getHeight() == 0) {
@@ -35,12 +31,10 @@ public final class Images extends ResourcesContainer<BufferedImage> {
     }
   }
 
-  /**
-   * Loads the image by the specified resourceName. This method supports both loading images from a folder and loading them from the resources.
-   *
-   * @param resourceName The path to the image.
-   * @return the image
-   */
+  /// Loads the image by the specified resourceName. This method supports both loading images from a folder and loading them from the resources.
+  ///
+  /// @param resourceName The path to the image.
+  /// @return the image
   @Override
   protected BufferedImage load(URL resourceName) throws IOException {
     BufferedImage img = ImageIO.read(resourceName);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Maps.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Maps.java
@@ -27,67 +27,60 @@ import java.util.function.IntBinaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * A container class for managing map resources. This class extends the ResourcesContainer class, specifically for IMap objects.
- */
+/// A container class for managing map resources. This class extends the ResourcesContainer class, specifically for IMap objects.
 public final class Maps extends ResourcesContainer<IMap> {
   private static final Logger log = Logger.getLogger(Maps.class.getName());
 
   Maps() {
   }
 
-  /**
-   * Checks if the specified file name has a supported extension.
-   *
-   * @param fileName The name of the file to check.
-   * @return true if the file has a supported extension, false otherwise.
-   */
+  /// Checks if the specified file name has a supported extension.
+  ///
+  /// @param fileName The name of the file to check.
+  /// @return true if the file has a supported extension, false otherwise.
   public static boolean isSupported(String fileName) {
     String extension = FileUtilities.getExtension(fileName);
     return extension.equalsIgnoreCase(TmxMap.FILE_EXTENSION);
   }
 
-  /**
-   * Starts a process that allows the generation of maps from code.
-   * <p>
-   * Notice that you must call this within a try-with block or ensure that {@link MapGenerator#close()} is called before using the generated map
-   * instance.
-   * <p>
-   *
-   * <b>Example usage:</b>
-   *
-   * <pre>
-   * IMap map;
-   * try (MapGenerator generator = Resources.maps().generate("name", 50, 50, 16, 16, Resources.tilesets().get("tileset.tsx"))) {
-   *   ITileLayer tileLayer = generator.addTileLayer(RenderType.GROUND, (x, y) -&gt; {
-   *     if (x == y) {
-   *       // draw a diagonal in another tile color
-   *       return 2;
-   *     }
-   *
-   *     // fill the entire map with this tile
-   *     return 1;
-   *   });
-   *
-   *   // set an explicit tile at a location
-   *   tileLayer.setTile(10, 10, 3);
-   *
-   *   // add a collision box to the map
-   *   generator.add(new CollisionBox(0, 64, 100, 10));
-   *
-   *   map = generator.getMap();
-   * }
-   * </pre>
-   *
-   * @param orientation The orientation of the map to be generated.
-   * @param name        The name of the map to be generated.
-   * @param width       The width (in tiles).
-   * @param height      The height (in tiles).
-   * @param tileWidth   The width of a tile (in pixels).
-   * @param tileHeight  The height of a tile (in pixels).
-   * @param tilesets    Tilesets that will be used by the map.
-   * @return A {@code MapGenerator} instance used to add additional layers or objects to the map.
-   */
+  /// Starts a process that allows the generation of maps from code.
+  ///
+  /// Notice that you must call this within a try-with block or ensure that [MapGenerator#close()] is called before using the generated map
+  /// instance.
+  ///
+  /// **Example usage:**
+  ///
+  /// ```java
+  /// IMap map;
+  /// try (MapGenerator generator = Resources.maps().generate("name", 50, 50, 16, 16, Resources.tilesets().get("tileset.tsx"))) {
+  ///   ITileLayer tileLayer = generator.addTileLayer(RenderType.GROUND, (x, y) -> {
+  ///     if (x == y) {
+  ///       // draw a diagonal in another tile color
+  ///       return 2;
+  ///     }
+  ///
+  ///     // fill the entire map with this tile
+  ///     return 1;
+  ///   });
+  ///
+  ///   // set an explicit tile at a location
+  ///   tileLayer.setTile(10, 10, 3);
+  ///
+  ///   // add a collision box to the map
+  ///   generator.add(new CollisionBox(0, 64, 100, 10));
+  ///
+  ///   map = generator.getMap();
+  /// }
+  /// ```
+  ///
+  /// @param orientation The orientation of the map to be generated.
+  /// @param name        The name of the map to be generated.
+  /// @param width       The width (in tiles).
+  /// @param height      The height (in tiles).
+  /// @param tileWidth   The width of a tile (in pixels).
+  /// @param tileHeight  The height of a tile (in pixels).
+  /// @param tilesets    Tilesets that will be used by the map.
+  /// @return A `MapGenerator` instance used to add additional layers or objects to the map.
   public MapGenerator generate(IMapOrientation orientation, String name, int width, int height, int tileWidth, int tileHeight, ITileset... tilesets) {
     TmxMap map = new TmxMap(orientation);
     map.setTileWidth(tileWidth);
@@ -103,14 +96,12 @@ public final class Maps extends ResourcesContainer<IMap> {
     return new MapGenerator(map);
   }
 
-  /**
-   * Loads an IMap resource from the specified URL.
-   *
-   * @param resourceName The URL of the resource to load.
-   * @return The loaded IMap resource.
-   * @throws IOException        If an I/O error occurs.
-   * @throws URISyntaxException If the URL is not formatted correctly.
-   */
+  /// Loads an IMap resource from the specified URL.
+  ///
+  /// @param resourceName The URL of the resource to load.
+  /// @return The loaded IMap resource.
+  /// @throws IOException        If an I/O error occurs.
+  /// @throws URISyntaxException If the URL is not formatted correctly.
   @Override
   protected IMap load(URL resourceName) throws IOException, URISyntaxException {
     TmxMap map;
@@ -136,9 +127,7 @@ public final class Maps extends ResourcesContainer<IMap> {
     return resource.getName();
   }
 
-  /**
-   * This class provides the API to simplify the generation of map resources from code.
-   */
+  /// This class provides the API to simplify the generation of map resources from code.
   public class MapGenerator implements AutoCloseable {
     private final TmxMap map;
 
@@ -146,40 +135,35 @@ public final class Maps extends ResourcesContainer<IMap> {
       this.map = map;
     }
 
-    /**
-     * Gets the map generated by this instance.
-     * <p>
-     * Make sure this instance is closed before using the map in your game.
-     * </p>
-     *
-     * @return The map generated by this instance.
-     * @see #close()
-     */
+    /// Gets the map generated by this instance.
+    ///
+    /// Make sure this instance is closed before using the map in your game.
+    ///
+    /// @return The map generated by this instance.
+    /// @see #close()
     public IMap getMap() {
       return this.map;
     }
 
-    /**
-     * Adds a new tile tile layer to the generated map of this instance.
-     *
-     * <b>Example for a tileCallback:</b>
-     *
-     * <pre>
-     * (x, y) -&gt; {
-     *   if (x == y) {
-     *     // draw a diagonal in another tile color
-     *     return 2;
-     *   }
-     *
-     *   // fill the entire map with this tile
-     *   return 1;
-     * }
-     * </pre>
-     *
-     * @param renderType   The rendertype of the added layer.
-     * @param tileCallback The callback that defines which tile gid will be assigned at the specified x, y grid coordinates.
-     * @return The newly added tile layer.
-     */
+    /// Adds a new tile tile layer to the generated map of this instance.
+    ///
+    /// **Example for a tileCallback:**
+    ///
+    /// ```java
+    /// (x, y) -> {
+    ///   if (x == y) {
+    ///     // draw a diagonal in another tile color
+    ///     return 2;
+    ///   }
+    ///
+    ///   // fill the entire map with this tile
+    ///   return 1;
+    /// }
+    /// ```
+    ///
+    /// @param renderType   The rendertype of the added layer.
+    /// @param tileCallback The callback that defines which tile gid will be assigned at the specified x, y grid coordinates.
+    /// @return The newly added tile layer.
     public ITileLayer addTileLayer(RenderType renderType, IntBinaryOperator tileCallback) {
       List<Tile> tiles = new ArrayList<>();
       for (int y = 0; y < this.map.getHeight(); y++) {
@@ -207,40 +191,32 @@ public final class Maps extends ResourcesContainer<IMap> {
       return layer;
     }
 
-    /**
-     * Adds a {@code MapObject} created by the specified entity to the map of this instance.
-     * <p>
-     * If no layer has been added yet, a default {@code MapObjectLayer} will be created by this method.
-     * </p>
-     *
-     * @param entity The entity to be converted to a map object and added to the first {@code MapObjectLayer} of the generated map.
-     * @return The created map object.
-     */
+    /// Adds a `MapObject` created by the specified entity to the map of this instance.
+    ///
+    /// If no layer has been added yet, a default `MapObjectLayer` will be created by this method.
+    ///
+    /// @param entity The entity to be converted to a map object and added to the first `MapObjectLayer` of the generated map.
+    /// @return The created map object.
     public IMapObject add(IEntity entity) {
       return this.add(MapObjectSerializer.serialize(entity));
     }
 
-    /**
-     * Adds a {@code MapObject} created by the specified entity to the map of this instance.
-     *
-     * @param layer  The layer to which the map object will be added.
-     * @param entity The entity to be converted to a map object and added to the specified {@code MapObjectLayer}.
-     * @return The created map object.
-     */
+    /// Adds a `MapObject` created by the specified entity to the map of this instance.
+    ///
+    /// @param layer  The layer to which the map object will be added.
+    /// @param entity The entity to be converted to a map object and added to the specified `MapObjectLayer`.
+    /// @return The created map object.
     public IMapObject add(IMapObjectLayer layer, IEntity entity) {
       IMapObject mapObject = MapObjectSerializer.serialize(entity);
       return this.add(layer, mapObject);
     }
 
-    /**
-     * Adds the specified map object to the map of this instance.
-     * <p>
-     * If no layer has been added yet, a default {@code MapObjectLayer} will be created by this method.
-     * </p>
-     *
-     * @param mapObject The mapObject to be added to the first {@code MapObjectLayer} of the generated map.
-     * @return The added map object.
-     */
+    /// Adds the specified map object to the map of this instance.
+    ///
+    /// If no layer has been added yet, a default `MapObjectLayer` will be created by this method.
+    ///
+    /// @param mapObject The mapObject to be added to the first `MapObjectLayer` of the generated map.
+    /// @return The added map object.
     public IMapObject add(IMapObject mapObject) {
       IMapObjectLayer layer;
       if (this.getMap().getMapObjectLayers().isEmpty()) {
@@ -254,26 +230,21 @@ public final class Maps extends ResourcesContainer<IMap> {
       return this.add(layer, mapObject);
     }
 
-    /**
-     * Adds the specified map object to the map of this instance.
-     *
-     * @param layer     The layer to which the map object will be added.
-     * @param mapObject The mapObject to be added to the specified {@code MapObjectLayer}.
-     * @return The added map object.
-     */
+    /// Adds the specified map object to the map of this instance.
+    ///
+    /// @param layer     The layer to which the map object will be added.
+    /// @param mapObject The mapObject to be added to the specified `MapObjectLayer`.
+    /// @return The added map object.
     public IMapObject add(IMapObjectLayer layer, IMapObject mapObject) {
       layer.addMapObject(mapObject);
       return mapObject;
     }
 
-    /**
-     * <b>It is crucial to call this before using the generated map of this instance.</b><br>
-     * <p>
-     * This will call the {@code finish} method on the map instance and make sure that the generated map is available over the resources API.
-     * </p>
-     *
-     * @see TmxMap#finish(URL)
-     */
+    /// **It is crucial to call this before using the generated map of this instance.**
+    ///
+    /// This will call the `finish` method on the map instance and make sure that the generated map is available over the resources API.
+    ///
+    /// @see TmxMap#finish(URL)
     @Override
     public void close() {
       try {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/NamedResource.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/NamedResource.java
@@ -3,30 +3,24 @@ package de.gurkenlabs.litiengine.resources;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 
-/**
- * An abstract class representing a named resource. This class implements the Resource interface and provides methods to get and set the resource
- * name.
- */
+/// An abstract class representing a named resource. This class implements the Resource interface and provides methods to get and set the resource
+/// name.
 public abstract class NamedResource implements Resource {
   @XmlAttribute
   private String name;
 
-  /**
-   * Gets the name of the resource.
-   *
-   * @return The name of the resource.
-   */
+  /// Gets the name of the resource.
+  ///
+  /// @return The name of the resource.
   @XmlTransient
   @Override
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Sets the name of the resource.
-   *
-   * @param n The new name of the resource.
-   */
+  /// Sets the name of the resource.
+  ///
+  /// @param n The new name of the resource.
   @Override
   public void setName(final String n) {
     this.name = n;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resource.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resource.java
@@ -2,31 +2,23 @@ package de.gurkenlabs.litiengine.resources;
 
 import de.gurkenlabs.litiengine.util.AlphanumComparator;
 
-/**
- * Represents a resource that can be compared to other resources. This interface extends the Comparable interface for Resource objects.
- */
+/// Represents a resource that can be compared to other resources. This interface extends the Comparable interface for Resource objects.
 public interface Resource extends Comparable<Resource> {
 
-  /**
-   * Gets the name of the resource.
-   *
-   * @return The name of the resource.
-   */
+  /// Gets the name of the resource.
+  ///
+  /// @return The name of the resource.
   String getName();
 
-  /**
-   * Sets the name of the resource.
-   *
-   * @param name The new name of the resource.
-   */
+  /// Sets the name of the resource.
+  ///
+  /// @param name The new name of the resource.
   void setName(String name);
 
-  /**
-   * Compares this resource with the specified resource for order.
-   *
-   * @param obj The resource to be compared.
-   * @return A negative integer, zero, or a positive integer as this resource is less than, equal to, or greater than the specified resource.
-   */
+  /// Compares this resource with the specified resource for order.
+  ///
+  /// @param obj The resource to be compared.
+  /// @return A negative integer, zero, or a positive integer as this resource is less than, equal to, or greater than the specified resource.
   @Override
   default int compareTo(Resource obj) {
     return AlphanumComparator.compareTo(this.getName(), obj.getName());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceBundle.java
@@ -39,10 +39,8 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipException;
 
-/**
- * Represents a resource bundle that can be serialized. This class is used to manage various game resources such as maps, sprite sheets, tilesets,
- * emitters, blueprints, and sounds.
- */
+/// Represents a resource bundle that can be serialized. This class is used to manage various game resources such as maps, sprite sheets, tilesets,
+/// emitters, blueprints, and sounds.
 @XmlRootElement(name = "litidata")
 public class ResourceBundle implements Serializable {
   private static final Logger log = Logger.getLogger(ResourceBundle.class.getName());
@@ -90,9 +88,7 @@ public class ResourceBundle implements Serializable {
   @XmlElement(name = "sound")
   private final List<SoundResource> sounds;
 
-  /**
-   * Constructs a new ResourceBundle instance. Initializes the lists for sprite sheets, maps, tilesets, emitters, blueprints, and sounds.
-   */
+  /// Constructs a new ResourceBundle instance. Initializes the lists for sprite sheets, maps, tilesets, emitters, blueprints, and sounds.
   public ResourceBundle() {
     this.spriteSheets = new ArrayList<>();
     this.maps = new ArrayList<>();
@@ -105,12 +101,10 @@ public class ResourceBundle implements Serializable {
     this.sounds = new ArrayList<>();
   }
 
-  /**
-   * Loads a ResourceBundle from a Path.
-   *
-   * @param filePath The Path to load the ResourceBundle from.
-   * @return The loaded ResourceBundle, or null if loading fails.
-   */
+  /// Loads a ResourceBundle from a Path.
+  ///
+  /// @param filePath The Path to load the ResourceBundle from.
+  /// @return The loaded ResourceBundle, or null if loading fails.
   public static ResourceBundle load(Path filePath) {
     if (!Files.exists(filePath)) {
       log.log(Level.WARNING, "File does not exist: {0}", filePath);
@@ -157,24 +151,20 @@ public class ResourceBundle implements Serializable {
     return null;
   }
 
-  /**
-   * Loads a ResourceBundle from a string file path (convenience overload).
-   *
-   * @param filePath The file path as a string to load the ResourceBundle from.
-   * @return The loaded ResourceBundle, or null if loading fails.
-   */
+  /// Loads a ResourceBundle from a string file path (convenience overload).
+  ///
+  /// @param filePath The file path as a string to load the ResourceBundle from.
+  /// @return The loaded ResourceBundle, or null if loading fails.
   public static ResourceBundle load(String filePath) {
     return load(Path.of(filePath));
   }
 
 
-  /**
-   * Loads a ResourceBundle from a URL (convenience overload). This method uses the Resources utility to resolve the URL and then delegates to the
-   * Path-based method.
-   *
-   * @param fileUrl The URL to load the ResourceBundle from.
-   * @return The loaded ResourceBundle, or null if loading fails.
-   */
+  /// Loads a ResourceBundle from a URL (convenience overload). This method uses the Resources utility to resolve the URL and then delegates to the
+  /// Path-based method.
+  ///
+  /// @param fileUrl The URL to load the ResourceBundle from.
+  /// @return The loaded ResourceBundle, or null if loading fails.
   public static ResourceBundle load(final URL fileUrl) {
     try {
       ResourceBundle gameFile = getResourceBundleFromUrl(fileUrl);
@@ -214,91 +204,77 @@ public class ResourceBundle implements Serializable {
     return null;
   }
 
-  /**
-   * Gets the list of maps in this resource bundle.
-   *
-   * @return The list of maps.
-   */
+  /// Gets the list of maps in this resource bundle.
+  ///
+  /// @return The list of maps.
   @XmlTransient
   public List<TmxMap> getMaps() {
     return this.maps;
   }
 
-  /**
-   * Gets the list of sprite sheets in this resource bundle.
-   *
-   * @return The list of sprite sheets.
-   */
+  /// Gets the list of sprite sheets in this resource bundle.
+  ///
+  /// @return The list of sprite sheets.
   @XmlTransient
   public List<SpritesheetResource> getSpriteSheets() {
     return this.spriteSheets;
   }
 
-  /**
-   * Gets the list of tilesets in this resource bundle.
-   *
-   * @return The list of tilesets.
-   */
+  /// Gets the list of tilesets in this resource bundle.
+  ///
+  /// @return The list of tilesets.
   @XmlTransient
   public List<Tileset> getTilesets() {
     return this.tilesets;
   }
 
-  /**
-   * Gets the list of emitters in this resource bundle.
-   *
-   * @return The list of emitters.
-   */
+  /// Gets the list of emitters in this resource bundle.
+  ///
+  /// @return The list of emitters.
   @XmlTransient
   public List<EmitterAttributes> getEmitters() {
     return this.emitters;
   }
 
-  /**
-   * Gets the list of blueprints in this resource bundle.
-   *
-   * @return The list of blueprints.
-   */
+  /// Gets the list of blueprints in this resource bundle.
+  ///
+  /// @return The list of blueprints.
   @XmlTransient
   public List<Blueprint> getBluePrints() {
     return this.blueprints;
   }
 
-  /** Gets reusable Java and runtime script definitions. */
+  /// Gets reusable Java and runtime script definitions.
   @XmlTransient
   public List<ScriptDefinition> getScripts() {
     return this.scripts;
   }
 
-  /** Gets scripts attached to the game lifecycle. */
+  /// Gets scripts attached to the game lifecycle.
   @XmlTransient
   public List<ScriptBinding> getGameScripts() {
     return this.gameScripts;
   }
 
-  /** Gets reusable script bindings that apply to entity project types. */
+  /// Gets reusable script bindings that apply to entity project types.
   @XmlTransient
   public List<EntityScriptBinding> getEntityScripts() {
     return this.entityScripts;
   }
 
-  /**
-   * Gets the list of sounds in this resource bundle.
-   *
-   * @return The list of sounds.
-   */
+  /// Gets the list of sounds in this resource bundle.
+  ///
+  /// @return The list of sounds.
   @XmlTransient
   public List<SoundResource> getSounds() {
     return this.sounds;
   }
 
-  /**
-   * Saves the ResourceBundle to a file.
-   *
-   * @param fileName The name of the file to save the ResourceBundle to.
-   * @param compress Whether to compress the file or not.
-   * @return The path of the saved file as a string.
-   */
+  /// Saves the ResourceBundle to a file.
+  ///
+  /// @param fileName The name of the file to save the ResourceBundle to.
+  /// @param compress Whether to compress the file or not.
+  /// @return The path of the saved file as a string.
   public String save(final String fileName, final boolean compress) {
     String fileNameWithExtension = fileName;
     if (!fileNameWithExtension.endsWith("." + FILE_EXTENSION)) {
@@ -349,12 +325,10 @@ public class ResourceBundle implements Serializable {
     return newFile.toString();
   }
 
-  /**
-   * Prepares the ResourceBundle for marshalling. This method ensures that the lists of sprite sheets and tilesets contain only distinct elements. It
-   * also sets the version of the ResourceBundle if it is not already set.
-   *
-   * @param m The Marshaller instance used for marshalling.
-   */
+  /// Prepares the ResourceBundle for marshalling. This method ensures that the lists of sprite sheets and tilesets contain only distinct elements. It
+  /// also sets the version of the ResourceBundle if it is not already set.
+  ///
+  /// @param m The Marshaller instance used for marshalling.
   void beforeMarshal(Marshaller m) {
     List<SpritesheetResource> distinctList = new ArrayList<>();
     for (SpritesheetResource sprite : this.getSpriteSheets()) {
@@ -383,15 +357,13 @@ public class ResourceBundle implements Serializable {
     }
   }
 
-  /**
-   * Retrieves a ResourceBundle from a specified Path. This method attempts to load the ResourceBundle from a compressed GZIP stream first. If that
-   * fails, it falls back to loading from plain XML.
-   *
-   * @param filePath The Path of the resource bundle file.
-   * @return The loaded ResourceBundle.
-   * @throws JAXBException If an error occurs during the unmarshalling process.
-   * @throws IOException   If an I/O error occurs.
-   */
+  /// Retrieves a ResourceBundle from a specified Path. This method attempts to load the ResourceBundle from a compressed GZIP stream first. If that
+  /// fails, it falls back to loading from plain XML.
+  ///
+  /// @param filePath The Path of the resource bundle file.
+  /// @return The loaded ResourceBundle.
+  /// @throws JAXBException If an error occurs during the unmarshalling process.
+  /// @throws IOException   If an I/O error occurs.
   private static ResourceBundle getResourceBundle(Path filePath) throws JAXBException, IOException {
     final JAXBContext jaxbContext = XmlUtilities.getContext(ResourceBundle.class);
     final Unmarshaller um = Objects.requireNonNull(jaxbContext).createUnmarshaller();
@@ -407,15 +379,13 @@ public class ResourceBundle implements Serializable {
     }
   }
 
-  /**
-   * Retrieves a ResourceBundle from a specified URL. This method attempts to load the ResourceBundle from a compressed GZIP stream first. If that
-   * fails, it falls back to loading from plain XML.
-   *
-   * @param fileUrl The URL of the resource bundle file.
-   * @return The loaded ResourceBundle.
-   * @throws JAXBException If an error occurs during the unmarshalling process.
-   * @throws IOException   If an I/O error occurs.
-   */
+  /// Retrieves a ResourceBundle from a specified URL. This method attempts to load the ResourceBundle from a compressed GZIP stream first. If that
+  /// fails, it falls back to loading from plain XML.
+  ///
+  /// @param fileUrl The URL of the resource bundle file.
+  /// @return The loaded ResourceBundle.
+  /// @throws JAXBException If an error occurs during the unmarshalling process.
+  /// @throws IOException   If an I/O error occurs.
   private static ResourceBundle getResourceBundleFromUrl(URL fileUrl) throws JAXBException, IOException {
     final JAXBContext jaxbContext = XmlUtilities.getContext(ResourceBundle.class);
     final Unmarshaller um = Objects.requireNonNull(jaxbContext).createUnmarshaller();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceLoadException.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourceLoadException.java
@@ -2,42 +2,32 @@ package de.gurkenlabs.litiengine.resources;
 
 import java.io.Serial;
 
-/**
- * Exception thrown when a resource fails to load.
- */
+/// Exception thrown when a resource fails to load.
 public class ResourceLoadException extends RuntimeException {
   @Serial private static final long serialVersionUID = 2690585643366673974L;
 
-  /**
-   * Constructs a new ResourceLoadException with {@code null} as its detail message.
-   */
+  /// Constructs a new ResourceLoadException with `null` as its detail message.
   public ResourceLoadException() {
   }
 
-  /**
-   * Constructs a new ResourceLoadException with the specified detail message.
-   *
-   * @param message The detail message.
-   */
+  /// Constructs a new ResourceLoadException with the specified detail message.
+  ///
+  /// @param message The detail message.
   public ResourceLoadException(String message) {
     super(message);
   }
 
-  /**
-   * Constructs a new ResourceLoadException with the specified cause.
-   *
-   * @param cause The cause of the exception.
-   */
+  /// Constructs a new ResourceLoadException with the specified cause.
+  ///
+  /// @param cause The cause of the exception.
   public ResourceLoadException(Throwable cause) {
     super(cause);
   }
 
-  /**
-   * Constructs a new ResourceLoadException with the specified detail message and cause.
-   *
-   * @param message The detail message.
-   * @param cause   The cause of the exception.
-   */
+  /// Constructs a new ResourceLoadException with the specified detail message and cause.
+  ///
+  /// @param message The detail message.
+  /// @param cause   The cause of the exception.
   public ResourceLoadException(String message, Throwable cause) {
     super(message, cause);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resources.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Resources.java
@@ -28,25 +28,20 @@ import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * This class is the engines entry point for accessing any kind of resources. A resource is any non-executable data that is deployed with your game.
- * The {@code Resources} class provides access to types of {@code ResourcesContainers} and is used by different (loading) mechanisms to make resources
- * available during runtime.
- * <p>
- * The LITIENGINE supports a variety of different resource types, including:
- * </p>
- *
- * <ul>
- * <li>images</li>
- * <li>fonts</li>
- * <li>maps</li>
- * <li>(localizable) strings</li>
- * <li>spritesheets</li>
- * <li>sounds</li>
- * </ul>
- *
- * @see ResourcesContainer
- */
+/// This class is the engines entry point for accessing any kind of resources. A resource is any non-executable data that is deployed with your game.
+/// The `Resources` class provides access to types of `ResourcesContainers` and is used by different (loading) mechanisms to make resources
+/// available during runtime.
+///
+/// The LITIENGINE supports a variety of different resource types, including:
+///
+/// - images
+/// - fonts
+/// - maps
+/// - (localizable) strings
+/// - spritesheets
+/// - sounds
+///
+/// @see ResourcesContainer
 public final class Resources {
   private static final Logger log = Logger.getLogger(Resources.class.getName());
   private static Fonts fonts = new Fonts();
@@ -63,117 +58,95 @@ public final class Resources {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Gets the container that manages {@code Font} resources.
-   *
-   * @return The Font resource container.
-   * @see Font
-   */
+  /// Gets the container that manages `Font` resources.
+  ///
+  /// @return The Font resource container.
+  /// @see Font
   public static Fonts fonts() {
     return fonts;
   }
 
-  /**
-   * Gets the container that manages {@code Sound} resources.
-   *
-   * @return The Sound resource container.
-   * @see Sound
-   */
+  /// Gets the container that manages `Sound` resources.
+  ///
+  /// @return The Sound resource container.
+  /// @see Sound
   public static Sounds sounds() {
     return sounds;
   }
 
-  /**
-   * Gets the container that manages {@code IMap} resources.
-   *
-   * @return The IMap resource container.
-   * @see IMap
-   */
+  /// Gets the container that manages `IMap` resources.
+  ///
+  /// @return The IMap resource container.
+  /// @see IMap
   public static Maps maps() {
     return maps;
   }
 
-  /**
-   * Gets the container that manages {@code Tileset} resources.<br> This implementation uses raw {@code Tileset}s, to avoid problems with
-   * {@code Tileset} methods that aren't in the {@code ITileset} interface.
-   *
-   * @return The Tileset resource container.
-   * @see Tileset
-   */
+  /// Gets the container that manages `Tileset` resources.
+  /// This implementation uses raw `Tileset`s, to avoid problems with
+  /// `Tileset` methods that aren't in the `ITileset` interface.
+  ///
+  /// @return The Tileset resource container.
+  /// @see Tileset
   public static Tilesets tilesets() {
     return tilesets;
   }
 
-  /**
-   * Gets a container that manages {@code String} resources.<br> This instance can be used to access localizable string from a ".properties" file.
-   *
-   * @return The String resource container.
-   */
+  /// Gets a container that manages `String` resources.
+  /// This instance can be used to access localizable string from a ".properties" file.
+  ///
+  /// @return The String resource container.
   public static Strings strings() {
     return strings;
   }
 
-  /**
-   * Gets the container that manages {@code BufferedImage} resources.
-   *
-   * @return The BufferedImage resource container.
-   * @see BufferedImage
-   */
+  /// Gets the container that manages `BufferedImage` resources.
+  ///
+  /// @return The BufferedImage resource container.
+  /// @see BufferedImage
   public static Images images() {
     return images;
   }
 
-  /**
-   * Gets the container that manages {@code Spritesheet} resources.
-   *
-   * @return The Spritesheet resource container.
-   * @see Spritesheet
-   */
+  /// Gets the container that manages `Spritesheet` resources.
+  ///
+  /// @return The Spritesheet resource container.
+  /// @see Spritesheet
   public static Spritesheets spritesheets() {
     return spritesheets;
   }
 
-  /**
-   * Gets the container that manages {@code Blueprint} resources.
-   *
-   * @return The Blueprint resource container.
-   * @see Blueprint
-   */
+  /// Gets the container that manages `Blueprint` resources.
+  ///
+  /// @return The Blueprint resource container.
+  /// @see Blueprint
   public static Blueprints blueprints() {
     return blueprints;
   }
 
-  /**
-   * Gets the container that manages {@code Animation} resources.
-   *
-   * <p>
-   * Animations can be imported from <a href="https://www.aseprite.org/docs/cli/#filename-format">Aseprite</a>
-   * JSON exports and re-exported to the same format via this container.
-   * </p>
-   *
-   * @return The Animation resource container.
-   * @see Animation
-   */
+  /// Gets the container that manages `Animation` resources.
+  ///
+  /// Animations can be imported from [Aseprite](https://www.aseprite.org/docs/cli/#filename-format)
+  /// JSON exports and re-exported to the same format via this container.
+  ///
+  /// @return The Animation resource container.
+  /// @see Animation
   public static Animations animations() {
     return animations;
   }
 
-  /**
-   * Load {@code Spritesheets}, {@code Tilesets} and {@code Maps} from a game resource file created with the utiLITI editor. After loading, these
-   * resources can be accessed via this API (e.g. {@code Resources.maps().get("mapname")}.
-   *
-   * @param gameResourceFile The file name of the game resource file
-   */
+  /// Load `Spritesheets`, `Tilesets` and `Maps` from a game resource file created with the utiLITI editor. After loading, these
+  /// resources can be accessed via this API (e.g. `Resources.maps().get("mapname")`.
+  ///
+  /// @param gameResourceFile The file name of the game resource file
   public static void load(final String gameResourceFile) {
     load(getLocation(gameResourceFile));
   }
 
-  /**
-   * Load {@code Spritesheets}, {@code Tilesets} and {@code Maps} from a game resource file created with the utiLITI editor. After loading, these
-   * resources can be accessed via this API (e.g. {@code Resources.maps().get("mapname")}.
-   *
-   * @param gameResourceFile The URL to the game resource file
-   */
+  /// Load `Spritesheets`, `Tilesets` and `Maps` from a game resource file created with the utiLITI editor. After loading, these
+  /// resources can be accessed via this API (e.g. `Resources.maps().get("mapname")`.
+  ///
+  /// @param gameResourceFile The URL to the game resource file
   public static void load(final URL gameResourceFile) {
     final long loadStart = System.nanoTime();
 
@@ -292,24 +265,20 @@ public final class Resources {
     log.log(Level.INFO, "loading game resources from {0} took {1} ms", new Object[] {gameResourceFile, loadTime});
   }
 
-  /**
-   * Gets the specified file as InputStream from either a resource folder or the file system.
-   *
-   * @param file The path to the file.
-   * @return The contents of the specified file as {@code InputStream}.
-   * @see Resources
-   */
+  /// Gets the specified file as InputStream from either a resource folder or the file system.
+  ///
+  /// @param file The path to the file.
+  /// @return The contents of the specified file as `InputStream`.
+  /// @see Resources
   public static InputStream get(String file) {
     return get(getLocation(file));
   }
 
-  /**
-   * Gets the specified file as InputStream from either a resource folder or the file system.
-   *
-   * @param file The path to the file.
-   * @return The contents of the specified file as {@code InputStream}.
-   * @see Resources
-   */
+  /// Gets the specified file as InputStream from either a resource folder or the file system.
+  ///
+  /// @param file The path to the file.
+  /// @return The contents of the specified file as `InputStream`.
+  /// @see Resources
   public static InputStream get(URL file) {
     InputStream stream = getResource(file);
     if (stream == null) {
@@ -319,24 +288,21 @@ public final class Resources {
     return stream.markSupported() ? stream : new BufferedInputStream(stream);
   }
 
-  /**
-   * Reads the specified file as String from either a resource folder or the file system.<br> Since no {@code Charset} is specified with this
-   * overload, the implementation uses UTF-8 by default.
-   *
-   * @param file The path to the file.
-   * @return The contents of the specified file as {@code String}
-   */
+  /// Reads the specified file as String from either a resource folder or the file system.
+  /// Since no `Charset` is specified with this
+  /// overload, the implementation uses UTF-8 by default.
+  ///
+  /// @param file The path to the file.
+  /// @return The contents of the specified file as `String`
   public static String read(String file) {
     return read(file, StandardCharsets.UTF_8);
   }
 
-  /**
-   * Reads the specified file as String from either a resource folder or the file system.<br>
-   *
-   * @param file    The path to the file.
-   * @param charset The charset that is used to read the String from the file.
-   * @return The contents of the specified file as {@code String}
-   */
+  /// Reads the specified file as String from either a resource folder or the file system.
+  ///
+  /// @param file    The path to the file.
+  /// @param charset The charset that is used to read the String from the file.
+  /// @return The contents of the specified file as `String`
   public static String read(String file, Charset charset) {
     final URL location = getLocation(file);
     if (location == null) {
@@ -346,24 +312,21 @@ public final class Resources {
     return read(location, charset);
   }
 
-  /**
-   * Reads the specified file as String from either a resource folder or the file system.<br> Since no {@code Charset} is specified with this
-   * overload, the implementation uses UTF-8 by default.
-   *
-   * @param file The path to the file.
-   * @return The contents of the specified file as {@code String}
-   */
+  /// Reads the specified file as String from either a resource folder or the file system.
+  /// Since no `Charset` is specified with this
+  /// overload, the implementation uses UTF-8 by default.
+  ///
+  /// @param file The path to the file.
+  /// @return The contents of the specified file as `String`
   public static String read(URL file) {
     return read(file, StandardCharsets.UTF_8);
   }
 
-  /**
-   * Reads the specified file as String from either a resource folder or the file system.<br>
-   *
-   * @param file    The path to the file.
-   * @param charset The charset that is used to read the String from the file.
-   * @return The contents of the specified file as {@code String}
-   */
+  /// Reads the specified file as String from either a resource folder or the file system.
+  ///
+  /// @param file    The path to the file.
+  /// @param charset The charset that is used to read the String from the file.
+  /// @return The contents of the specified file as `String`
   public static String read(URL file, Charset charset) {
     try (Scanner scanner = new Scanner(file.openStream(), charset)) {
       scanner.useDelimiter("\\A");
@@ -374,9 +337,7 @@ public final class Resources {
     }
   }
 
-  /**
-   * Clears the all resource containers by removing previously loaded resources.
-   */
+  /// Clears the all resource containers by removing previously loaded resources.
   public static void clearAll() {
     Game.scripts().detachAll();
     Game.scripts().setDefinitions(List.of());
@@ -391,13 +352,11 @@ public final class Resources {
     animations().clear();
   }
 
-  /**
-   * Gets the location of the specified resource. This method attempts to find the resource using the system class loader first. If the resource is
-   * not found, it tries to locate it as a file in the file system.
-   *
-   * @param name The name of the resource.
-   * @return The URL of the resource, or null if the resource could not be found.
-   */
+  /// Gets the location of the specified resource. This method attempts to find the resource using the system class loader first. If the resource is
+  /// not found, it tries to locate it as a file in the file system.
+  ///
+  /// @param name The name of the resource.
+  /// @return The URL of the resource, or null if the resource could not be found.
   public static URL getLocation(String name) {
     if (name == null || name.isBlank()) {
       return null;
@@ -417,12 +376,10 @@ public final class Resources {
     }
   }
 
-  /**
-   * Retrieves an InputStream for the specified URL. This method attempts to open a stream to the resource located at the given URL.
-   *
-   * @param file The URL of the resource to be accessed.
-   * @return An InputStream to the resource, or null if an I/O error occurs.
-   */
+  /// Retrieves an InputStream for the specified URL. This method attempts to open a stream to the resource located at the given URL.
+  ///
+  /// @param file The URL of the resource to be accessed.
+  /// @return An InputStream to the resource, or null if an I/O error occurs.
   private static InputStream getResource(final URL file) {
     try {
       return file.openStream();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourcesContainer.java
@@ -16,13 +16,11 @@ import java.util.concurrent.Future;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-/**
- * An abstract implementation for all classes that provide a certain type of resources. Basically, it's an in-memory cache of the resources and
- * provides access to manage the resources.
- *
- * @param <T> The type of the resource that is contained by this instance.
- * @see ResourcesContainerListener
- */
+/// An abstract implementation for all classes that provide a certain type of resources. Basically, it's an in-memory cache of the resources and
+/// provides access to manage the resources.
+///
+/// @param <T> The type of the resource that is contained by this instance.
+/// @see ResourcesContainerListener
 public abstract class ResourcesContainer<T> {
 
   // use a work-stealing pool to maximize resource load speed while minimizing the number of resources
@@ -43,62 +41,52 @@ public abstract class ResourcesContainer<T> {
     });
   }
 
-  /**
-   * Add a new container listener to this instance in order to observe resource life cycles. The listener will get notified whenever a resource was
-   * added to or removed from this container.
-   *
-   * @param listener The container listener instance that will receive call backs from this container.
-   * @see #removeContainerListener(ResourcesContainerListener)
-   */
+  /// Add a new container listener to this instance in order to observe resource life cycles. The listener will get notified whenever a resource was
+  /// added to or removed from this container.
+  ///
+  /// @param listener The container listener instance that will receive call backs from this container.
+  /// @see #removeContainerListener(ResourcesContainerListener)
   public void addContainerListener(ResourcesContainerListener<? super T> listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Remove the specified listener from this container.
-   *
-   * @param listener The listener instance that was previously added to this container.
-   * @see #addContainerListener(ResourcesContainerListener)
-   */
+  /// Remove the specified listener from this container.
+  ///
+  /// @param listener The listener instance that was previously added to this container.
+  /// @see #addContainerListener(ResourcesContainerListener)
   public void removeContainerListener(ResourcesContainerListener<T> listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Add a new container listener to this instance that observes whenever this instance is cleared.
-   *
-   * @param listener The container listener instance.
-   * @see #removeClearedListener(ResourcesContainerClearedListener)
-   */
+  /// Add a new container listener to this instance that observes whenever this instance is cleared.
+  ///
+  /// @param listener The container listener instance.
+  /// @see #removeClearedListener(ResourcesContainerClearedListener)
   public void addClearedListener(ResourcesContainerClearedListener listener) {
     this.clearedListeners.add(listener);
   }
 
-  /**
-   * Remove the specified listener from this container.
-   *
-   * @param listener The listener instance that was previously added to this container.
-   * @see #addClearedListener(ResourcesContainerClearedListener)
-   */
+  /// Remove the specified listener from this container.
+  ///
+  /// @param listener The listener instance that was previously added to this container.
+  /// @see #addClearedListener(ResourcesContainerClearedListener)
   public void removeClearedListener(ResourcesContainerClearedListener listener) {
     this.clearedListeners.remove(listener);
   }
 
-  /**
-   * Add the specified resource to this container.<br> The added element can later be retrieved from this container by calling
-   * {@code get(resourceName)}.
-   * <p>
-   * Use this method to make a resource accessible over this container during runtime.
-   * </p>
-   *
-   * @param resourceName The name that the resource is managed by.
-   * @param resource     The resource instance.
-   * @see #get(Predicate)
-   * @see #get(String)
-   * @see #get(String, boolean)
-   * @see #remove(String)
-   * @see #tryGet(String)
-   */
+  /// Add the specified resource to this container.
+  /// The added element can later be retrieved from this container by calling
+  /// `get(resourceName)`.
+  ///
+  /// Use this method to make a resource accessible over this container during runtime.
+  ///
+  /// @param resourceName The name that the resource is managed by.
+  /// @param resource     The resource instance.
+  /// @see #get(Predicate)
+  /// @see #get(String)
+  /// @see #get(String, boolean)
+  /// @see #remove(String)
+  /// @see #tryGet(String)
   public void add(String resourceName, T resource) {
     this.resources.put(resourceName, resource);
 
@@ -107,20 +95,16 @@ public abstract class ResourcesContainer<T> {
     }
   }
 
-  /**
-   * Adds the specified resource to this container using the given URL as the resource name. The added element can later be retrieved from this
-   * container by calling {@code get(resourceName)}.
-   *
-   * @param resourceName The URL of the resource to be added.
-   * @param resource     The resource instance to be added.
-   */
+  /// Adds the specified resource to this container using the given URL as the resource name. The added element can later be retrieved from this
+  /// container by calling `get(resourceName)`.
+  ///
+  /// @param resourceName The URL of the resource to be added.
+  /// @param resource     The resource instance to be added.
   public void add(URL resourceName, T resource) {
     this.add(resourceName.toString(), resource);
   }
 
-  /**
-   * Clears the resource container by removing all previously loaded resources.
-   */
+  /// Clears the resource container by removing all previously loaded resources.
   public void clear() {
     this.resources.clear();
 
@@ -129,55 +113,44 @@ public abstract class ResourcesContainer<T> {
     }
   }
 
-  /**
-   * Checks if this instance contains a resource with the specified name.
-   * <p>
-   * Note that the name is <b>not case-sensitive</b>.
-   * </p>
-   *
-   * @param resourceName The resource's name.
-   * @return True if this container contains a resource with the specified name; otherwise false.
-   * @see ResourcesContainer#contains(Object)
-   */
+  /// Checks if this instance contains a resource with the specified name.
+  ///
+  /// Note that the name is **not case-sensitive**.
+  ///
+  /// @param resourceName The resource's name.
+  /// @return True if this container contains a resource with the specified name; otherwise false.
+  /// @see ResourcesContainer#contains(Object)
   public boolean contains(String resourceName) {
     return this.resources.containsKey(this.getIdentifier(resourceName));
   }
 
-  /**
-   * Checks if this instance contains a resource with the specified URL.
-   *
-   * @param resourceName The URL of the resource.
-   * @return True if this container contains a resource with the specified URL; otherwise false.
-   */
+  /// Checks if this instance contains a resource with the specified URL.
+  ///
+  /// @param resourceName The URL of the resource.
+  /// @return True if this container contains a resource with the specified URL; otherwise false.
   public boolean contains(URL resourceName) {
     return this.contains(resourceName.toString());
   }
 
-  /**
-   * Checks if the specified resource is contained by this instance.
-   *
-   * @param resource The resource.
-   * @return True if this instance contains the specified resource instance; otherwise false.
-   */
+  /// Checks if the specified resource is contained by this instance.
+  ///
+  /// @param resource The resource.
+  /// @return True if this instance contains the specified resource instance; otherwise false.
   public boolean contains(T resource) {
     return this.resources.containsValue(resource);
   }
 
-  /**
-   * Gets the amount of resources that this container holds.
-   *
-   * @return The amount of resources in this container.
-   */
+  /// Gets the amount of resources that this container holds.
+  ///
+  /// @return The amount of resources in this container.
   public int count() {
     return this.resources.size();
   }
 
-  /**
-   * Gets all resources that match the specified condition.
-   *
-   * @param pred The condition that a resource must fulfill in order to be returned.
-   * @return All resources that match the specified condition.
-   */
+  /// Gets all resources that match the specified condition.
+  ///
+  /// @param pred The condition that a resource must fulfill in order to be returned.
+  /// @return All resources that match the specified condition.
   public Collection<T> get(Predicate<? super T> pred) {
     if (pred == null) {
       return new ArrayList<>();
@@ -186,46 +159,36 @@ public abstract class ResourcesContainer<T> {
     return this.resources.values().stream().filter(pred).toList();
   }
 
-  /**
-   * Gets the resource with the specified name.<br>
-   * <p>
-   * This is the most common (and preferred) way to fetch resources from a container.
-   * </p>
-   * <p>
-   * If not previously loaded, this method attempts to load the resource on the fly otherwise it will be retrieved from the cache.
-   * </p>
-   *
-   * @param resourceName The resource's name.
-   * @return The resource with the specified name or null if not found.
-   */
+  /// Gets the resource with the specified name.
+  ///
+  /// This is the most common (and preferred) way to fetch resources from a container.
+  ///
+  /// If not previously loaded, this method attempts to load the resource on the fly otherwise it will be retrieved from the cache.
+  ///
+  /// @param resourceName The resource's name.
+  /// @return The resource with the specified name or null if not found.
   public T get(String resourceName) {
     return this.get(this.getIdentifier(resourceName), false);
   }
 
-  /**
-   * Gets the resource with the specified URL.
-   * <p>
-   * If not previously loaded, this method attempts to load the resource on the fly; otherwise, it will be retrieved from the cache.
-   * </p>
-   *
-   * @param resourceName The URL of the resource.
-   * @return The resource with the specified URL or null if not found.
-   */
+  /// Gets the resource with the specified URL.
+  ///
+  /// If not previously loaded, this method attempts to load the resource on the fly; otherwise, it will be retrieved from the cache.
+  ///
+  /// @param resourceName The URL of the resource.
+  /// @return The resource with the specified URL or null if not found.
   public T get(URL resourceName) {
     return this.get(resourceName, false);
   }
 
-  /**
-   * Gets the resource with the specified name.<br>
-   * <p>
-   * If no such resource is currently present on the container, it will be loaded with the specified {@code loadCallback} and added to this
-   * container.
-   * </p>
-   *
-   * @param resourceName The resource's name.
-   * @param loadCallback The callback that is used to load the resource on-demand if it's not present on this container.
-   * @return T The resource with the specified name.
-   */
+  /// Gets the resource with the specified name.
+  ///
+  /// If no such resource is currently present on the container, it will be loaded with the specified `loadCallback` and added to this
+  /// container.
+  ///
+  /// @param resourceName The resource's name.
+  /// @param loadCallback The callback that is used to load the resource on-demand if it's not present on this container.
+  /// @return T The resource with the specified name.
   public T get(String resourceName, Supplier<? extends T> loadCallback) {
     Optional<T> opt = this.tryGet(resourceName);
     if (opt.isPresent()) {
@@ -241,31 +204,25 @@ public abstract class ResourcesContainer<T> {
 
   }
 
-  /**
-   * Gets the resource with the specified URL.
-   * <p>
-   * If no such resource is currently present in the container, it will be loaded with the specified {@code loadCallback} and added to this
-   * container.
-   * </p>
-   *
-   * @param resourceName The URL of the resource.
-   * @param loadCallback The callback that is used to load the resource on-demand if it's not present in this container.
-   * @return The resource with the specified URL.
-   */
+  /// Gets the resource with the specified URL.
+  ///
+  /// If no such resource is currently present in the container, it will be loaded with the specified `loadCallback` and added to this
+  /// container.
+  ///
+  /// @param resourceName The URL of the resource.
+  /// @param loadCallback The callback that is used to load the resource on-demand if it's not present in this container.
+  /// @return The resource with the specified URL.
   public T get(URL resourceName, Supplier<? extends T> loadCallback) {
     return this.get(resourceName.toString(), loadCallback);
   }
 
-  /**
-   * Gets the resource with the specified name.
-   * <p>
-   * If not previously loaded, this method attempts to load the resource on the fly otherwise it will be retrieved from the cache.
-   * </p>
-   *
-   * @param resourceName The name of the game resource.
-   * @param forceLoad    If set to true, cached resource (if existing) will be discarded and the resource will be freshly loaded.
-   * @return The game resource or null if not found.
-   */
+  /// Gets the resource with the specified name.
+  ///
+  /// If not previously loaded, this method attempts to load the resource on the fly otherwise it will be retrieved from the cache.
+  ///
+  /// @param resourceName The name of the game resource.
+  /// @param forceLoad    If set to true, cached resource (if existing) will be discarded and the resource will be freshly loaded.
+  /// @return The game resource or null if not found.
   public T get(String resourceName, boolean forceLoad) {
     if (resourceName == null || resourceName.isBlank()) {
       return null;
@@ -285,57 +242,46 @@ public abstract class ResourcesContainer<T> {
     }
   }
 
-  /**
-   * Gets the resource with the specified URL.
-   * <p>
-   * If not previously loaded, this method attempts to load the resource on the fly; otherwise, it will be retrieved from the cache.
-   * </p>
-   *
-   * @param resourceName The URL of the resource.
-   * @param forceLoad    If set to true, cached resource (if existing) will be discarded and the resource will be freshly loaded.
-   * @return The resource with the specified URL or null if not found.
-   */
+  /// Gets the resource with the specified URL.
+  ///
+  /// If not previously loaded, this method attempts to load the resource on the fly; otherwise, it will be retrieved from the cache.
+  ///
+  /// @param resourceName The URL of the resource.
+  /// @param forceLoad    If set to true, cached resource (if existing) will be discarded and the resource will be freshly loaded.
+  /// @return The resource with the specified URL or null if not found.
   public T get(URL resourceName, boolean forceLoad) {
     return this.get(resourceName.toString(), forceLoad);
   }
 
-  /**
-   * Eventually gets the resource with the specified location. The resource is loaded asynchronously and can be retrieved from the returned
-   * {@code Future} object returned by this method once loaded.
-   *
-   * @param location The location of the resource
-   * @return A {@code Future} object that can be used to retrieve the resource once it is finished loading
-   */
+  /// Eventually gets the resource with the specified location. The resource is loaded asynchronously and can be retrieved from the returned
+  /// `Future` object returned by this method once loaded.
+  ///
+  /// @param location The location of the resource
+  /// @return A `Future` object that can be used to retrieve the resource once it is finished loading
   public Future<T> getAsync(URL location) {
     return ASYNC_POOL.submit(() -> this.get(location));
   }
 
-  /**
-   * Eventually gets the resource with the specified location. The resource is loaded asynchronously and can be retrieved from the returned
-   * {@code Future} object returned by this method once loaded.
-   *
-   * @param name The name or location of the resource
-   * @return A {@code Future} object that can be used to retrieve the resource once it is finished loading
-   */
+  /// Eventually gets the resource with the specified location. The resource is loaded asynchronously and can be retrieved from the returned
+  /// `Future` object returned by this method once loaded.
+  ///
+  /// @param name The name or location of the resource
+  /// @return A `Future` object that can be used to retrieve the resource once it is finished loading
   public Future<T> getAsync(String name) {
     return this.getAsync(Resources.getLocation(this.getIdentifier(name)));
   }
 
-  /**
-   * Gets all loaded resources from this container.
-   *
-   * @return All loaded resources.
-   */
+  /// Gets all loaded resources from this container.
+  ///
+  /// @return All loaded resources.
   public Collection<T> getAll() {
     return this.resources.values();
   }
 
-  /**
-   * Removes the resource with the specified name from this container.
-   *
-   * @param resourceName The name of the resource that should be removed.
-   * @return The removed resource.
-   */
+  /// Removes the resource with the specified name from this container.
+  ///
+  /// @param resourceName The name of the resource that should be removed.
+  /// @return The removed resource.
   public T remove(String resourceName) {
     T removedResource = this.resources.remove(resourceName);
 
@@ -349,29 +295,25 @@ public abstract class ResourcesContainer<T> {
 
   }
 
-  /**
-   * Removes the resource with the specified URL from this container.
-   *
-   * @param resourceName The URL of the resource that should be removed.
-   * @return The removed resource.
-   */
+  /// Removes the resource with the specified URL from this container.
+  ///
+  /// @param resourceName The URL of the resource that should be removed.
+  /// @return The removed resource.
   public T remove(URL resourceName) {
     return this.remove(resourceName.toString());
   }
 
-  /**
-   * Tries to get a resource with the specified name from this container.
-   * <p>
-   * This method should be used, if it's not clear whether the resource is present on this container.<br> It is basically a combination of
-   * {@code get(String)} and {@code contains(String)} and allows to check whether a resource is present while also fetching it from the container.
-   * </p>
-   *
-   * @param resourceName The name of the resource.
-   * @return An Optional instance that holds the resource instance, if present on this container.
-   * @see Optional
-   * @see #contains(String)
-   * @see #get(String)
-   */
+  /// Tries to get a resource with the specified name from this container.
+  ///
+  /// This method should be used, if it's not clear whether the resource is present on this container.
+  /// It is basically a combination of
+  /// `get(String)` and `contains(String)` and allows to check whether a resource is present while also fetching it from the container.
+  ///
+  /// @param resourceName The name of the resource.
+  /// @return An Optional instance that holds the resource instance, if present on this container.
+  /// @see Optional
+  /// @see #contains(String)
+  /// @see #get(String)
   public Optional<T> tryGet(String resourceName) {
     if (this.contains(resourceName)) {
       return Optional.of(this.get(resourceName));
@@ -380,63 +322,50 @@ public abstract class ResourcesContainer<T> {
     return Optional.empty();
   }
 
-  /**
-   * Tries to get a resource with the specified URL from this container.
-   * <p>
-   * This method should be used if it's not clear whether the resource is present in this container. It is basically a combination of {@code get(URL)}
-   * and {@code contains(URL)} and allows checking whether a resource is present while also fetching it from the container.
-   * </p>
-   *
-   * @param resourceName The URL of the resource.
-   * @return An Optional instance that holds the resource instance, if present in this container.
-   */
+  /// Tries to get a resource with the specified URL from this container.
+  ///
+  /// This method should be used if it's not clear whether the resource is present in this container. It is basically a combination of `get(URL)`
+  /// and `contains(URL)` and allows checking whether a resource is present while also fetching it from the container.
+  ///
+  /// @param resourceName The URL of the resource.
+  /// @return An Optional instance that holds the resource instance, if present in this container.
   public Optional<T> tryGet(URL resourceName) {
     return this.tryGet(resourceName.getPath());
   }
 
-  /**
-   * Loads the resource with the specified URL.
-   * <p>
-   * This method must be implemented by subclasses to define how a resource is loaded from the given URL.
-   * </p>
-   *
-   * @param resourceName The URL of the resource to be loaded.
-   * @return The loaded resource.
-   * @throws Exception If an error occurs while loading the resource.
-   */
+  /// Loads the resource with the specified URL.
+  ///
+  /// This method must be implemented by subclasses to define how a resource is loaded from the given URL.
+  ///
+  /// @param resourceName The URL of the resource to be loaded.
+  /// @return The loaded resource.
+  /// @throws Exception If an error occurs while loading the resource.
   protected abstract T load(URL resourceName) throws Exception;
 
-  /**
-   * Gets an alias for the specified resourceName. Note that the process of providing an alias is up to the ResourceContainer implementation.
-   *
-   * @param resourceName The original name of the resource.
-   * @param resource     The resource.
-   * @return An alias for the specified resource.
-   */
+  /// Gets an alias for the specified resourceName. Note that the process of providing an alias is up to the ResourceContainer implementation.
+  ///
+  /// @param resourceName The original name of the resource.
+  /// @param resource     The resource.
+  /// @return An alias for the specified resource.
   protected String getAlias(String resourceName, T resource) {
     return null;
   }
 
-  /**
-   * Gets the map of resources contained in this container.
-   *
-   * @return A map where the keys are resource names and the values are the resources.
-   */
+  /// Gets the map of resources contained in this container.
+  ///
+  /// @return A map where the keys are resource names and the values are the resources.
   protected Map<String, T> getResources() {
     return this.resources;
   }
 
-  /**
-   * Loads the resource with the specified identifier.
-   * <p>
-   * This method attempts to load the resource using the provided identifier. If the resource is successfully loaded, it notifies all registered
-   * listeners and updates the alias map if an alias is provided.
-   * </p>
-   *
-   * @param identifier The identifier of the resource to be loaded.
-   * @return The loaded resource.
-   * @throws ResourceLoadException If an error occurs while loading the resource.
-   */
+  /// Loads the resource with the specified identifier.
+  ///
+  /// This method attempts to load the resource using the provided identifier. If the resource is successfully loaded, it notifies all registered
+  /// listeners and updates the alias map if an alias is provided.
+  ///
+  /// @param identifier The identifier of the resource to be loaded.
+  /// @return The loaded resource.
+  /// @throws ResourceLoadException If an error occurs while loading the resource.
   private T loadResource(String identifier) {
     T newResource;
     try {
@@ -457,17 +386,14 @@ public abstract class ResourcesContainer<T> {
     return newResource;
   }
 
-  /**
-   * Gets the identifier for the specified resource name.
-   * <p>
-   * This method first attempts a case-sensitive lookup against the registered aliases and loaded resources. If no exact match is found, it falls back
-   * to a case-insensitive lookup so that already loaded or aliased resources can be retrieved regardless of the casing of the requested name. This
-   * prevents misleading errors (e.g. XML parse failures) when a resource is requested with the wrong capitalization.
-   * </p>
-   *
-   * @param resourceName The name of the resource.
-   * @return The identifier for the resource, which may be an alias or the original resource name.
-   */
+  /// Gets the identifier for the specified resource name.
+  ///
+  /// This method first attempts a case-sensitive lookup against the registered aliases and loaded resources. If no exact match is found, it falls back
+  /// to a case-insensitive lookup so that already loaded or aliased resources can be retrieved regardless of the casing of the requested name. This
+  /// prevents misleading errors (e.g. XML parse failures) when a resource is requested with the wrong capitalization.
+  ///
+  /// @param resourceName The name of the resource.
+  /// @return The identifier for the resource, which may be an alias or the original resource name.
   private String getIdentifier(String resourceName) {
     if (resourceName == null) {
       return null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourcesContainerClearedListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourcesContainerClearedListener.java
@@ -2,17 +2,12 @@ package de.gurkenlabs.litiengine.resources;
 
 import java.util.EventListener;
 
-/**
- * This listener provides a callback for when a {@code ResourcesContainer} was cleared.
- *
- * @see ResourcesContainer
- * 
- */
+/// This listener provides a callback for when a `ResourcesContainer` was cleared.
+///
+/// @see ResourcesContainer
 public interface ResourcesContainerClearedListener extends EventListener {
-  /**
-   * This method gets called after the {@code ResourcesContainer.clear} method was executed.
-   * 
-   * @see ResourcesContainer#clear()
-   */
+  /// This method gets called after the `ResourcesContainer.clear` method was executed.
+  ///
+  /// @see ResourcesContainer#clear()
   void cleared();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourcesContainerListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/ResourcesContainerListener.java
@@ -1,44 +1,36 @@
 package de.gurkenlabs.litiengine.resources;
 
-/**
- * This listener provides callbacks to observe {@code ResourcesContainer} instances.
- *
- * @param <T> The type of the resource that is managed by the container.
- * @see ResourcesContainer
- * @see Images
- * @see Fonts
- * @see Maps
- * @see Sounds
- * @see Spritesheets
- */
+/// This listener provides callbacks to observe `ResourcesContainer` instances.
+///
+/// @param <T> The type of the resource that is managed by the container.
+/// @see ResourcesContainer
+/// @see Images
+/// @see Fonts
+/// @see Maps
+/// @see Sounds
+/// @see Spritesheets
 public interface ResourcesContainerListener<T> extends ResourcesContainerClearedListener {
 
-  /**
-   * This method gets called after the {@code ResourcesContainer.add} method was executed.
-   *
-   * @param resourceName The name by which the added resource is identified.
-   * @param resource     The added resource.
-   * @see ResourcesContainer#add(String, Object)
-   */
+  /// This method gets called after the `ResourcesContainer.add` method was executed.
+  ///
+  /// @param resourceName The name by which the added resource is identified.
+  /// @param resource     The added resource.
+  /// @see ResourcesContainer#add(String, Object)
   default void added(String resourceName, T resource) {
   }
 
-  /**
-   * This method gets called after the {@code ResourcesContainer.remove} method was executed.
-   *
-   * @param resourceName The name by which the removed resource was identified.
-   * @param resource     The removed resource.
-   * @see ResourcesContainer#remove(String)
-   */
+  /// This method gets called after the `ResourcesContainer.remove` method was executed.
+  ///
+  /// @param resourceName The name by which the removed resource was identified.
+  /// @param resource     The removed resource.
+  /// @see ResourcesContainer#remove(String)
   default void removed(String resourceName, T resource) {
   }
 
-  /**
-   * This method gets called after the {@code ResourcesContainer.clear} method was executed. It notifies that all resources have been removed from the
-   * container.
-   *
-   * @see ResourcesContainer#clear()
-   */
+  /// This method gets called after the `ResourcesContainer.clear` method was executed. It notifies that all resources have been removed from the
+  /// container.
+  ///
+  /// @see ResourcesContainer#clear()
   default void cleared() {
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SoundFormat.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SoundFormat.java
@@ -2,62 +2,51 @@ package de.gurkenlabs.litiengine.resources;
 
 import java.nio.file.Path;
 
-/**
- * Contains all known audio file-formats supported by the engine.
- *
- * @see ImageFormat
- */
+/// Contains all known audio file-formats supported by the engine.
+///
+/// @see ImageFormat
 public enum SoundFormat {
   UNSUPPORTED,
   OGG,
   MP3,
   WAV;
 
-  /**
-   * Gets the {@code SoundFormat} of the specified format string.
-   *
-   * @param format The format string from which to extract the format.
-   * @return The format of the specified string or {@code UNDEFINED} if not supported.
-   */
+  /// Gets the `SoundFormat` of the specified format string.
+  ///
+  /// @param format The format string from which to extract the format.
+  /// @return The format of the specified string or `UNDEFINED` if not supported.
   public static SoundFormat get(String format) {
     return DataFormat.get(format, values(), UNSUPPORTED);
   }
 
-  /**
-   * Determines whether the extension of the specified file is supported by the engine.
-   *
-   * @param file The file to check for.
-   * @return True if the extension is part of this enum; otherwise false.
-   */
+  /// Determines whether the extension of the specified file is supported by the engine.
+  ///
+  /// @param file The file to check for.
+  /// @return True if the extension is part of this enum; otherwise false.
   public static boolean isSupported(Path file) {
     return isSupported(file.getFileName().toString());
   }
 
-  /**
-   * Determines whether the extension of the specified file is supported by the engine.
-   *
-   * @param fileName The file name to check for.
-   * @return True if the extension is part of this enum; otherwise false.
-   */
+  /// Determines whether the extension of the specified file is supported by the engine.
+  ///
+  /// @param fileName The file name to check for.
+  /// @return True if the extension is part of this enum; otherwise false.
   public static boolean isSupported(String fileName) {
     return DataFormat.isSupported(fileName, values(), UNSUPPORTED);
   }
 
-  /**
-   * Gets all the file extensions supported by the engine.
-   *
-   * @return An array of strings representing all supported file extensions.
-   */
+  /// Gets all the file extensions supported by the engine.
+  ///
+  /// @return An array of strings representing all supported file extensions.
   public static String[] getAllExtensions() {
     return DataFormat.getAllExtensions(values(), UNSUPPORTED);
   }
 
-  /**
-   * Converts this format instance to a file format string that can be used as an extension (e.g. .ogg).<br> It adds a leading '.' to the lower-case
-   * string representation of this instance.
-   *
-   * @return The file extension string for this instance.
-   */
+  /// Converts this format instance to a file format string that can be used as an extension (e.g. .ogg).
+  /// It adds a leading '.' to the lower-case
+  /// string representation of this instance.
+  ///
+  /// @return The file extension string for this instance.
   public String toFileExtension() {
     return "." + this.name().toLowerCase();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SoundResource.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SoundResource.java
@@ -9,12 +9,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
-/**
- * Represents a sound resource that extends the NamedResource class.
- * <p>
- * This class is used to manage sound resources, including their data and format.
- * </p>
- */
+/// Represents a sound resource that extends the NamedResource class.
+///
+/// This class is used to manage sound resources, including their data and format.
 @XmlRootElement(name = "sound")
 public class SoundResource extends NamedResource {
   @XmlElement(name = "data")
@@ -23,95 +20,74 @@ public class SoundResource extends NamedResource {
   @XmlElement(name = "format")
   private SoundFormat format = SoundFormat.UNSUPPORTED;
 
-  /**
-   * Default constructor for SoundResource.
-   * <p>
-   * This constructor doesn't do anything and is intended for XML serialization purposes.
-   * </p>
-   */
+  /// Default constructor for SoundResource.
+  ///
+  /// This constructor doesn't do anything and is intended for XML serialization purposes.
   public SoundResource() {
     // keep for xml serialization
   }
 
-  /**
-   * Constructs a new SoundResource with the specified sound and format.
-   * <p>
-   * This constructor initializes the SoundResource with the provided Sound object and SoundFormat. It sets the name of the resource to the name of
-   * the sound and encodes the raw data of the sound.
-   * </p>
-   *
-   * @param sound  The Sound object to be used for this resource.
-   * @param format The format of the sound.
-   */
+  /// Constructs a new SoundResource with the specified sound and format.
+  ///
+  /// This constructor initializes the SoundResource with the provided Sound object and SoundFormat. It sets the name of the resource to the name of
+  /// the sound and encodes the raw data of the sound.
+  ///
+  /// @param sound  The Sound object to be used for this resource.
+  /// @param format The format of the sound.
   public SoundResource(Sound sound, SoundFormat format) {
     this.setName(sound.getName());
     this.data = Codec.encode(sound.getRawData());
     this.format = format;
   }
 
-  /**
-   * Constructs a new SoundResource with the specified input stream, name, and format.
-   * <p>
-   * This constructor initializes the SoundResource by creating a new Sound object from the provided input stream and name, and sets the format of the
-   * sound.
-   * </p>
-   *
-   * @param data   The input stream containing the sound data.
-   * @param name   The name of the sound.
-   * @param format The format of the sound.
-   * @throws IOException                   If an I/O error occurs while reading the sound data.
-   * @throws UnsupportedAudioFileException If the audio file format is not supported.
-   */
+  /// Constructs a new SoundResource with the specified input stream, name, and format.
+  ///
+  /// This constructor initializes the SoundResource by creating a new Sound object from the provided input stream and name, and sets the format of the
+  /// sound.
+  ///
+  /// @param data   The input stream containing the sound data.
+  /// @param name   The name of the sound.
+  /// @param format The format of the sound.
+  /// @throws IOException                   If an I/O error occurs while reading the sound data.
+  /// @throws UnsupportedAudioFileException If the audio file format is not supported.
   public SoundResource(InputStream data, String name, SoundFormat format) throws IOException, UnsupportedAudioFileException {
     this(new Sound(data, name), format);
   }
 
-  /**
-   * Gets the encoded sound data.
-   * <p>
-   * This method returns the encoded sound data as a string.
-   * </p>
-   *
-   * @return The encoded sound data.
-   */
+  /// Gets the encoded sound data.
+  ///
+  /// This method returns the encoded sound data as a string.
+  ///
+  /// @return The encoded sound data.
   @XmlTransient
   public String getData() {
     return this.data;
   }
 
-  /**
-   * Gets the format of the sound.
-   * <p>
-   * This method returns the format of the sound.
-   * </p>
-   *
-   * @return The format of the sound.
-   */
+  /// Gets the format of the sound.
+  ///
+  /// This method returns the format of the sound.
+  ///
+  /// @return The format of the sound.
   @XmlTransient
   public SoundFormat getFormat() {
     return this.format;
   }
 
-  /**
-   * Sets the encoded sound data.
-   * <p>
-   * This method sets the encoded sound data.
-   * </p>
-   *
-   * @param data The encoded sound data to set.
-   */
+  /// Sets the encoded sound data.
+  ///
+  /// This method sets the encoded sound data.
+  ///
+  /// @param data The encoded sound data to set.
   public void setData(String data) {
     this.data = data;
   }
 
-  /**
-   * Sets the format of the sound.
-   * <p>
-   * This method sets the format of the sound.
-   * </p>
-   *
-   * @param format The format of the sound to set.
-   */
+  /// Sets the format of the sound.
+  ///
+  /// This method sets the format of the sound.
+  ///
+  /// @param format The format of the sound to set.
   public void setFormat(SoundFormat format) {
     this.format = format;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Sounds.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Sounds.java
@@ -11,25 +11,20 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
-/**
- * Represents a container for managing sound resources.
- * <p>
- * This class extends the {@code ResourcesContainer} class to provide specific functionality for handling {@code Sound} objects.
- * </p>
- */
+/// Represents a container for managing sound resources.
+///
+/// This class extends the `ResourcesContainer` class to provide specific functionality for handling `Sound` objects.
 public final class Sounds extends ResourcesContainer<Sound> {
   private static final Logger log = Logger.getLogger(Sounds.class.getName());
 
   Sounds() {
   }
 
-  /**
-   * Loads a sound from the specified XML resource.
-   *
-   * @param resource The XML resource that contains the sound as Base64 string.
-   * @return The {@code Sound} instance loaded from the specified resource.
-   * @see Codec#decode(String)
-   */
+  /// Loads a sound from the specified XML resource.
+  ///
+  /// @param resource The XML resource that contains the sound as Base64 string.
+  /// @return The `Sound` instance loaded from the specified resource.
+  /// @see Codec#decode(String)
   public Sound load(final SoundResource resource) {
     byte[] data = Codec.decode(resource.getData());
     ByteArrayInputStream input = new ByteArrayInputStream(data);
@@ -45,12 +40,10 @@ public final class Sounds extends ResourcesContainer<Sound> {
     return null;
   }
 
-  /**
-   * Loads the sound from the specified path and returns it.
-   *
-   * @param resourceName The path of the file to be loaded.(Can be relative or absolute)
-   * @return The loaded Sound from the specified path.
-   */
+  /// Loads the sound from the specified path and returns it.
+  ///
+  /// @param resourceName The path of the file to be loaded.(Can be relative or absolute)
+  /// @return The loaded Sound from the specified path.
   @Override
   protected Sound load(URL resourceName) throws Exception {
     try (final InputStream is = Resources.get(resourceName)) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SpritesheetResource.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/SpritesheetResource.java
@@ -12,13 +12,10 @@ import java.awt.image.BufferedImage;
 import java.io.Serial;
 import java.io.Serializable;
 
-/**
- * Represents a resource for managing spritesheets.
- * <p>
- * This class extends the {@code NamedResource} class and implements {@code Serializable} to provide specific functionality for handling spritesheet
- * resources.
- * </p>
- */
+/// Represents a resource for managing spritesheets.
+///
+/// This class extends the `NamedResource` class and implements `Serializable` to provide specific functionality for handling spritesheet
+/// resources.
 @XmlRootElement(name = "sprite")
 public class SpritesheetResource extends NamedResource implements Serializable {
   public static final String PLAIN_TEXT_FILE_EXTENSION = "info";
@@ -38,24 +35,18 @@ public class SpritesheetResource extends NamedResource implements Serializable {
   @XmlElement(required = false)
   private String keyframes;
 
-  /**
-   * Default constructor for SpritesheetResource.
-   * <p>
-   * This constructor is kept for serialization purposes.
-   * </p>
-   */
+  /// Default constructor for SpritesheetResource.
+  ///
+  /// This constructor is kept for serialization purposes.
   public SpritesheetResource() {
     // keep empty constructor for serialization
   }
 
-  /**
-   * Constructs a new SpritesheetResource from a Spritesheet object.
-   * <p>
-   * This constructor initializes the SpritesheetResource with the specified sprite's width, height, name, image, image format, and keyframes.
-   * </p>
-   *
-   * @param sprite The Spritesheet object to initialize the resource from.
-   */
+  /// Constructs a new SpritesheetResource from a Spritesheet object.
+  ///
+  /// This constructor initializes the SpritesheetResource with the specified sprite's width, height, name, image, image format, and keyframes.
+  ///
+  /// @param sprite The Spritesheet object to initialize the resource from.
   public SpritesheetResource(final Spritesheet sprite) {
     this(sprite.getSpriteWidth(), sprite.getSpriteHeight(), sprite.getName());
     this.setImage(Codec.encode(sprite.getImage(), sprite.getImageFormat()));
@@ -81,84 +72,68 @@ public class SpritesheetResource extends NamedResource implements Serializable {
     this.setName(original.getName());
   }
 
-  /**
-   * Constructs a new SpritesheetResource from a BufferedImage.
-   * <p>
-   * This constructor initializes the SpritesheetResource with the specified image, name, width, and height.
-   * </p>
-   *
-   * @param image  The BufferedImage to initialize the resource from.
-   * @param name   The name of the spritesheet.
-   * @param width  The width of the spritesheet.
-   * @param height The height of the spritesheet.
-   */
+  /// Constructs a new SpritesheetResource from a BufferedImage.
+  ///
+  /// This constructor initializes the SpritesheetResource with the specified image, name, width, and height.
+  ///
+  /// @param image  The BufferedImage to initialize the resource from.
+  /// @param name   The name of the spritesheet.
+  /// @param width  The width of the spritesheet.
+  /// @param height The height of the spritesheet.
   public SpritesheetResource(final BufferedImage image, String name, final int width, final int height) {
     this(width, height, name);
     this.setImage(Codec.encode(image));
     this.setImageFormat(ImageFormat.PNG);
   }
 
-  /**
-   * Constructs a new SpritesheetResource with the specified width, height, and name.
-   * <p>
-   * This private constructor is used internally to initialize the resource with the specified dimensions and name.
-   * </p>
-   *
-   * @param width  The width of the spritesheet.
-   * @param height The height of the spritesheet.
-   * @param name   The name of the spritesheet.
-   */
+  /// Constructs a new SpritesheetResource with the specified width, height, and name.
+  ///
+  /// This private constructor is used internally to initialize the resource with the specified dimensions and name.
+  ///
+  /// @param width  The width of the spritesheet.
+  /// @param height The height of the spritesheet.
+  /// @param name   The name of the spritesheet.
   private SpritesheetResource(int width, int height, String name) {
     this.setWidth(width);
     this.setHeight(height);
     this.setName(name);
   }
 
-  /**
-   * Gets the height of the spritesheet.
-   *
-   * @return The height of the spritesheet.
-   */
+  /// Gets the height of the spritesheet.
+  ///
+  /// @return The height of the spritesheet.
   @XmlTransient
   public int getHeight() {
     return this.height;
   }
 
-  /**
-   * Gets the image data of the spritesheet.
-   *
-   * @return The image data of the spritesheet.
-   */
+  /// Gets the image data of the spritesheet.
+  ///
+  /// @return The image data of the spritesheet.
   @XmlTransient
   public String getImage() {
     return this.image;
   }
 
-  /**
-   * Gets the width of the spritesheet.
-   *
-   * @return The width of the spritesheet.
-   */
+  /// Gets the width of the spritesheet.
+  ///
+  /// @return The width of the spritesheet.
   @XmlTransient
   public int getWidth() {
     return this.width;
   }
 
-  /**
-   * Gets the image format of the spritesheet.
-   *
-   * @return The image format of the spritesheet.
-   */
+  /// Gets the image format of the spritesheet.
+  ///
+  /// @return The image format of the spritesheet.
   @XmlTransient
   public ImageFormat getImageFormat() {
     return this.imageformat;
   }
 
-  /**
-   * Gets the keyframes of the spritesheet.
-   *
-   * @return An array of keyframes of the spritesheet.
-   */
+  /// Gets the keyframes of the spritesheet.
+  ///
+  /// @return An array of keyframes of the spritesheet.
   @XmlTransient
   public int[] getKeyframes() {
     if (this.keyframes == null || this.keyframes.isEmpty()) {
@@ -168,59 +143,46 @@ public class SpritesheetResource extends NamedResource implements Serializable {
     return ArrayUtilities.splitInt(this.keyframes);
   }
 
-  /**
-   * Sets the height of the spritesheet.
-   *
-   * @param h The height to set.
-   */
+  /// Sets the height of the spritesheet.
+  ///
+  /// @param h The height to set.
   public void setHeight(final int h) {
     this.height = h;
   }
 
-  /**
-   * Sets the image data of the spritesheet.
-   *
-   * @param image The image data to set.
-   */
+  /// Sets the image data of the spritesheet.
+  ///
+  /// @param image The image data to set.
   public void setImage(final String image) {
     this.image = image;
   }
 
-  /**
-   * Sets the width of the spritesheet.
-   *
-   * @param w The width to set.
-   */
+  /// Sets the width of the spritesheet.
+  ///
+  /// @param w The width to set.
   public void setWidth(final int w) {
     this.width = w;
   }
 
-  /**
-   * Sets the image format of the spritesheet.
-   *
-   * @param f The image format to set.
-   */
+  /// Sets the image format of the spritesheet.
+  ///
+  /// @param f The image format to set.
   public void setImageFormat(final ImageFormat f) {
     this.imageformat = f;
   }
 
-  /**
-   * Sets the keyframes of the spritesheet.
-   *
-   * @param keyframes An array of keyframes to set.
-   */
+  /// Sets the keyframes of the spritesheet.
+  ///
+  /// @param keyframes An array of keyframes to set.
   public void setKeyframes(int[] keyframes) {
     this.keyframes = ArrayUtilities.join(keyframes);
   }
 
-  /**
-   * Prepares the object for marshalling.
-   * <p>
-   * This method is called before the object is marshalled to XML. It ensures that the keyframes field is set to null if it is empty.
-   * </p>
-   *
-   * @param m The marshaller.
-   */
+  /// Prepares the object for marshalling.
+  ///
+  /// This method is called before the object is marshalled to XML. It ensures that the keyframes field is set to null if it is empty.
+  ///
+  /// @param m The marshaller.
   @SuppressWarnings("unused")
   private void beforeMarshal(Marshaller m) {
     if (this.keyframes != null && this.keyframes.isEmpty()) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Spritesheets.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Spritesheets.java
@@ -25,13 +25,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 
-/**
- * Manages the loading, storing, and retrieval of spritesheets.
- * <p>
- * This class provides methods to load spritesheets from various sources, manage custom keyframe durations, and handle listeners for resource
- * container clearing events.
- * </p>
- */
+/// Manages the loading, storing, and retrieval of spritesheets.
+///
+/// This class provides methods to load spritesheets from various sources, manage custom keyframe durations, and handle listeners for resource
+/// container clearing events.
 public final class Spritesheets {
   private final Map<String, int[]> customKeyFrameDurations = new ConcurrentHashMap<>();
   private final Map<String, Spritesheet> loadedSpritesheets = new ConcurrentHashMap<>();
@@ -42,58 +39,46 @@ public final class Spritesheets {
   Spritesheets() {
   }
 
-  /**
-   * Adds a spritesheet to the collection of loaded spritesheets.
-   *
-   * @param name        The name of the spritesheet.
-   * @param spritesheet The spritesheet to add.
-   */
+  /// Adds a spritesheet to the collection of loaded spritesheets.
+  ///
+  /// @param name        The name of the spritesheet.
+  /// @param spritesheet The spritesheet to add.
   public void add(String name, Spritesheet spritesheet) {
     this.loadedSpritesheets.put(name, spritesheet);
   }
 
-  /**
-   * Adds a listener for resource container clearing events.
-   *
-   * @param listener The listener to add.
-   */
+  /// Adds a listener for resource container clearing events.
+  ///
+  /// @param listener The listener to add.
   public void addClearedListener(ResourcesContainerClearedListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes a listener for resource container clearing events.
-   *
-   * @param listener The listener to remove.
-   */
+  /// Removes a listener for resource container clearing events.
+  ///
+  /// @param listener The listener to remove.
   public void removeClearedListener(ResourcesContainerClearedListener listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Clears all loaded spritesheets and notifies listeners of the clearing event.
-   */
+  /// Clears all loaded spritesheets and notifies listeners of the clearing event.
   public void clear() {
     this.loadedSpritesheets.clear();
     listeners.forEach(ResourcesContainerClearedListener::cleared);
   }
 
-  /**
-   * Checks if a spritesheet with the specified name is loaded.
-   *
-   * @param name The name of the spritesheet.
-   * @return True if the spritesheet is loaded, false otherwise.
-   */
+  /// Checks if a spritesheet with the specified name is loaded.
+  ///
+  /// @param name The name of the spritesheet.
+  /// @return True if the spritesheet is loaded, false otherwise.
   public boolean contains(String name) {
     return this.loadedSpritesheets.containsKey(name);
   }
 
-  /**
-   * Finds Spritesheets that were previously loaded by any load method or by the sprites.info file.
-   *
-   * @param path The path of the spritesheet.
-   * @return The {@link Spritesheet} associated with the path or null if not loaded yet
-   */
+  /// Finds Spritesheets that were previously loaded by any load method or by the sprites.info file.
+  ///
+  /// @param path The path of the spritesheet.
+  /// @return The [Spritesheet] associated with the path or null if not loaded yet
   public Spritesheet get(final String path) {
     if (path == null || path.isEmpty()) {
       return null;
@@ -104,12 +89,10 @@ public final class Spritesheets {
     return this.loadedSpritesheets.get(name); // this already returns null if absent
   }
 
-  /**
-   * Gets a collection of spritesheets that match the specified predicate.
-   *
-   * @param pred The predicate to filter the spritesheets.
-   * @return A collection of spritesheets that match the predicate, or an empty collection if the predicate is null.
-   */
+  /// Gets a collection of spritesheets that match the specified predicate.
+  ///
+  /// @param pred The predicate to filter the spritesheets.
+  /// @return A collection of spritesheets that match the predicate, or an empty collection if the predicate is null.
   public Collection<Spritesheet> get(Predicate<? super Spritesheet> pred) {
     if (pred == null) {
       return new ArrayList<>();
@@ -118,54 +101,44 @@ public final class Spritesheets {
     return this.loadedSpritesheets.values().stream().filter(pred).toList();
   }
 
-  /**
-   * Gets a collection of all loaded spritesheets.
-   *
-   * @return A collection of all loaded spritesheets.
-   */
+  /// Gets a collection of all loaded spritesheets.
+  ///
+  /// @return A collection of all loaded spritesheets.
   public Collection<Spritesheet> getAll() {
     return this.loadedSpritesheets.values();
   }
 
-  /**
-   * Gets the custom keyframe durations for the specified spritesheet name.
-   *
-   * @param name The name of the spritesheet.
-   * @return An array of custom keyframe durations, or an empty array if none are found.
-   */
+  /// Gets the custom keyframe durations for the specified spritesheet name.
+  ///
+  /// @param name The name of the spritesheet.
+  /// @return An array of custom keyframe durations, or an empty array if none are found.
   public int[] getCustomKeyFrameDurations(final String name) {
     return this.customKeyFrameDurations.getOrDefault(FileUtilities.getFileName(name), new int[0]);
   }
 
-  /**
-   * Gets the custom keyframe durations for the specified spritesheet.
-   *
-   * @param sprite The spritesheet to get the custom keyframe durations for.
-   * @return An array of custom keyframe durations, or an empty array if none are found.
-   */
+  /// Gets the custom keyframe durations for the specified spritesheet.
+  ///
+  /// @param sprite The spritesheet to get the custom keyframe durations for.
+  /// @return An array of custom keyframe durations, or an empty array if none are found.
   public int[] getCustomKeyFrameDurations(final Spritesheet sprite) {
     return getCustomKeyFrameDurations(sprite.getName());
   }
 
-  /**
-   * Loads a spritesheet from the specified image, path, width, and height.
-   *
-   * @param image        The image of the spritesheet.
-   * @param path         The path of the spritesheet.
-   * @param spriteWidth  The width of each sprite in the spritesheet.
-   * @param spriteHeight The height of each sprite in the spritesheet.
-   * @return The loaded spritesheet.
-   */
+  /// Loads a spritesheet from the specified image, path, width, and height.
+  ///
+  /// @param image        The image of the spritesheet.
+  /// @param path         The path of the spritesheet.
+  /// @param spriteWidth  The width of each sprite in the spritesheet.
+  /// @param spriteHeight The height of each sprite in the spritesheet.
+  /// @return The loaded spritesheet.
   public Spritesheet load(final BufferedImage image, final String path, final int spriteWidth, final int spriteHeight) {
     return new Spritesheet(image, path, spriteWidth, spriteHeight);
   }
 
-  /**
-   * Loads a spritesheet from the specified tileset.
-   *
-   * @param tileset The tileset to load the spritesheet from.
-   * @return The loaded spritesheet, or null if the tileset or its image is null, or if the image's absolute source path is null.
-   */
+  /// Loads a spritesheet from the specified tileset.
+  ///
+  /// @param tileset The tileset to load the spritesheet from.
+  /// @return The loaded spritesheet, or null if the tileset or its image is null, or if the image's absolute source path is null.
   public Spritesheet load(final ITileset tileset) {
     if (tileset == null || tileset.getImage() == null) {
       return null;
@@ -179,12 +152,10 @@ public final class Spritesheets {
       tileset.getTileDimension().width, tileset.getTileDimension().height);
   }
 
-  /**
-   * Loads a spritesheet from the specified spritesheet resource.
-   *
-   * @param info The spritesheet resource containing the information to load the spritesheet.
-   * @return The loaded spritesheet, or null if the image is null or empty.
-   */
+  /// Loads a spritesheet from the specified spritesheet resource.
+  ///
+  /// @param info The spritesheet resource containing the information to load the spritesheet.
+  /// @return The loaded spritesheet, or null if the image is null or empty.
   public Spritesheet load(final SpritesheetResource info) {
     Spritesheet sprite;
     if (info.getImage() == null || info.getImage().isEmpty()) {
@@ -202,12 +173,10 @@ public final class Spritesheets {
     return sprite;
   }
 
-  /**
-   * The sprite info file must be located under the GameInfo#getSpritesDirectory() directory.
-   *
-   * @param spriteInfoFile The path to the sprite info file.
-   * @return A list of spritesheets that were loaded from the info file.
-   */
+  /// The sprite info file must be located under the GameInfo#getSpritesDirectory() directory.
+  ///
+  /// @param spriteInfoFile The path to the sprite info file.
+  /// @return A list of spritesheets that were loaded from the info file.
   public List<Spritesheet> loadFrom(final String spriteInfoFile) {
 
     final ArrayList<Spritesheet> sprites = new ArrayList<>();
@@ -245,13 +214,11 @@ public final class Spritesheets {
     return sprites;
   }
 
-  /**
-   * Saves the spritesheet information to the specified file.
-   *
-   * @param spriteInfoFile The path to the file where the spritesheet information will be saved.
-   * @param metadataOnly   If true, only the metadata will be saved; if false, both the sprites and metadata will be saved.
-   * @return True if the spritesheet information was successfully saved, false otherwise.
-   */
+  /// Saves the spritesheet information to the specified file.
+  ///
+  /// @param spriteInfoFile The path to the file where the spritesheet information will be saved.
+  /// @param metadataOnly   If true, only the metadata will be saved; if false, both the sprites and metadata will be saved.
+  /// @return True if the spritesheet information was successfully saved, false otherwise.
   public boolean saveTo(final String spriteInfoFile, boolean metadataOnly) {
     // get all spritesheets
     List<Spritesheet> allSpriteSheets = new ArrayList<>(getAll());
@@ -296,36 +263,30 @@ public final class Spritesheets {
     }
   }
 
-  /**
-   * Loads a spritesheet from the specified path, width, and height.
-   *
-   * @param path         The path of the spritesheet.
-   * @param spriteWidth  The width of each sprite in the spritesheet.
-   * @param spriteHeight The height of each sprite in the spritesheet.
-   * @return The loaded spritesheet.
-   */
+  /// Loads a spritesheet from the specified path, width, and height.
+  ///
+  /// @param path         The path of the spritesheet.
+  /// @param spriteWidth  The width of each sprite in the spritesheet.
+  /// @param spriteHeight The height of each sprite in the spritesheet.
+  /// @return The loaded spritesheet.
   public Spritesheet load(final String path, final int spriteWidth, final int spriteHeight) {
     return new Spritesheet(Resources.images().get(path, true), path, spriteWidth, spriteHeight);
   }
 
-  /**
-   * Removes a spritesheet from the collection of loaded spritesheets.
-   *
-   * @param path The path of the spritesheet to remove.
-   * @return The removed spritesheet, or null if no spritesheet was found for the specified path.
-   */
+  /// Removes a spritesheet from the collection of loaded spritesheets.
+  ///
+  /// @param path The path of the spritesheet to remove.
+  /// @return The removed spritesheet, or null if no spritesheet was found for the specified path.
   public Spritesheet remove(final String path) {
     Spritesheet spriteToRemove = this.loadedSpritesheets.remove(path);
     customKeyFrameDurations.remove(path);
     return spriteToRemove;
   }
 
-  /**
-   * Updates a spritesheet with the specified resource information.
-   *
-   * @param info The resource information for the spritesheet to update.
-   * @return The updated spritesheet, or null if the resource information is invalid or the spritesheet could not be updated.
-   */
+  /// Updates a spritesheet with the specified resource information.
+  ///
+  /// @param info The resource information for the spritesheet to update.
+  /// @return The updated spritesheet, or null if the resource information is invalid or the spritesheet could not be updated.
   public Spritesheet update(final SpritesheetResource info) {
     if (info == null || info.getName() == null) {
       return null;
@@ -343,14 +304,12 @@ public final class Spritesheets {
     return null;
   }
 
-  /**
-   * Parses a line from the sprite info file and loads the corresponding spritesheet.
-   *
-   * @param baseDirectory The base directory of the sprite info file.
-   * @param sprites       The list to which the loaded spritesheet will be added.
-   * @param items         The list of items parsed from the line.
-   * @param parts         The array of parts parsed from the line.
-   */
+  /// Parses a line from the sprite info file and loads the corresponding spritesheet.
+  ///
+  /// @param baseDirectory The base directory of the sprite info file.
+  /// @param sprites       The list to which the loaded spritesheet will be added.
+  /// @param items         The list of items parsed from the line.
+  /// @param parts         The array of parts parsed from the line.
   private void getSpriteSheetFromSpriteInfoLine(String baseDirectory, ArrayList<Spritesheet> sprites, List<String> items, String[] parts) {
     try {
       final String name = baseDirectory + items.get(0);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Strings.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Strings.java
@@ -17,10 +17,8 @@ import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * This class provides methods to manage and retrieve localized strings from resource bundles. It supports different encodings and allows fetching
- * strings with or without formatting arguments.
- */
+/// This class provides methods to manage and retrieve localized strings from resource bundles. It supports different encodings and allows fetching
+/// strings with or without formatting arguments.
 public final class Strings {
   public static final String DEFAULT_BUNDLE = "strings";
 
@@ -33,21 +31,17 @@ public final class Strings {
   Strings() {
   }
 
-  /**
-   * Sets the character encoding to be used for reading resource bundles.
-   *
-   * @param charset The character encoding to set.
-   */
+  /// Sets the character encoding to be used for reading resource bundles.
+  ///
+  /// @param charset The character encoding to set.
   public void setEncoding(Charset charset) {
     this.charset = charset;
   }
 
-  /**
-   * Retrieves the localized string for the specified key from the default resource bundle.
-   *
-   * @param key The key for the desired string.
-   * @return The localized string corresponding to the specified key, or null if the key is null.
-   */
+  /// Retrieves the localized string for the specified key from the default resource bundle.
+  ///
+  /// @param key The key for the desired string.
+  /// @return The localized string corresponding to the specified key, or null if the key is null.
   public String get(final String key) {
     if (key == null) {
       return null;
@@ -56,13 +50,11 @@ public final class Strings {
     return this.getFrom(DEFAULT_BUNDLE, key);
   }
 
-  /**
-   * Retrieves the localized string for the specified key from the default resource bundle, with optional formatting arguments.
-   *
-   * @param key  The key for the desired string.
-   * @param args The arguments to format the string with.
-   * @return The localized string corresponding to the specified key, formatted with the provided arguments, or null if the key is null.
-   */
+  /// Retrieves the localized string for the specified key from the default resource bundle, with optional formatting arguments.
+  ///
+  /// @param key  The key for the desired string.
+  /// @param args The arguments to format the string with.
+  /// @return The localized string corresponding to the specified key, formatted with the provided arguments, or null if the key is null.
   public String get(final String key, Object... args) {
     if (key == null) {
       return null;
@@ -71,15 +63,13 @@ public final class Strings {
     return this.getFrom(DEFAULT_BUNDLE, key, args);
   }
 
-  /**
-   * Retrieves the localized string for the specified key from the specified resource bundle, with optional formatting arguments.
-   *
-   * @param bundleName The name of the resource bundle to retrieve the string from.
-   * @param key        The key for the desired string.
-   * @param args       The arguments to format the string with.
-   * @return The localized string corresponding to the specified key, formatted with the provided arguments, or the key itself if the resource is not
-   * found.
-   */
+  /// Retrieves the localized string for the specified key from the specified resource bundle, with optional formatting arguments.
+  ///
+  /// @param bundleName The name of the resource bundle to retrieve the string from.
+  /// @param key        The key for the desired string.
+  /// @param args       The arguments to format the string with.
+  /// @return The localized string corresponding to the specified key, formatted with the provided arguments, or the key itself if the resource is not
+  /// found.
   public String getFrom(final String bundleName, final String key, Object... args) {
     if (bundleName == null || key == null) {
       return null;
@@ -108,14 +98,13 @@ public final class Strings {
     return key;
   }
 
-  /**
-   * Get a list of strings from the specified raw text files. Strings are separated by a new line. <br>
-   * <b>This method is not cached. Ever call will open up a new {@link InputStream} to read the strings from the text
-   * file.</b>
-   *
-   * @param textFile The text file that will be retrieved.
-   * @return A list with all strings that are contained by the text file.
-   */
+  /// Get a list of strings from the specified raw text files. Strings are separated by a new line.
+  ///
+  /// **This method is not cached. Ever call will open up a new [InputStream] to read the strings from the text
+  /// file.**
+  ///
+  /// @param textFile The text file that will be retrieved.
+  /// @return A list with all strings that are contained by the text file.
   public String[] getList(String textFile) {
     if (textFile == null || textFile.isEmpty()) {
       return new String[0];
@@ -145,23 +134,19 @@ public final class Strings {
     return new String[0];
   }
 
-  /**
-   * Checks if the default resource bundle contains the specified key.
-   *
-   * @param key The key to check for.
-   * @return True if the key is found in the default resource bundle, false otherwise.
-   */
+  /// Checks if the default resource bundle contains the specified key.
+  ///
+  /// @param key The key to check for.
+  /// @return True if the key is found in the default resource bundle, false otherwise.
   public boolean contains(final String key) {
     return contains(DEFAULT_BUNDLE, key);
   }
 
-  /**
-   * Checks if the specified resource bundle contains the specified key.
-   *
-   * @param bundleName The name of the resource bundle to check.
-   * @param key        The key to check for.
-   * @return True if the key is found in the specified resource bundle, false otherwise.
-   */
+  /// Checks if the specified resource bundle contains the specified key.
+  ///
+  /// @param bundleName The name of the resource bundle to check.
+  /// @param key        The key to check for.
+  /// @return True if the key is found in the specified resource bundle, false otherwise.
   public boolean contains(final String bundleName, final String key) {
     try {
       final ResourceBundle defaultBundle = ResourceBundle.getBundle(bundleName, Game.config().client().getLocale());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/TextureAtlas.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/TextureAtlas.java
@@ -14,10 +14,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Represents a texture atlas, which is a collection of images packed into a single image. This class provides methods to read the texture atlas from
- * an XML file and access its properties.
- */
+/// Represents a texture atlas, which is a collection of images packed into a single image. This class provides methods to read the texture atlas from
+/// an XML file and access its properties.
 @XmlRootElement(name = "TextureAtlas")
 public class TextureAtlas {
   private static final Logger log = Logger.getLogger(TextureAtlas.class.getName());
@@ -36,19 +34,15 @@ public class TextureAtlas {
 
   private String absoluteImagePath;
 
-  /**
-   * Default constructor for the TextureAtlas class. This constructor is kept for serialization purposes.
-   */
+  /// Default constructor for the TextureAtlas class. This constructor is kept for serialization purposes.
   TextureAtlas() {
     // keep for serialization
   }
 
-  /**
-   * Reads a TextureAtlas from the specified XML file.
-   *
-   * @param textureAtlasFile The path to the XML file containing the texture atlas data.
-   * @return The TextureAtlas object read from the file, or null if the file could not be read.
-   */
+  /// Reads a TextureAtlas from the specified XML file.
+  ///
+  /// @param textureAtlasFile The path to the XML file containing the texture atlas data.
+  /// @return The TextureAtlas object read from the file, or null if the file could not be read.
   public static TextureAtlas read(String textureAtlasFile) {
     try {
       TextureAtlas atlas = XmlUtilities.read(TextureAtlas.class, Resources.getLocation(textureAtlasFile));
@@ -65,41 +59,33 @@ public class TextureAtlas {
     }
   }
 
-  /**
-   * Gets the absolute image path of the texture atlas.
-   *
-   * @return The absolute image path.
-   */
+  /// Gets the absolute image path of the texture atlas.
+  ///
+  /// @return The absolute image path.
   @XmlTransient
   public String getAbsoluteImagePath() {
     return this.absoluteImagePath;
   }
 
-  /**
-   * Gets the width of the texture atlas.
-   *
-   * @return The width of the texture atlas.
-   */
+  /// Gets the width of the texture atlas.
+  ///
+  /// @return The width of the texture atlas.
   @XmlTransient
   public int getWidth() {
     return this.width;
   }
 
-  /**
-   * Gets the height of the texture atlas.
-   *
-   * @return The height of the texture atlas.
-   */
+  /// Gets the height of the texture atlas.
+  ///
+  /// @return The height of the texture atlas.
   @XmlTransient
   public int getHeight() {
     return this.height;
   }
 
-  /**
-   * Gets the list of sprites in the texture atlas. If the list is null, it initializes a new empty list.
-   *
-   * @return The list of sprites.
-   */
+  /// Gets the list of sprites in the texture atlas. If the list is null, it initializes a new empty list.
+  ///
+  /// @return The list of sprites.
   @XmlTransient
   public List<Sprite> getSprites() {
     if (this.sprites == null) {
@@ -109,12 +95,10 @@ public class TextureAtlas {
     return this.sprites;
   }
 
-  /**
-   * Retrieves a sprite by its name from the texture atlas.
-   *
-   * @param name The name of the sprite to retrieve.
-   * @return The sprite with the specified name, or null if no such sprite exists.
-   */
+  /// Retrieves a sprite by its name from the texture atlas.
+  ///
+  /// @param name The name of the sprite to retrieve.
+  /// @return The sprite with the specified name, or null if no such sprite exists.
   public Sprite getSprite(String name) {
     if (name == null || name.isEmpty()) {
       return null;
@@ -123,45 +107,35 @@ public class TextureAtlas {
     return this.getSprites().stream().filter(x -> x.getName().equals(name)).findFirst().orElse(null);
   }
 
-  /**
-   * Sets the image path for the texture atlas.
-   *
-   * @param imagePath The new image path to set.
-   */
+  /// Sets the image path for the texture atlas.
+  ///
+  /// @param imagePath The new image path to set.
   public void setImagePath(String imagePath) {
     this.rawImagePath = imagePath;
   }
 
-  /**
-   * Sets the width of the texture atlas.
-   *
-   * @param width The new width to set.
-   */
+  /// Sets the width of the texture atlas.
+  ///
+  /// @param width The new width to set.
   public void setWidth(int width) {
     this.width = width;
   }
 
-  /**
-   * Sets the height of the texture atlas.
-   *
-   * @param height The new height to set.
-   */
+  /// Sets the height of the texture atlas.
+  ///
+  /// @param height The new height to set.
   public void setHeight(int height) {
     this.height = height;
   }
 
-  /**
-   * Sets the list of sprites in the texture atlas.
-   *
-   * @param sprites The new list of sprites to set.
-   */
+  /// Sets the list of sprites in the texture atlas.
+  ///
+  /// @param sprites The new list of sprites to set.
   public void setSprites(List<Sprite> sprites) {
     this.sprites = sprites;
   }
 
-  /**
-   * Represents a sprite in the texture atlas. This class contains properties such as name, position, dimensions, and rotation status of the sprite.
-   */
+  /// Represents a sprite in the texture atlas. This class contains properties such as name, position, dimensions, and rotation status of the sprite.
   @XmlRootElement(name = "sprite")
   public static class Sprite {
     @XmlAttribute(name = "n")
@@ -189,178 +163,140 @@ public class TextureAtlas {
     @XmlJavaTypeAdapter(CustomBooleanAdapter.class)
     private Boolean rotated;
 
-    /**
-     * Default constructor for the Sprite class. This constructor is kept for serialization purposes.
-     */
+    /// Default constructor for the Sprite class. This constructor is kept for serialization purposes.
     Sprite() {
       // keep for serialization
     }
 
-    /**
-     * Gets the name of the sprite.
-     *
-     * @return The name of the sprite.
-     */
+    /// Gets the name of the sprite.
+    ///
+    /// @return The name of the sprite.
     @XmlTransient
     public String getName() {
       return this.name;
     }
 
-    /**
-     * Gets the x-coordinate of the sprite.
-     *
-     * @return The x-coordinate of the sprite.
-     */
+    /// Gets the x-coordinate of the sprite.
+    ///
+    /// @return The x-coordinate of the sprite.
     @XmlTransient
     public int getX() {
       return this.x;
     }
 
-    /**
-     * Gets the y-coordinate of the sprite.
-     *
-     * @return The y-coordinate of the sprite.
-     */
+    /// Gets the y-coordinate of the sprite.
+    ///
+    /// @return The y-coordinate of the sprite.
     @XmlTransient
     public int getY() {
       return this.y;
     }
 
-    /**
-     * Gets the width of the sprite.
-     *
-     * @return The width of the sprite.
-     */
+    /// Gets the width of the sprite.
+    ///
+    /// @return The width of the sprite.
     @XmlTransient
     public int getWidth() {
       return this.width;
     }
 
-    /**
-     * Gets the height of the sprite.
-     *
-     * @return The height of the sprite.
-     */
+    /// Gets the height of the sprite.
+    ///
+    /// @return The height of the sprite.
     @XmlTransient
     public int getHeight() {
       return this.height;
     }
 
-    /**
-     * Gets the x-offset of the sprite.
-     *
-     * @return The x-offset of the sprite.
-     */
+    /// Gets the x-offset of the sprite.
+    ///
+    /// @return The x-offset of the sprite.
     @XmlTransient
     public int getOffsetX() {
       return this.offsetX;
     }
 
-    /**
-     * Gets the y-offset of the sprite.
-     *
-     * @return The y-offset of the sprite.
-     */
+    /// Gets the y-offset of the sprite.
+    ///
+    /// @return The y-offset of the sprite.
     @XmlTransient
     public int getOffsetY() {
       return this.offsetY;
     }
 
-    /**
-     * Checks if the sprite is rotated.
-     *
-     * @return True if the sprite is rotated, false otherwise.
-     */
+    /// Checks if the sprite is rotated.
+    ///
+    /// @return True if the sprite is rotated, false otherwise.
     @XmlTransient
     public boolean isRotated() {
       return this.rotated != null && this.rotated;
     }
 
-    /**
-     * Sets the name of the sprite.
-     *
-     * @param name The new name to set.
-     */
+    /// Sets the name of the sprite.
+    ///
+    /// @param name The new name to set.
     public void setName(String name) {
       this.name = name;
     }
 
-    /**
-     * Sets the x-coordinate of the sprite.
-     *
-     * @param x The new x-coordinate to set.
-     */
+    /// Sets the x-coordinate of the sprite.
+    ///
+    /// @param x The new x-coordinate to set.
     public void setX(int x) {
       this.x = x;
     }
 
-    /**
-     * Sets the y-coordinate of the sprite.
-     *
-     * @param y The new y-coordinate to set.
-     */
+    /// Sets the y-coordinate of the sprite.
+    ///
+    /// @param y The new y-coordinate to set.
     public void setY(int y) {
       this.y = y;
     }
 
-    /**
-     * Sets the width of the sprite.
-     *
-     * @param width The new width to set.
-     */
+    /// Sets the width of the sprite.
+    ///
+    /// @param width The new width to set.
     public void setWidth(int width) {
       this.width = width;
     }
 
-    /**
-     * Sets the height of the sprite.
-     *
-     * @param height The new height to set.
-     */
+    /// Sets the height of the sprite.
+    ///
+    /// @param height The new height to set.
     public void setHeight(int height) {
       this.height = height;
     }
 
-    /**
-     * Sets the x-offset of the sprite.
-     *
-     * @param offsetX The new x-offset to set.
-     */
+    /// Sets the x-offset of the sprite.
+    ///
+    /// @param offsetX The new x-offset to set.
     public void setOffsetX(int offsetX) {
       this.offsetX = offsetX;
     }
 
-    /**
-     * Sets the y-offset of the sprite.
-     *
-     * @param offsetY The new y-offset to set.
-     */
+    /// Sets the y-offset of the sprite.
+    ///
+    /// @param offsetY The new y-offset to set.
     public void setOffsetY(int offsetY) {
       this.offsetY = offsetY;
     }
 
-    /**
-     * Sets the rotation status of the sprite.
-     *
-     * @param rotated The new rotation status to set.
-     */
+    /// Sets the rotation status of the sprite.
+    ///
+    /// @param rotated The new rotation status to set.
     public void setRotated(boolean rotated) {
       this.rotated = rotated;
     }
   }
 
-  /**
-   * Custom adapter to convert between String and Boolean values for XML serialization. This adapter interprets "y", "yes", "1", and "true"
-   * (case-insensitive) as true, and any other value as false.
-   */
+  /// Custom adapter to convert between String and Boolean values for XML serialization. This adapter interprets "y", "yes", "1", and "true"
+  /// (case-insensitive) as true, and any other value as false.
   public static class CustomBooleanAdapter extends XmlAdapter<String, Boolean> {
-    /**
-     * Converts a String value to a Boolean.
-     *
-     * @param v The String value to convert.
-     * @return The Boolean representation of the String value.
-     * @throws Exception If an error occurs during conversion.
-     */
+    /// Converts a String value to a Boolean.
+    ///
+    /// @param v The String value to convert.
+    /// @return The Boolean representation of the String value.
+    /// @throws Exception If an error occurs during conversion.
     @Override
     public Boolean unmarshal(String v) throws Exception {
       if (v == null || v.isEmpty()) {
@@ -370,13 +306,11 @@ public class TextureAtlas {
       return v.equalsIgnoreCase("y") || v.equalsIgnoreCase("yes") || v.equals("1") || v.equalsIgnoreCase("true");
     }
 
-    /**
-     * Converts a Boolean value to a String.
-     *
-     * @param v The Boolean value to convert.
-     * @return The String representation of the Boolean value.
-     * @throws Exception If an error occurs during conversion.
-     */
+    /// Converts a Boolean value to a String.
+    ///
+    /// @param v The Boolean value to convert.
+    /// @return The String representation of the Boolean value.
+    /// @throws Exception If an error occurs during conversion.
     @Override
     public String marshal(Boolean v) throws Exception {
       return v ? "y" : "n";

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Tilesets.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/Tilesets.java
@@ -8,25 +8,19 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-/**
- * Manages the loading and storage of Tileset resources.
- */
+/// Manages the loading and storage of Tileset resources.
 public class Tilesets extends ResourcesContainer<Tileset> {
 
-  /**
-   * Default constructor for the Tilesets class. This constructor is kept for serialization purposes.
-   */
+  /// Default constructor for the Tilesets class. This constructor is kept for serialization purposes.
   Tilesets() {
   }
 
-  /**
-   * Loads a Tileset from the specified URL.
-   *
-   * @param resourceName The URL of the resource to load.
-   * @return The loaded Tileset.
-   * @throws IOException        If an I/O error occurs.
-   * @throws URISyntaxException If the URL is not formatted correctly.
-   */
+  /// Loads a Tileset from the specified URL.
+  ///
+  /// @param resourceName The URL of the resource to load.
+  /// @return The loaded Tileset.
+  /// @throws IOException        If an I/O error occurs.
+  /// @throws URISyntaxException If the URL is not formatted correctly.
   @Override
   protected Tileset load(URL resourceName) throws IOException, URISyntaxException {
     try {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/resources/package-info.java
@@ -1,0 +1,5 @@
+/// Typed repositories and loading utilities for maps, images, sounds, sprites, and other assets.
+///
+/// Access the standard repositories through the static
+/// [de.gurkenlabs.litiengine.resources.Resources] facade.
+package de.gurkenlabs.litiengine.resources;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/AbstractScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/AbstractScript.java
@@ -14,8 +14,14 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.geom.Point2D;
 
 /// Base implementation that provides typed access to a script host, context, and global state.
+///
+/// Override the protected lifecycle and input callbacks needed by the script. Resources registered
+/// through [#context()] are automatically released after [#detached()] completes.
+///
+/// @param <T> The required host type.
 public abstract class AbstractScript<T> implements ScriptInstance {
   private ScriptContext<T> context;
+  /// Game-wide values shared between scripts.
   protected final ScriptGlobals globals = Game.scripts().globals();
 
   @Override
@@ -43,112 +49,205 @@ public abstract class AbstractScript<T> implements ScriptInstance {
   }
 
   /// Called during the render pass for custom graphics rendering.
+  ///
+  /// @param g The current graphics context.
+  /// @throws Exception if rendering fails.
   protected void onRender(Graphics2D g) throws Exception {}
 
   /// Called when a key is pressed.
+  ///
+  /// @param event The keyboard event.
+  /// @throws Exception if handling fails.
   protected void onKeyPressed(KeyEvent event) throws Exception {}
 
   /// Called when a key is released.
+  ///
+  /// @param event The keyboard event.
+  /// @throws Exception if handling fails.
   protected void onKeyReleased(KeyEvent event) throws Exception {}
 
   /// Called when a key is typed.
+  ///
+  /// @param event The keyboard event.
+  /// @throws Exception if handling fails.
   protected void onKeyTyped(KeyEvent event) throws Exception {}
 
   /// Called when a mouse button is clicked (pressed and released).
+  ///
+  /// @param event The mouse event.
+  /// @throws Exception if handling fails.
   protected void onMouseClicked(MouseEvent event) throws Exception {}
 
   /// Called when a mouse button is pressed.
+  ///
+  /// @param event The mouse event.
+  /// @throws Exception if handling fails.
   protected void onMousePressed(MouseEvent event) throws Exception {}
 
   /// Called when a mouse button is released.
+  ///
+  /// @param event The mouse event.
+  /// @throws Exception if handling fails.
   protected void onMouseReleased(MouseEvent event) throws Exception {}
 
   /// Called when the mouse is moved.
+  ///
+  /// @param event The mouse event.
+  /// @throws Exception if handling fails.
   protected void onMouseMoved(MouseEvent event) throws Exception {}
 
   /// Called when the mouse wheel is rotated.
+  ///
+  /// @param event The wheel event.
+  /// @throws Exception if handling fails.
   protected void onMouseWheel(MouseWheelEvent event) throws Exception {}
 
+  /// Returns the current attachment context.
+  ///
+  /// @return The current context.
+  /// @throws IllegalStateException if the script is not attached.
   protected final ScriptContext<T> context() {
     if (this.context == null) throw new IllegalStateException("The script is not attached.");
     return this.context;
   }
 
+  /// Returns the current script host.
+  ///
+  /// @return The typed host.
   protected final T host() {
     return this.context().host();
   }
 
   /// Returns the host's current environment, or `null` for game scripts without one.
+  ///
+  /// @return The current environment, or `null` when unavailable.
   protected final Environment environment() {
     return this.context().environment();
   }
 
+  /// Returns game-wide values shared between scripts.
+  ///
+  /// @return The shared global registry.
   protected final ScriptGlobals globals() {
     return this.globals;
   }
 
   /// Returns the managed input helper for key/mouse bindings and state queries.
+  ///
+  /// @return The input helper owned by this attachment.
   protected final ScriptInput input() {
     return this.context().input();
   }
 
   /// Returns the scripted UI overlay service owned by this context.
+  ///
+  /// @return The overlay owned by this attachment.
   protected final ScriptUiOverlay ui() {
     return this.context().ui();
   }
 
   /// Returns the active camera from the game world.
+  ///
+  /// @return The active camera, or `null` when unavailable.
   protected final ICamera camera() {
     return this.context().camera();
   }
 
   /// Returns a fluent spawner for creating entities in the current environment.
+  ///
+  /// @return A spawner bound to the current environment.
   protected final ScriptedSpawner spawner() {
     return this.context().spawner();
   }
 
   /// Spawns a creature with the given sprite prefix at the specified coordinates.
+  ///
+  /// @param spritePrefix The animation sprite prefix.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @return The spawned creature.
   protected final Creature spawnCreature(String spritePrefix, double x, double y) {
     return this.context().spawnCreature(spritePrefix, x, y);
   }
 
   /// Spawns a creature with the given sprite prefix at the specified location.
+  ///
+  /// @param spritePrefix The animation sprite prefix.
+  /// @param location The location in map coordinates.
+  /// @return The spawned creature.
   protected final Creature spawnCreature(String spritePrefix, Point2D location) {
     return this.context().spawnCreature(spritePrefix, location);
   }
 
   /// Spawns a prop with the given spritesheet at the specified coordinates.
+  ///
+  /// @param spriteSheet The spritesheet name.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @return The spawned prop.
   protected final Prop spawnProp(String spriteSheet, double x, double y) {
     return this.context().spawnProp(spriteSheet, x, y);
   }
 
   /// Spawns a prop with the given spritesheet at the specified location.
+  ///
+  /// @param spriteSheet The spritesheet name.
+  /// @param location The location in map coordinates.
+  /// @return The spawned prop.
   protected final Prop spawnProp(String spriteSheet, Point2D location) {
     return this.context().spawnProp(spriteSheet, location);
   }
 
   /// Spawns an entity of the given type at the specified coordinates.
+  ///
+  /// @param entityType The concrete entity type.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @param <E> The entity type.
+  /// @return The spawned entity.
   protected final <E extends IEntity> E spawn(Class<E> entityType, double x, double y) {
     return this.context().spawn(entityType, x, y);
   }
 
   /// Spawns an entity of the given type at the specified location.
+  ///
+  /// @param entityType The concrete entity type.
+  /// @param location The location in map coordinates.
+  /// @param <E> The entity type.
+  /// @return The spawned entity.
   protected final <E extends IEntity> E spawn(Class<E> entityType, Point2D location) {
     return this.context().spawn(entityType, location);
   }
 
   /// Spawns the given entity at the specified coordinates.
+  ///
+  /// @param entity The entity to add.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @param <E> The entity type.
+  /// @return The supplied entity.
   protected final <E extends IEntity> E spawn(E entity, double x, double y) {
     return this.context().spawn(entity, x, y);
   }
 
   /// Spawns the given entity at the specified location.
+  ///
+  /// @param entity The entity to add.
+  /// @param location The location in map coordinates.
+  /// @param <E> The entity type.
+  /// @return The supplied entity.
   protected final <E extends IEntity> E spawn(E entity, Point2D location) {
     return this.context().spawn(entity, location);
   }
 
+  /// Called after the context is installed and the script becomes active.
+  ///
+  /// @throws Exception if initialization fails.
   protected void attached() throws Exception {}
 
+  /// Called before context-owned resources are released.
+  ///
+  /// @throws Exception if cleanup fails.
   protected void detached() throws Exception {}
 
   final void dispatchKeyPressed(KeyEvent event) throws Exception {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/AbstractScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/AbstractScript.java
@@ -13,7 +13,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.Point2D;
 
-/** Base implementation that provides typed access to a script host, context, and global state. */
+/// Base implementation that provides typed access to a script host, context, and global state.
 public abstract class AbstractScript<T> implements ScriptInstance {
   private ScriptContext<T> context;
   protected final ScriptGlobals globals = Game.scripts().globals();
@@ -42,31 +42,31 @@ public abstract class AbstractScript<T> implements ScriptInstance {
     this.onRender(g);
   }
 
-  /** Called during the render pass for custom graphics rendering. */
+  /// Called during the render pass for custom graphics rendering.
   protected void onRender(Graphics2D g) throws Exception {}
 
-  /** Called when a key is pressed. */
+  /// Called when a key is pressed.
   protected void onKeyPressed(KeyEvent event) throws Exception {}
 
-  /** Called when a key is released. */
+  /// Called when a key is released.
   protected void onKeyReleased(KeyEvent event) throws Exception {}
 
-  /** Called when a key is typed. */
+  /// Called when a key is typed.
   protected void onKeyTyped(KeyEvent event) throws Exception {}
 
-  /** Called when a mouse button is clicked (pressed and released). */
+  /// Called when a mouse button is clicked (pressed and released).
   protected void onMouseClicked(MouseEvent event) throws Exception {}
 
-  /** Called when a mouse button is pressed. */
+  /// Called when a mouse button is pressed.
   protected void onMousePressed(MouseEvent event) throws Exception {}
 
-  /** Called when a mouse button is released. */
+  /// Called when a mouse button is released.
   protected void onMouseReleased(MouseEvent event) throws Exception {}
 
-  /** Called when the mouse is moved. */
+  /// Called when the mouse is moved.
   protected void onMouseMoved(MouseEvent event) throws Exception {}
 
-  /** Called when the mouse wheel is rotated. */
+  /// Called when the mouse wheel is rotated.
   protected void onMouseWheel(MouseWheelEvent event) throws Exception {}
 
   protected final ScriptContext<T> context() {
@@ -78,7 +78,7 @@ public abstract class AbstractScript<T> implements ScriptInstance {
     return this.context().host();
   }
 
-  /** Returns the host's current environment, or {@code null} for game scripts without one. */
+  /// Returns the host's current environment, or `null` for game scripts without one.
   protected final Environment environment() {
     return this.context().environment();
   }
@@ -87,62 +87,62 @@ public abstract class AbstractScript<T> implements ScriptInstance {
     return this.globals;
   }
 
-  /** Returns the managed input helper for key/mouse bindings and state queries. */
+  /// Returns the managed input helper for key/mouse bindings and state queries.
   protected final ScriptInput input() {
     return this.context().input();
   }
 
-  /** Returns the scripted UI overlay service owned by this context. */
+  /// Returns the scripted UI overlay service owned by this context.
   protected final ScriptUiOverlay ui() {
     return this.context().ui();
   }
 
-  /** Returns the active camera from the game world. */
+  /// Returns the active camera from the game world.
   protected final ICamera camera() {
     return this.context().camera();
   }
 
-  /** Returns a fluent spawner for creating entities in the current environment. */
+  /// Returns a fluent spawner for creating entities in the current environment.
   protected final ScriptedSpawner spawner() {
     return this.context().spawner();
   }
 
-  /** Spawns a creature with the given sprite prefix at the specified coordinates. */
+  /// Spawns a creature with the given sprite prefix at the specified coordinates.
   protected final Creature spawnCreature(String spritePrefix, double x, double y) {
     return this.context().spawnCreature(spritePrefix, x, y);
   }
 
-  /** Spawns a creature with the given sprite prefix at the specified location. */
+  /// Spawns a creature with the given sprite prefix at the specified location.
   protected final Creature spawnCreature(String spritePrefix, Point2D location) {
     return this.context().spawnCreature(spritePrefix, location);
   }
 
-  /** Spawns a prop with the given spritesheet at the specified coordinates. */
+  /// Spawns a prop with the given spritesheet at the specified coordinates.
   protected final Prop spawnProp(String spriteSheet, double x, double y) {
     return this.context().spawnProp(spriteSheet, x, y);
   }
 
-  /** Spawns a prop with the given spritesheet at the specified location. */
+  /// Spawns a prop with the given spritesheet at the specified location.
   protected final Prop spawnProp(String spriteSheet, Point2D location) {
     return this.context().spawnProp(spriteSheet, location);
   }
 
-  /** Spawns an entity of the given type at the specified coordinates. */
+  /// Spawns an entity of the given type at the specified coordinates.
   protected final <E extends IEntity> E spawn(Class<E> entityType, double x, double y) {
     return this.context().spawn(entityType, x, y);
   }
 
-  /** Spawns an entity of the given type at the specified location. */
+  /// Spawns an entity of the given type at the specified location.
   protected final <E extends IEntity> E spawn(Class<E> entityType, Point2D location) {
     return this.context().spawn(entityType, location);
   }
 
-  /** Spawns the given entity at the specified coordinates. */
+  /// Spawns the given entity at the specified coordinates.
   protected final <E extends IEntity> E spawn(E entity, double x, double y) {
     return this.context().spawn(entity, x, y);
   }
 
-  /** Spawns the given entity at the specified location. */
+  /// Spawns the given entity at the specified location.
   protected final <E extends IEntity> E spawn(E entity, Point2D location) {
     return this.context().spawn(entity, location);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/CompiledScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/CompiledScript.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.scripting;
 
-/** A compiled script generation that can create fresh instances. */
+/// A compiled script generation that can create fresh instances.
 public interface CompiledScript extends AutoCloseable {
   ScriptInstance create() throws ScriptException;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/CreatureScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/CreatureScript.java
@@ -8,55 +8,55 @@ import de.gurkenlabs.litiengine.scripting.combat.ScriptedAbilityBuilder;
 import de.gurkenlabs.litiengine.util.geom.GeometricUtilities;
 import java.awt.geom.Point2D;
 
-/** Convenient base class for creature behavior scripts with movement and combat helpers. */
+/// Convenient base class for creature behavior scripts with movement and combat helpers.
 public abstract class CreatureScript extends EntityScript<Creature> {
-  /** Moves the creature towards a target point in the game world. */
+  /// Moves the creature towards a target point in the game world.
   public void moveTowards(Point2D target) {
     if (target == null || this.host() == null) return;
     double angle = GeometricUtilities.calcRotationAngleInDegrees(this.host().getCenter(), target);
     Game.physics().move(this.host(), angle, this.host().getTickVelocity());
   }
 
-  /** Moves the creature towards a target entity. */
+  /// Moves the creature towards a target entity.
   public void moveTowards(IEntity target) {
     if (target != null) {
       this.moveTowards(target.getCenter());
     }
   }
 
-  /** Moves the creature in a specific compass direction. */
+  /// Moves the creature in a specific compass direction.
   public void moveInDirection(Direction direction) {
     if (direction != null && this.host() != null) {
       Game.physics().move(this.host(), direction.toAngle(), this.host().getTickVelocity());
     }
   }
 
-  /** Moves the creature at a specific angle in degrees (0 = North, 90 = East, 180 = South, 270 = West). */
+  /// Moves the creature at a specific angle in degrees (0 = North, 90 = East, 180 = South, 270 = West).
   public void moveInAngle(double angleDegrees) {
     if (this.host() != null) {
       Game.physics().move(this.host(), angleDegrees, this.host().getTickVelocity());
     }
   }
 
-  /** Checks if the creature is currently dead. */
+  /// Checks if the creature is currently dead.
   @Override
   public boolean isDead() {
     return this.host() != null && this.host().isDead();
   }
 
-  /** Returns current health / hitpoints. */
+  /// Returns current health / hitpoints.
   @Override
   public int getHealth() {
     return this.host() != null ? this.host().getHitPoints().getModifiedValue() : 0;
   }
 
-  /** Returns maximum health / hitpoints. */
+  /// Returns maximum health / hitpoints.
   @Override
   public int getMaxHealth() {
     return this.host() != null ? this.host().getHitPoints().getMax() : 0;
   }
 
-  /** Begins building a scripted ability executed by this creature. */
+  /// Begins building a scripted ability executed by this creature.
   public ScriptedAbilityBuilder createAbility(String name) {
     if (this.host() == null) {
       throw new IllegalStateException("Creature host is not attached.");
@@ -64,41 +64,37 @@ public abstract class CreatureScript extends EntityScript<Creature> {
     return new ScriptedAbilityBuilder(this.host(), name);
   }
 
-  /** Casts an ability registered on this creature by its name. */
+  /// Casts an ability registered on this creature by its name.
   public de.gurkenlabs.litiengine.abilities.AbilityExecution cast(String name) {
     return this.host() != null ? this.host().cast(name) : null;
   }
 
-  /** Gets an ability registered on this creature by its name. */
+  /// Gets an ability registered on this creature by its name.
   public java.util.Optional<de.gurkenlabs.litiengine.abilities.Ability> getAbility(String name) {
     return this.host() != null ? this.host().getAbility(name) : java.util.Optional.empty();
   }
 
-  /** Checks if this creature has an ability registered with the specified name. */
+  /// Checks if this creature has an ability registered with the specified name.
   public boolean hasAbility(String name) {
     return this.host() != null && this.host().hasAbility(name);
   }
 
-  /** Checks if an ability registered with the specified name can currently be cast. */
+  /// Checks if an ability registered with the specified name can currently be cast.
   public boolean canCast(String name) {
     return this.host() != null && this.host().canCast(name);
   }
 
-  /** Checks if an ability registered with the specified name is currently on cooldown. */
+  /// Checks if an ability registered with the specified name is currently on cooldown.
   public boolean isOnCooldown(String name) {
     return this.host() != null && this.host().isOnCooldown(name);
   }
 
-  /**
-   * Configures top-down WASD keyboard movement for this creature and binds its lifecycle to this script.
-   */
+  /// Configures top-down WASD keyboard movement for this creature and binds its lifecycle to this script.
   public de.gurkenlabs.litiengine.input.KeyboardEntityController<Creature> enableTopDownMovement() {
     return this.enableTopDownMovement(java.awt.event.KeyEvent.VK_W, java.awt.event.KeyEvent.VK_S, java.awt.event.KeyEvent.VK_A, java.awt.event.KeyEvent.VK_D);
   }
 
-  /**
-   * Configures top-down keyboard movement with custom keys for this creature and binds its lifecycle to this script.
-   */
+  /// Configures top-down keyboard movement with custom keys for this creature and binds its lifecycle to this script.
   public de.gurkenlabs.litiengine.input.KeyboardEntityController<Creature> enableTopDownMovement(int up, int down, int left, int right) {
     if (this.host() == null) {
       throw new IllegalStateException("Creature host is not attached.");
@@ -109,16 +105,12 @@ public abstract class CreatureScript extends EntityScript<Creature> {
     return controller;
   }
 
-  /**
-   * Configures platforming movement (A/D/Space) for this creature and binds its lifecycle to this script.
-   */
+  /// Configures platforming movement (A/D/Space) for this creature and binds its lifecycle to this script.
   public de.gurkenlabs.litiengine.input.PlatformingMovementController<Creature> enablePlatformingMovement() {
     return this.enablePlatformingMovement(java.awt.event.KeyEvent.VK_A, java.awt.event.KeyEvent.VK_D, java.awt.event.KeyEvent.VK_SPACE);
   }
 
-  /**
-   * Configures platforming movement with custom keys for this creature and binds its lifecycle to this script.
-   */
+  /// Configures platforming movement with custom keys for this creature and binds its lifecycle to this script.
   public de.gurkenlabs.litiengine.input.PlatformingMovementController<Creature> enablePlatformingMovement(int left, int right, int jump) {
     if (this.host() == null) {
       throw new IllegalStateException("Creature host is not attached.");
@@ -131,7 +123,7 @@ public abstract class CreatureScript extends EntityScript<Creature> {
     return controller;
   }
 
-  /** Disables and removes active movement controllers on this creature. */
+  /// Disables and removes active movement controllers on this creature.
   public void disableMovementController() {
     if (this.host() != null) {
       var current = this.host().getController(de.gurkenlabs.litiengine.physics.IMovementController.class);
@@ -142,7 +134,7 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
 
-  /** Called when the platforming movement controller executes a jump action. */
+  /// Called when the platforming movement controller executes a jump action.
   protected void onJump() throws Exception {}
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/CreatureScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/CreatureScript.java
@@ -11,6 +11,7 @@ import java.awt.geom.Point2D;
 /// Convenient base class for creature behavior scripts with movement and combat helpers.
 public abstract class CreatureScript extends EntityScript<Creature> {
   /// Moves the creature towards a target point in the game world.
+  /// @param target The target in map coordinates; `null` has no effect.
   public void moveTowards(Point2D target) {
     if (target == null || this.host() == null) return;
     double angle = GeometricUtilities.calcRotationAngleInDegrees(this.host().getCenter(), target);
@@ -18,6 +19,7 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
   /// Moves the creature towards a target entity.
+  /// @param target The target entity; `null` has no effect.
   public void moveTowards(IEntity target) {
     if (target != null) {
       this.moveTowards(target.getCenter());
@@ -25,6 +27,7 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
   /// Moves the creature in a specific compass direction.
+  /// @param direction The direction; `null` has no effect.
   public void moveInDirection(Direction direction) {
     if (direction != null && this.host() != null) {
       Game.physics().move(this.host(), direction.toAngle(), this.host().getTickVelocity());
@@ -32,6 +35,7 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
   /// Moves the creature at a specific angle in degrees (0 = North, 90 = East, 180 = South, 270 = West).
+  /// @param angleDegrees The movement angle in degrees.
   public void moveInAngle(double angleDegrees) {
     if (this.host() != null) {
       Game.physics().move(this.host(), angleDegrees, this.host().getTickVelocity());
@@ -39,24 +43,29 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
   /// Checks if the creature is currently dead.
+  /// @return `true` if the attached creature is dead.
   @Override
   public boolean isDead() {
     return this.host() != null && this.host().isDead();
   }
 
   /// Returns current health / hitpoints.
+  /// @return The current hit points, or zero when detached.
   @Override
   public int getHealth() {
     return this.host() != null ? this.host().getHitPoints().getModifiedValue() : 0;
   }
 
   /// Returns maximum health / hitpoints.
+  /// @return The maximum hit points, or zero when detached.
   @Override
   public int getMaxHealth() {
     return this.host() != null ? this.host().getHitPoints().getMax() : 0;
   }
 
   /// Begins building a scripted ability executed by this creature.
+  /// @param name The ability name.
+  /// @return A builder for the new ability.
   public ScriptedAbilityBuilder createAbility(String name) {
     if (this.host() == null) {
       throw new IllegalStateException("Creature host is not attached.");
@@ -65,36 +74,52 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
   /// Casts an ability registered on this creature by its name.
+  /// @param name The ability name.
+  /// @return The execution, or `null` when detached or not castable.
   public de.gurkenlabs.litiengine.abilities.AbilityExecution cast(String name) {
     return this.host() != null ? this.host().cast(name) : null;
   }
 
   /// Gets an ability registered on this creature by its name.
+  /// @param name The ability name.
+  /// @return The ability, or an empty optional.
   public java.util.Optional<de.gurkenlabs.litiengine.abilities.Ability> getAbility(String name) {
     return this.host() != null ? this.host().getAbility(name) : java.util.Optional.empty();
   }
 
   /// Checks if this creature has an ability registered with the specified name.
+  /// @param name The ability name.
+  /// @return `true` if it is registered.
   public boolean hasAbility(String name) {
     return this.host() != null && this.host().hasAbility(name);
   }
 
   /// Checks if an ability registered with the specified name can currently be cast.
+  /// @param name The ability name.
+  /// @return `true` if it can currently be cast.
   public boolean canCast(String name) {
     return this.host() != null && this.host().canCast(name);
   }
 
   /// Checks if an ability registered with the specified name is currently on cooldown.
+  /// @param name The ability name.
+  /// @return `true` if it is cooling down.
   public boolean isOnCooldown(String name) {
     return this.host() != null && this.host().isOnCooldown(name);
   }
 
   /// Configures top-down WASD keyboard movement for this creature and binds its lifecycle to this script.
+  /// @return The installed movement controller.
   public de.gurkenlabs.litiengine.input.KeyboardEntityController<Creature> enableTopDownMovement() {
     return this.enableTopDownMovement(java.awt.event.KeyEvent.VK_W, java.awt.event.KeyEvent.VK_S, java.awt.event.KeyEvent.VK_A, java.awt.event.KeyEvent.VK_D);
   }
 
   /// Configures top-down keyboard movement with custom keys for this creature and binds its lifecycle to this script.
+  /// @param up The key code for upward movement.
+  /// @param down The key code for downward movement.
+  /// @param left The key code for left movement.
+  /// @param right The key code for right movement.
+  /// @return The installed movement controller.
   public de.gurkenlabs.litiengine.input.KeyboardEntityController<Creature> enableTopDownMovement(int up, int down, int left, int right) {
     if (this.host() == null) {
       throw new IllegalStateException("Creature host is not attached.");
@@ -106,11 +131,16 @@ public abstract class CreatureScript extends EntityScript<Creature> {
   }
 
   /// Configures platforming movement (A/D/Space) for this creature and binds its lifecycle to this script.
+  /// @return The installed movement controller.
   public de.gurkenlabs.litiengine.input.PlatformingMovementController<Creature> enablePlatformingMovement() {
     return this.enablePlatformingMovement(java.awt.event.KeyEvent.VK_A, java.awt.event.KeyEvent.VK_D, java.awt.event.KeyEvent.VK_SPACE);
   }
 
   /// Configures platforming movement with custom keys for this creature and binds its lifecycle to this script.
+  /// @param left The key code for left movement.
+  /// @param right The key code for right movement.
+  /// @param jump The key code for jumping.
+  /// @return The installed movement controller.
   public de.gurkenlabs.litiengine.input.PlatformingMovementController<Creature> enablePlatformingMovement(int left, int right, int jump) {
     if (this.host() == null) {
       throw new IllegalStateException("Creature host is not attached.");
@@ -135,6 +165,7 @@ public abstract class CreatureScript extends EntityScript<Creature> {
 
 
   /// Called when the platforming movement controller executes a jump action.
+  /// @throws Exception if handling fails.
   protected void onJump() throws Exception {}
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EngineTypeCatalog.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EngineTypeCatalog.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarFile;
 
-/** Lazily indexes public types from the engine artifact and optional project classloaders. */
+/// Lazily indexes public types from the engine artifact and optional project classloaders.
 public final class EngineTypeCatalog {
   private static final String ENGINE_PACKAGE = "de/gurkenlabs/litiengine/";
   private static final Map<ClassLoader, List<Class<?>>> CACHE = new ConcurrentHashMap<>();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScript.java
@@ -6,17 +6,23 @@ import de.gurkenlabs.litiengine.entities.IEntity;
 import java.util.Objects;
 
 /// Base class for scripts attached to an entity.
+///
+/// @param <T> The required entity host type.
 public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> {
   @Override protected final void attached() throws Exception { this.onLoaded(); }
   @Override protected final void detached() throws Exception { this.onUnloaded(); }
 
   /// Called from the entity's loaded event after its environment is available.
+  /// @throws Exception if initialization fails.
   protected void onLoaded() throws Exception { this.loaded(); }
 
   /// Called when the entity controller is detached or the entity is removed.
+  /// @throws Exception if cleanup fails.
   protected void onUnloaded() throws Exception { this.unloaded(); }
 
   /// Called for messages delivered to the attached entity.
+  /// @param event The message event.
+  /// @throws Exception if handling fails.
   protected void onMessage(EntityMessageEvent event) throws Exception {
     this.message(event);
     if (event != null) {
@@ -25,47 +31,66 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
   }
 
   /// Called when a text message is received by the attached entity.
+  /// @param message The message text.
+  /// @param sender The sending object, or `null`.
+  /// @throws Exception if handling fails.
   protected void onMessage(String message, Object sender) throws Exception {}
 
   /// Called when the attached combat entity is hit.
+  /// @param event The hit event.
+  /// @throws Exception if handling fails.
   protected void onHit(de.gurkenlabs.litiengine.entities.EntityHitEvent event) throws Exception {
     this.onHit();
   }
 
   /// Called when the attached combat entity is hit.
+  /// @throws Exception if handling fails.
   protected void onHit() throws Exception {}
 
   /// Called when the attached combat entity dies.
+  /// @param entity The entity that died.
+  /// @param hitEvent The final hit, or `null` when no hit caused the death.
+  /// @throws Exception if handling fails.
   protected void onDeath(de.gurkenlabs.litiengine.entities.ICombatEntity entity, de.gurkenlabs.litiengine.entities.EntityHitEvent hitEvent) throws Exception {
     this.onDeath();
   }
 
   /// Called when the attached combat entity dies.
+  /// @throws Exception if handling fails.
   protected void onDeath() throws Exception {}
 
   /// Called when the attached collision entity collides with another collision entity.
+  /// @param event The collision details.
+  /// @throws Exception if handling fails.
   protected void onCollision(de.gurkenlabs.litiengine.physics.CollisionEvent event) throws Exception {
     this.onCollision();
   }
 
   /// Called when the attached collision entity collides with another collision entity.
+  /// @throws Exception if handling fails.
   protected void onCollision() throws Exception {}
 
   /// Called when another entity interacts with the attached entity.
+  /// @param source The interacting entity.
+  /// @throws Exception if handling fails.
   protected void onInteract(IEntity source) throws Exception {}
 
   /// Called when an entity action is performed on the attached entity.
+  /// @param action The action identifier.
+  /// @throws Exception if handling fails.
   protected void onAction(String action) throws Exception {}
 
   /// Sends a message from this entity to all of its listeners.
+  /// @param message The message text.
   public void sendMessage(String message) {
-
     if (this.host() != null) {
       this.host().sendMessage(this.host(), message);
     }
   }
 
   /// Sends a message from this entity to a target receiver entity.
+  /// @param receiver The receiving entity.
+  /// @param message The message text.
   public void sendMessage(IEntity receiver, String message) {
     Objects.requireNonNull(receiver, "Receiver entity must not be null.");
     if (this.host() != null) {
@@ -81,6 +106,7 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
   }
 
   /// Checks if the host entity is dead (if it is a combat entity).
+  /// @return `true` if the host is a dead combat entity.
   public boolean isDead() {
     return this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat && combat.isDead();
   }
@@ -100,24 +126,36 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
   }
 
   /// Returns current health / hitpoints (or 0 if not a combat entity).
+  /// @return The current hit points, or zero for non-combat hosts.
   public int getHealth() {
     return this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat ? combat.getHitPoints().getModifiedValue() : 0;
   }
 
   /// Returns maximum health / hitpoints (or 0 if not a combat entity).
+  /// @return The maximum hit points, or zero for non-combat hosts.
   public int getMaxHealth() {
     return this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat ? combat.getHitPoints().getMax() : 0;
   }
 
+  /// Legacy callback invoked after the entity environment becomes available.
+  ///
   /// @deprecated Override [#onLoaded()] in new scripts.
+  /// @throws Exception if handling fails.
   @Deprecated
   protected void loaded() throws Exception {}
 
+  /// Legacy callback invoked when the script is unloaded.
+  ///
   /// @deprecated Override [#onUnloaded()] in new scripts.
+  /// @throws Exception if handling fails.
   @Deprecated
   protected void unloaded() throws Exception {}
 
-  /// @deprecated Override [#onMessage(EntityMessageEvent)] or [Object)][#onMessage(String,] in new scripts.
+  /// Legacy callback invoked when an entity message is received.
+  ///
+  /// @param event The message event.
+  /// @throws Exception if handling fails.
+  /// @deprecated Override [#onMessage(EntityMessageEvent)] or [#onMessage(String, Object)] in new scripts.
   @Deprecated
   protected void message(EntityMessageEvent event) throws Exception {}
 
@@ -145,5 +183,3 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
     this.onAction(action);
   }
 }
-
-

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScript.java
@@ -5,18 +5,18 @@ import de.gurkenlabs.litiengine.entities.EntityMessageListener;
 import de.gurkenlabs.litiengine.entities.IEntity;
 import java.util.Objects;
 
-/** Base class for scripts attached to an entity. */
+/// Base class for scripts attached to an entity.
 public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> {
   @Override protected final void attached() throws Exception { this.onLoaded(); }
   @Override protected final void detached() throws Exception { this.onUnloaded(); }
 
-  /** Called from the entity's loaded event after its environment is available. */
+  /// Called from the entity's loaded event after its environment is available.
   protected void onLoaded() throws Exception { this.loaded(); }
 
-  /** Called when the entity controller is detached or the entity is removed. */
+  /// Called when the entity controller is detached or the entity is removed.
   protected void onUnloaded() throws Exception { this.unloaded(); }
 
-  /** Called for messages delivered to the attached entity. */
+  /// Called for messages delivered to the attached entity.
   protected void onMessage(EntityMessageEvent event) throws Exception {
     this.message(event);
     if (event != null) {
@@ -24,40 +24,40 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
     }
   }
 
-  /** Called when a text message is received by the attached entity. */
+  /// Called when a text message is received by the attached entity.
   protected void onMessage(String message, Object sender) throws Exception {}
 
-  /** Called when the attached combat entity is hit. */
+  /// Called when the attached combat entity is hit.
   protected void onHit(de.gurkenlabs.litiengine.entities.EntityHitEvent event) throws Exception {
     this.onHit();
   }
 
-  /** Called when the attached combat entity is hit. */
+  /// Called when the attached combat entity is hit.
   protected void onHit() throws Exception {}
 
-  /** Called when the attached combat entity dies. */
+  /// Called when the attached combat entity dies.
   protected void onDeath(de.gurkenlabs.litiengine.entities.ICombatEntity entity, de.gurkenlabs.litiengine.entities.EntityHitEvent hitEvent) throws Exception {
     this.onDeath();
   }
 
-  /** Called when the attached combat entity dies. */
+  /// Called when the attached combat entity dies.
   protected void onDeath() throws Exception {}
 
-  /** Called when the attached collision entity collides with another collision entity. */
+  /// Called when the attached collision entity collides with another collision entity.
   protected void onCollision(de.gurkenlabs.litiengine.physics.CollisionEvent event) throws Exception {
     this.onCollision();
   }
 
-  /** Called when the attached collision entity collides with another collision entity. */
+  /// Called when the attached collision entity collides with another collision entity.
   protected void onCollision() throws Exception {}
 
-  /** Called when another entity interacts with the attached entity. */
+  /// Called when another entity interacts with the attached entity.
   protected void onInteract(IEntity source) throws Exception {}
 
-  /** Called when an entity action is performed on the attached entity. */
+  /// Called when an entity action is performed on the attached entity.
   protected void onAction(String action) throws Exception {}
 
-  /** Sends a message from this entity to all of its listeners. */
+  /// Sends a message from this entity to all of its listeners.
   public void sendMessage(String message) {
 
     if (this.host() != null) {
@@ -65,7 +65,7 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
     }
   }
 
-  /** Sends a message from this entity to a target receiver entity. */
+  /// Sends a message from this entity to a target receiver entity.
   public void sendMessage(IEntity receiver, String message) {
     Objects.requireNonNull(receiver, "Receiver entity must not be null.");
     if (this.host() != null) {
@@ -73,51 +73,51 @@ public abstract class EntityScript<T extends IEntity> extends AbstractScript<T> 
     }
   }
 
-  /** Removes this entity from its current environment. */
+  /// Removes this entity from its current environment.
   public void remove() {
     if (this.host() != null && this.host().getEnvironment() != null) {
       this.host().getEnvironment().remove(this.host());
     }
   }
 
-  /** Checks if the host entity is dead (if it is a combat entity). */
+  /// Checks if the host entity is dead (if it is a combat entity).
   public boolean isDead() {
     return this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat && combat.isDead();
   }
 
-  /** Marks the host combat entity as dead. */
+  /// Marks the host combat entity as dead.
   public void die() {
     if (this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat) {
       combat.die();
     }
   }
 
-  /** Resurrects the host combat entity. */
+  /// Resurrects the host combat entity.
   public void resurrect() {
     if (this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat) {
       combat.resurrect();
     }
   }
 
-  /** Returns current health / hitpoints (or 0 if not a combat entity). */
+  /// Returns current health / hitpoints (or 0 if not a combat entity).
   public int getHealth() {
     return this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat ? combat.getHitPoints().getModifiedValue() : 0;
   }
 
-  /** Returns maximum health / hitpoints (or 0 if not a combat entity). */
+  /// Returns maximum health / hitpoints (or 0 if not a combat entity).
   public int getMaxHealth() {
     return this.host() instanceof de.gurkenlabs.litiengine.entities.ICombatEntity combat ? combat.getHitPoints().getMax() : 0;
   }
 
-  /** @deprecated Override {@link #onLoaded()} in new scripts. */
+  /// @deprecated Override [#onLoaded()] in new scripts.
   @Deprecated
   protected void loaded() throws Exception {}
 
-  /** @deprecated Override {@link #onUnloaded()} in new scripts. */
+  /// @deprecated Override [#onUnloaded()] in new scripts.
   @Deprecated
   protected void unloaded() throws Exception {}
 
-  /** @deprecated Override {@link #onMessage(EntityMessageEvent)} or {@link #onMessage(String, Object)} in new scripts. */
+  /// @deprecated Override [#onMessage(EntityMessageEvent)] or [Object)][#onMessage(String,] in new scripts.
   @Deprecated
   protected void message(EntityMessageEvent event) throws Exception {}
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScriptBinding.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScriptBinding.java
@@ -8,7 +8,7 @@ import jakarta.xml.bind.annotation.XmlElementWrapper;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Reusable script bindings that are automatically applied to entities of a project type. */
+/// Reusable script bindings that are automatically applied to entities of a project type.
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class EntityScriptBinding {
   @XmlAttribute(required = true) private String targetType;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScriptController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScriptController.java
@@ -27,6 +27,10 @@ public final class EntityScriptController<T extends IEntity> implements IEntityC
   private boolean controllerAttached;
   private boolean scriptsAttached;
 
+  /// Creates a script controller for an entity.
+  ///
+  /// @param entity The entity to control.
+  /// @param bindings The initial explicit bindings, or `null` for none.
   public EntityScriptController(T entity, Collection<ScriptBinding> bindings) {
     this.entity = Objects.requireNonNull(entity);
     this.explicitBindings = copyBindings(bindings);
@@ -76,16 +80,23 @@ public final class EntityScriptController<T extends IEntity> implements IEntityC
     return this.entity;
   }
 
+  /// Returns the merged, ordered list of active script bindings for this entity.
+  ///
+  /// @return The list of merged bindings.
   public List<ScriptBinding> getBindings() {
     return this.bindings;
   }
 
   /// Returns only bindings explicitly configured on this entity.
+  ///
+  /// @return The list of explicit bindings.
   public List<ScriptBinding> getExplicitBindings() {
     return this.explicitBindings;
   }
 
   /// Replaces the ordered bindings and restarts this controller if it is active.
+  ///
+  /// @param bindings The replacement bindings, or `null` to clear them.
   public void setBindings(Collection<ScriptBinding> bindings) {
     boolean restart = this.scriptsAttached;
     if (restart) this.detachScripts();
@@ -95,6 +106,8 @@ public final class EntityScriptController<T extends IEntity> implements IEntityC
   }
 
   /// Replaces inherited type-level bindings while retaining per-entity overrides.
+  ///
+  /// @param bindings The default bindings, or `null` to clear them.
   public void setDefaultBindings(Collection<ScriptBinding> bindings) {
     boolean restart = this.scriptsAttached;
     if (restart) this.detachScripts();
@@ -103,6 +116,9 @@ public final class EntityScriptController<T extends IEntity> implements IEntityC
     if (restart && this.controllerAttached && this.entity.isLoaded()) this.attachScripts();
   }
 
+  /// Returns whether script instances are currently attached to the entity.
+  ///
+  /// @return `true` if scripts are attached.
   public boolean isAttached() {
     return this.scriptsAttached;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScriptController.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EntityScriptController.java
@@ -12,14 +12,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-/**
- * Owns the script bindings of an entity and maps them onto the regular entity-controller lifecycle.
- *
- * <p>The controller is attached by the environment before {@link IEntity#loaded(Environment)} is fired. Script
- * instances are therefore created from the entity's loaded event, after its current environment is available.
- */
+/// Owns the script bindings of an entity and maps them onto the regular entity-controller lifecycle.
+///
+/// The controller is attached by the environment before [IEntity#loaded(Environment)] is fired. Script
+/// instances are therefore created from the entity's loaded event, after its current environment is available.
 public final class EntityScriptController<T extends IEntity> implements IEntityController {
-  /** Entity scripts are behavior orchestration and run after default movement controllers. */
+  /// Entity scripts are behavior orchestration and run after default movement controllers.
   public static final int SCRIPT_UPDATE_PRIORITY = 100;
   private final T entity;
   private final EntityListener lifecycleListener;
@@ -82,12 +80,12 @@ public final class EntityScriptController<T extends IEntity> implements IEntityC
     return this.bindings;
   }
 
-  /** Returns only bindings explicitly configured on this entity. */
+  /// Returns only bindings explicitly configured on this entity.
   public List<ScriptBinding> getExplicitBindings() {
     return this.explicitBindings;
   }
 
-  /** Replaces the ordered bindings and restarts this controller if it is active. */
+  /// Replaces the ordered bindings and restarts this controller if it is active.
   public void setBindings(Collection<ScriptBinding> bindings) {
     boolean restart = this.scriptsAttached;
     if (restart) this.detachScripts();
@@ -96,7 +94,7 @@ public final class EntityScriptController<T extends IEntity> implements IEntityC
     if (restart && this.controllerAttached && this.entity.isLoaded()) this.attachScripts();
   }
 
-  /** Replaces inherited type-level bindings while retaining per-entity overrides. */
+  /// Replaces inherited type-level bindings while retaining per-entity overrides.
   public void setDefaultBindings(Collection<ScriptBinding> bindings) {
     boolean restart = this.scriptsAttached;
     if (restart) this.detachScripts();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EnvironmentScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/EnvironmentScript.java
@@ -3,31 +3,31 @@ package de.gurkenlabs.litiengine.scripting;
 import de.gurkenlabs.litiengine.entities.IEntity;
 import de.gurkenlabs.litiengine.environment.Environment;
 
-/** Base class for scripts attached to one loaded environment. */
+/// Base class for scripts attached to one loaded environment.
 public abstract class EnvironmentScript extends AbstractScript<Environment> {
   @Override protected final void attached() throws Exception { this.onLoaded(); }
   @Override protected final void detached() throws Exception { this.onUnloaded(); }
 
-  /** Called after the environment has loaded and is the current world environment. */
+  /// Called after the environment has loaded and is the current world environment.
   protected void onLoaded() throws Exception { this.loaded(); }
 
-  /** Called when the environment binding is detached during unload. */
+  /// Called when the environment binding is detached during unload.
   protected void onUnloaded() throws Exception { this.unloaded(); }
 
-  /** Called when the attached environment is cleared while it remains active. */
+  /// Called when the attached environment is cleared while it remains active.
   protected void onCleared() throws Exception {}
 
-  /** Called when an entity is added to the attached environment. */
+  /// Called when an entity is added to the attached environment.
   protected void onEntityAdded(IEntity entity) throws Exception {}
 
-  /** Called when an entity is removed from the attached environment. */
+  /// Called when an entity is removed from the attached environment.
   protected void onEntityRemoved(IEntity entity) throws Exception {}
 
-  /** @deprecated Override {@link #onLoaded()} in new scripts. */
+  /// @deprecated Override [#onLoaded()] in new scripts.
   @Deprecated
   protected void loaded() throws Exception {}
 
-  /** @deprecated Override {@link #onUnloaded()} in new scripts. */
+  /// @deprecated Override [#onUnloaded()] in new scripts.
   @Deprecated
   protected void unloaded() throws Exception {}
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/GameScript.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/GameScript.java
@@ -6,30 +6,30 @@ import de.gurkenlabs.litiengine.resources.Resources;
 import de.gurkenlabs.litiengine.sound.Sound;
 import java.util.Objects;
 
-/** Base class for scripts attached to the game lifecycle. */
+/// Base class for scripts attached to the game lifecycle.
 public abstract class GameScript extends AbstractScript<Object> {
   @Override protected final void attached() throws Exception { this.onStarted(); }
   @Override protected final void detached() throws Exception { this.onStopped(); }
 
-  /** Called after the binding enters the running game lifecycle. */
+  /// Called after the binding enters the running game lifecycle.
   protected void onStarted() throws Exception { this.started(); }
 
-  /** Called before the binding leaves the game lifecycle. */
+  /// Called before the binding leaves the game lifecycle.
   protected void onStopped() throws Exception { this.stopped(); }
 
-  /** Loads an environment map by map name. */
+  /// Loads an environment map by map name.
   public void loadMap(String mapName) {
     Objects.requireNonNull(mapName, "Map name must not be null.");
     Game.world().loadEnvironment(mapName);
   }
 
-  /** Loads an environment map. */
+  /// Loads an environment map.
   public void loadMap(IMap map) {
     Objects.requireNonNull(map, "Map must not be null.");
     Game.world().loadEnvironment(map);
   }
 
-  /** Plays a sound effect by resource name. */
+  /// Plays a sound effect by resource name.
   public void playSound(String soundName) {
     if (soundName == null || soundName.isBlank()) return;
     Sound sound = Resources.sounds().get(soundName);
@@ -38,7 +38,7 @@ public abstract class GameScript extends AbstractScript<Object> {
     }
   }
 
-  /** Plays a background music track by resource name. */
+  /// Plays a background music track by resource name.
   public void playMusic(String musicName) {
     if (musicName == null || musicName.isBlank()) return;
     Sound music = Resources.sounds().get(musicName);
@@ -47,21 +47,21 @@ public abstract class GameScript extends AbstractScript<Object> {
     }
   }
 
-  /** Stops currently playing music. */
+  /// Stops currently playing music.
   public void stopMusic() {
     Game.audio().stopMusic();
   }
 
-  /** Exits and terminates the game. */
+  /// Exits and terminates the game.
   public void exit() {
     Game.terminate();
   }
 
-  /** @deprecated Override {@link #onStarted()} in new scripts. */
+  /// @deprecated Override [#onStarted()] in new scripts.
   @Deprecated
   protected void started() throws Exception {}
 
-  /** @deprecated Override {@link #onStopped()} in new scripts. */
+  /// @deprecated Override [#onStopped()] in new scripts.
   @Deprecated
   protected void stopped() throws Exception {}
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/JavaLanguageService.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/JavaLanguageService.java
@@ -35,7 +35,7 @@ import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import javax.tools.ToolProvider;
 
-/** Language service providing Monaco intellisense (completion, hover, diagnostics, definition) for Java scripts. */
+/// Language service providing Monaco intellisense (completion, hover, diagnostics, definition) for Java scripts.
 public class JavaLanguageService implements ScriptLanguageService {
   private static final Logger log = Logger.getLogger(JavaLanguageService.class.getName());
   private static final Pattern IMPORT = Pattern.compile("(?m)^\\s*import\\s+(?:static\\s+)?([\\w.$]+(?:\\.\\*)?)(?:\\s+as\\s+([A-Za-z_$][\\w$]*))?\\s*;?\\s*$");

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/JavaScriptProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/JavaScriptProvider.java
@@ -28,7 +28,7 @@ import javax.tools.SimpleJavaFileObject;
 
 import javax.tools.ToolProvider;
 
-/** Compiles Java source files at runtime using the system Java compiler or loads precompiled script classes. */
+/// Compiles Java source files at runtime using the system Java compiler or loads precompiled script classes.
 public class JavaScriptProvider implements ScriptProvider {
   @Override
   public String language() {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptAnnotationProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptAnnotationProvider.java
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/** Provides completions and snippet templates for script annotations (@ScriptProperty, @ScriptInfo) and @Override event lifecycle methods. */
+/// Provides completions and snippet templates for script annotations (@ScriptProperty, @ScriptInfo) and @Override event lifecycle methods.
 final class ScriptAnnotationProvider {
   private ScriptAnnotationProvider() {}
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptBinding.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptBinding.java
@@ -10,7 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Configures one script attachment to a game, environment, or entity. */
+/// Configures one script attachment to a game, environment, or entity.
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class ScriptBinding {
   @XmlAttribute(required = true) private String script;
@@ -30,7 +30,7 @@ public final class ScriptBinding {
     this.enabled = enabled;
   }
 
-  /** Creates an independent copy suitable for controller ownership. */
+  /// Creates an independent copy suitable for controller ownership.
   public ScriptBinding(ScriptBinding binding) {
     this.script = binding.script;
     this.enabled = binding.enabled;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptBinding.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptBinding.java
@@ -11,6 +11,10 @@ import java.util.List;
 import java.util.Map;
 
 /// Configures one script attachment to a game, environment, or entity.
+///
+/// Bindings reference a [ScriptDefinition] by identifier and supply instance-specific parameters.
+/// Lower order values attach first. The parameter-value list is the live JAXB representation;
+/// [#getParameters()] returns a convenient snapshot keyed by name.
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class ScriptBinding {
   @XmlAttribute(required = true) private String script;
@@ -19,18 +23,28 @@ public final class ScriptBinding {
   @XmlElementWrapper(name = "parameters") @XmlElement(name = "parameter")
   private final List<ScriptParameterValue> parameters = new ArrayList<>();
 
+  /// Creates an enabled binding without a script identifier.
   public ScriptBinding() {}
 
+  /// Creates an enabled binding for a script.
+  ///
+  /// @param script The definition identifier.
   public ScriptBinding(String script) {
     this.script = script;
   }
 
+  /// Creates a binding for a script.
+  ///
+  /// @param script The definition identifier.
+  /// @param enabled Whether the binding should attach.
   public ScriptBinding(String script, boolean enabled) {
     this.script = script;
     this.enabled = enabled;
   }
 
   /// Creates an independent copy suitable for controller ownership.
+  ///
+  /// @param binding The binding to copy.
   public ScriptBinding(ScriptBinding binding) {
     this.script = binding.script;
     this.enabled = binding.enabled;
@@ -38,14 +52,39 @@ public final class ScriptBinding {
     binding.parameters.forEach(parameter -> this.parameters.add(new ScriptParameterValue(parameter.getName(), parameter.getValue())));
   }
 
+  /// Returns the referenced definition identifier.
+  /// @return The script identifier.
   public String getScript() { return this.script; }
+
+  /// Returns whether this binding participates in attachment.
+  /// @return `true` when enabled.
   public boolean isEnabled() { return this.enabled; }
+
+  /// Returns the attachment order.
+  /// @return The order; lower values attach first.
   public int getOrder() { return this.order; }
+
+  /// Returns the live JAXB parameter list.
+  /// @return The mutable parameter-value list.
   public List<ScriptParameterValue> getParameterValues() { return this.parameters; }
+
+  /// Sets the referenced definition identifier.
+  /// @param script The script identifier.
   public void setScript(String script) { this.script = script; }
+
+  /// Enables or disables this binding.
+  /// @param enabled Whether it should attach.
   public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+  /// Sets the attachment order.
+  /// @param order The order; lower values attach first.
   public void setOrder(int order) { this.order = order; }
 
+  /// Returns the configured parameters keyed by name.
+  ///
+  /// Later duplicate names replace earlier values.
+  ///
+  /// @return A mutable snapshot of named parameter values.
   public Map<String, String> getParameters() {
     Map<String, String> values = new LinkedHashMap<>();
     for (ScriptParameterValue parameter : this.parameters) {
@@ -54,6 +93,11 @@ public final class ScriptBinding {
     return values;
   }
 
+  /// Adds or replaces a named parameter.
+  ///
+  /// @param name The non-null parameter name.
+  /// @param value The parameter value; may be `null`.
+  /// @throws NullPointerException if `name` is `null`.
   public void setParameter(String name, String value) {
     this.parameters.stream().filter(parameter -> name.equals(parameter.getName())).findFirst()
       .ifPresentOrElse(parameter -> parameter.setValue(value), () -> this.parameters.add(new ScriptParameterValue(name, value)));

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptBindingCodec.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptBindingCodec.java
@@ -12,7 +12,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-/** Encodes structured script bindings in TMX-compatible JSON properties. */
+/// Encodes structured script bindings in TMX-compatible JSON properties.
 public final class ScriptBindingCodec {
   private ScriptBindingCodec() {}
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptCompilationContext.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptCompilationContext.java
@@ -4,6 +4,11 @@ import java.nio.file.Path;
 import java.util.List;
 
 /// Build-tool-neutral inputs required to compile a script source generation.
+///
+/// @param parent The parent class loader visible to the compiled script; `null` selects the engine
+/// class loader.
+/// @param classpath Additional normalized class-path entries; null entries are discarded.
+/// @param javaVersion The Java language level, or zero to let the provider select its default.
 public record ScriptCompilationContext(ClassLoader parent, List<Path> classpath, int javaVersion) {
   public ScriptCompilationContext {
     if (parent == null) parent = ScriptCompilationContext.class.getClassLoader();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptCompilationContext.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptCompilationContext.java
@@ -3,7 +3,7 @@ package de.gurkenlabs.litiengine.scripting;
 import java.nio.file.Path;
 import java.util.List;
 
-/** Build-tool-neutral inputs required to compile a script source generation. */
+/// Build-tool-neutral inputs required to compile a script source generation.
 public record ScriptCompilationContext(ClassLoader parent, List<Path> classpath, int javaVersion) {
   public ScriptCompilationContext {
     if (parent == null) parent = ScriptCompilationContext.class.getClassLoader();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptContext.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptContext.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 
-/** Runtime services and binding values supplied to a script instance. */
+/// Runtime services and binding values supplied to a script instance.
 public final class ScriptContext<T> implements AutoCloseable {
   private final ScriptDefinition definition;
   private final ScriptBinding binding;
@@ -46,14 +46,14 @@ public final class ScriptContext<T> implements AutoCloseable {
     return Game.world().environment();
   }
 
-  /** Starts a fluent query against the current environment. */
+  /// Starts a fluent query against the current environment.
   public <E> EntityQuery<E> entities(Class<? extends E> type) {
     Environment environment = this.environment();
     if (environment == null) return new EntityQuery<>(java.util.List.of());
     return environment.query(type);
   }
 
-  /** Begins building a scripted ability executed by the current host creature. */
+  /// Begins building a scripted ability executed by the current host creature.
   public ScriptedAbilityBuilder createAbility(String name) {
     if (!(this.host instanceof Creature creature)) {
       throw new IllegalStateException("The script host is not a Creature. Specify the executor explicitly via createAbility(executor, name).");
@@ -61,12 +61,12 @@ public final class ScriptContext<T> implements AutoCloseable {
     return new ScriptedAbilityBuilder(creature, name);
   }
 
-  /** Begins building a scripted ability for a specific executor creature. */
+  /// Begins building a scripted ability for a specific executor creature.
   public ScriptedAbilityBuilder createAbility(Creature executor, String name) {
     return new ScriptedAbilityBuilder(executor, name);
   }
 
-  /** Casts an ability on the current host creature by name. */
+  /// Casts an ability on the current host creature by name.
   public AbilityExecution cast(String name) {
     if (!(this.host instanceof Creature creature)) {
       throw new IllegalStateException("The script host is not a Creature. Specify the executor explicitly via cast(executor, name).");
@@ -74,37 +74,37 @@ public final class ScriptContext<T> implements AutoCloseable {
     return creature.cast(name);
   }
 
-  /** Casts an ability on a specific executor creature by name. */
+  /// Casts an ability on a specific executor creature by name.
   public AbilityExecution cast(Creature executor, String name) {
     return executor != null ? executor.cast(name) : null;
   }
 
-  /** Checks if an ability on the current host creature can currently be cast. */
+  /// Checks if an ability on the current host creature can currently be cast.
   public boolean canCast(String name) {
     return this.host instanceof Creature creature && creature.canCast(name);
   }
 
-  /** Checks if an ability on a specific executor creature can currently be cast. */
+  /// Checks if an ability on a specific executor creature can currently be cast.
   public boolean canCast(Creature executor, String name) {
     return executor != null && executor.canCast(name);
   }
 
-  /** Checks if an ability on the current host creature is currently on cooldown. */
+  /// Checks if an ability on the current host creature is currently on cooldown.
   public boolean isOnCooldown(String name) {
     return this.host instanceof Creature creature && creature.isOnCooldown(name);
   }
 
-  /** Checks if an ability on a specific executor creature is currently on cooldown. */
+  /// Checks if an ability on a specific executor creature is currently on cooldown.
   public boolean isOnCooldown(Creature executor, String name) {
     return executor != null && executor.isOnCooldown(name);
   }
 
-  /** Begins building and spawning a scripted projectile in the current environment. */
+  /// Begins building and spawning a scripted projectile in the current environment.
   public ScriptedProjectileBuilder spawnProjectile() {
     return new ScriptedProjectileBuilder(this.environment());
   }
 
-  /** Returns the scripted UI overlay service owned by this context. */
+  /// Returns the scripted UI overlay service owned by this context.
   public synchronized ScriptUiOverlay ui() {
     if (this.uiOverlay == null) {
       this.uiOverlay = new ScriptUiOverlay();
@@ -113,14 +113,14 @@ public final class ScriptContext<T> implements AutoCloseable {
     return this.uiOverlay;
   }
 
-  /** Returns the active camera from the game world. */
+  /// Returns the active camera from the game world.
   public ICamera camera() {
     return Game.world().camera();
   }
 
   private ScriptInput scriptInput;
 
-  /** Returns the managed input helper owned by this context. */
+  /// Returns the managed input helper owned by this context.
   public synchronized ScriptInput input() {
     if (this.scriptInput == null) {
       this.scriptInput = new ScriptInput(this);
@@ -128,66 +128,66 @@ public final class ScriptContext<T> implements AutoCloseable {
     return this.scriptInput;
   }
 
-  /** Returns a fluent spawner for creating entities in the current environment. */
+  /// Returns a fluent spawner for creating entities in the current environment.
   public ScriptedSpawner spawner() {
     Environment environment = this.environment();
     if (environment == null) throw new IllegalStateException("No environment is currently active to spawn entities into.");
     return new ScriptedSpawner(environment);
   }
 
-  /** Spawns a creature with the given sprite prefix at the specified coordinates. */
+  /// Spawns a creature with the given sprite prefix at the specified coordinates.
   public Creature spawnCreature(String spritePrefix, double x, double y) {
     return this.spawner().creature(spritePrefix).at(x, y).spawn();
   }
 
-  /** Spawns a creature with the given sprite prefix at the specified location. */
+  /// Spawns a creature with the given sprite prefix at the specified location.
   public Creature spawnCreature(String spritePrefix, java.awt.geom.Point2D location) {
     return this.spawner().creature(spritePrefix).at(location).spawn();
   }
 
-  /** Spawns a prop with the given spritesheet at the specified coordinates. */
+  /// Spawns a prop with the given spritesheet at the specified coordinates.
   public de.gurkenlabs.litiengine.entities.Prop spawnProp(String spriteSheet, double x, double y) {
     return this.spawner().prop(spriteSheet).at(x, y).spawn();
   }
 
-  /** Spawns a prop with the given spritesheet at the specified location. */
+  /// Spawns a prop with the given spritesheet at the specified location.
   public de.gurkenlabs.litiengine.entities.Prop spawnProp(String spriteSheet, java.awt.geom.Point2D location) {
     return this.spawner().prop(spriteSheet).at(location).spawn();
   }
 
-  /** Spawns an entity of the given type at the specified coordinates. */
+  /// Spawns an entity of the given type at the specified coordinates.
   public <E extends IEntity> E spawn(Class<E> entityType, double x, double y) {
     return this.spawner().entity(entityType).at(x, y).spawn();
   }
 
-  /** Spawns an entity of the given type at the specified location. */
+  /// Spawns an entity of the given type at the specified location.
   public <E extends IEntity> E spawn(Class<E> entityType, java.awt.geom.Point2D location) {
     return this.spawner().entity(entityType).at(location).spawn();
   }
 
-  /** Spawns the given entity at the specified coordinates. */
+  /// Spawns the given entity at the specified coordinates.
   public <E extends IEntity> E spawn(E entity, double x, double y) {
     return this.spawner().entity(entity).at(x, y).spawn();
   }
 
-  /** Spawns the given entity at the specified location. */
+  /// Spawns the given entity at the specified location.
   public <E extends IEntity> E spawn(E entity, java.awt.geom.Point2D location) {
     return this.spawner().entity(entity).at(location).spawn();
   }
 
-  /** Adds a registration that will be released when the script is detached or reloaded. */
+  /// Adds a registration that will be released when the script is detached or reloaded.
   public <S extends Subscription> S manage(S subscription) {
     return this.subscriptions.add(subscription);
   }
 
-  /** Owns an arbitrary resource and invokes its release action when the script detaches or reloads. */
+  /// Owns an arbitrary resource and invokes its release action when the script detaches or reloads.
   public <R> R manage(R resource, Consumer<? super R> release) {
     Objects.requireNonNull(release);
     this.manage(() -> release.accept(resource));
     return resource;
   }
 
-  /** Registers a listener and automatically removes it when the script detaches or reloads. */
+  /// Registers a listener and automatically removes it when the script detaches or reloads.
   public <L> L listen(Consumer<? super L> add, Consumer<? super L> remove, L listener) {
     Objects.requireNonNull(add);
     Objects.requireNonNull(remove);
@@ -197,14 +197,14 @@ public final class ScriptContext<T> implements AutoCloseable {
     return listener;
   }
 
-  /** Schedules a cancellable action on the game loop. */
+  /// Schedules a cancellable action on the game loop.
   public Subscription schedule(int delay, Runnable action) {
     Objects.requireNonNull(action);
     int id = Game.loop().perform(delay, action);
     return this.manage(() -> Game.loop().removeAction(id));
   }
 
-  /** Creates an ordered, cancellable sequence of actions and delays owned by this context. */
+  /// Creates an ordered, cancellable sequence of actions and delays owned by this context.
   public ScriptSequence sequence() {
     return new ScriptSequence(this);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptContext.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptContext.java
@@ -16,6 +16,12 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 /// Runtime services and binding values supplied to a script instance.
+///
+/// A context owns the input listeners, scheduled actions, UI elements, and other subscriptions
+/// registered through it. [#close()] releases those resources when the script detaches or reloads.
+///
+/// @param <T> The type of object hosting the script.
+/// @see ScriptInstance#attach(ScriptContext)
 public final class ScriptContext<T> implements AutoCloseable {
   private final ScriptDefinition definition;
   private final ScriptBinding binding;
@@ -24,6 +30,11 @@ public final class ScriptContext<T> implements AutoCloseable {
   private final Logger logger;
   private ScriptUiOverlay uiOverlay;
 
+  /// Creates a context for one attached script instance.
+  ///
+  /// @param definition The registered script definition.
+  /// @param binding The binding that created the instance.
+  /// @param host The object hosting the script.
   public ScriptContext(ScriptDefinition definition, ScriptBinding binding, T host) {
     this.definition = Objects.requireNonNull(definition);
     this.binding = Objects.requireNonNull(binding);
@@ -31,15 +42,54 @@ public final class ScriptContext<T> implements AutoCloseable {
     this.logger = Logger.getLogger("scripts." + definition.getId());
   }
 
+  /// Returns the definition used to create the script.
+  ///
+  /// @return The script definition.
   public ScriptDefinition definition() { return this.definition; }
+
+  /// Returns the binding applied to this instance.
+  ///
+  /// @return The script binding.
   public ScriptBinding binding() { return this.binding; }
+
+  /// Returns the object hosting this script.
+  ///
+  /// @return The script host.
   public T host() { return this.host; }
+
+  /// Returns a logger named for the script definition.
+  ///
+  /// @return The script logger.
   public Logger logger() { return this.logger; }
+
+  /// Returns the game-wide script globals.
+  ///
+  /// @return The shared global registry.
   public ScriptGlobals globals() { return Game.scripts().globals(); }
+
+  /// Returns the parameters configured by the binding.
+  ///
+  /// @return The binding parameters.
   public Map<String, String> parameters() { return this.binding.getParameters(); }
+
+  /// Looks up a binding parameter.
+  ///
+  /// @param name The parameter name.
+  /// @return The configured value, or `null` if absent.
   public String parameter(String name) { return this.binding.getParameters().get(name); }
+
+  /// Looks up a binding parameter with a fallback.
+  ///
+  /// @param name The parameter name.
+  /// @param defaultValue The value returned when the parameter is absent.
+  /// @return The configured value or `defaultValue`.
   public String parameter(String name, String defaultValue) { return this.binding.getParameters().getOrDefault(name, defaultValue); }
 
+  /// Returns the environment associated with this host.
+  ///
+  /// Entity hosts use their current environment; environment hosts return themselves.
+  ///
+  /// @return The associated environment, or `null` if neither the host nor the game world has one.
   public Environment environment() {
     if (this.host instanceof Environment environment) return environment;
     if (this.host instanceof IEntity entity) return entity.getEnvironment();
@@ -47,6 +97,10 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Starts a fluent query against the current environment.
+  ///
+  /// @param type The entity type to query.
+  /// @param <E> The entity type.
+  /// @return A query over matching entities in the current environment.
   public <E> EntityQuery<E> entities(Class<? extends E> type) {
     Environment environment = this.environment();
     if (environment == null) return new EntityQuery<>(java.util.List.of());
@@ -54,6 +108,10 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Begins building a scripted ability executed by the current host creature.
+  ///
+  /// @param name The ability name.
+  /// @return A builder for the new ability.
+  /// @throws IllegalStateException if the host is not a creature.
   public ScriptedAbilityBuilder createAbility(String name) {
     if (!(this.host instanceof Creature creature)) {
       throw new IllegalStateException("The script host is not a Creature. Specify the executor explicitly via createAbility(executor, name).");
@@ -62,11 +120,19 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Begins building a scripted ability for a specific executor creature.
+  ///
+  /// @param executor The creature that will execute the ability.
+  /// @param name The ability name.
+  /// @return A builder for the new ability.
   public ScriptedAbilityBuilder createAbility(Creature executor, String name) {
     return new ScriptedAbilityBuilder(executor, name);
   }
 
   /// Casts an ability on the current host creature by name.
+  ///
+  /// @param name The registered ability name.
+  /// @return The ability execution, or `null` when the ability cannot be cast.
+  /// @throws IllegalStateException if the host is not a creature.
   public AbilityExecution cast(String name) {
     if (!(this.host instanceof Creature creature)) {
       throw new IllegalStateException("The script host is not a Creature. Specify the executor explicitly via cast(executor, name).");
@@ -75,36 +141,58 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Casts an ability on a specific executor creature by name.
+  ///
+  /// @param executor The creature that will execute the ability.
+  /// @param name The registered ability name.
+  /// @return The ability execution, or `null` when the executor is absent or cannot cast it.
   public AbilityExecution cast(Creature executor, String name) {
     return executor != null ? executor.cast(name) : null;
   }
 
   /// Checks if an ability on the current host creature can currently be cast.
+  ///
+  /// @param name The registered ability name.
+  /// @return `true` if the host is a creature and can cast the ability.
   public boolean canCast(String name) {
     return this.host instanceof Creature creature && creature.canCast(name);
   }
 
   /// Checks if an ability on a specific executor creature can currently be cast.
+  ///
+  /// @param executor The creature to check.
+  /// @param name The registered ability name.
+  /// @return `true` if the executor exists and can cast the ability.
   public boolean canCast(Creature executor, String name) {
     return executor != null && executor.canCast(name);
   }
 
   /// Checks if an ability on the current host creature is currently on cooldown.
+  ///
+  /// @param name The registered ability name.
+  /// @return `true` if the host is a creature and the ability is cooling down.
   public boolean isOnCooldown(String name) {
     return this.host instanceof Creature creature && creature.isOnCooldown(name);
   }
 
   /// Checks if an ability on a specific executor creature is currently on cooldown.
+  ///
+  /// @param executor The creature to check.
+  /// @param name The registered ability name.
+  /// @return `true` if the executor exists and the ability is cooling down.
   public boolean isOnCooldown(Creature executor, String name) {
     return executor != null && executor.isOnCooldown(name);
   }
 
   /// Begins building and spawning a scripted projectile in the current environment.
+  ///
+  /// @return A projectile builder bound to the current environment.
   public ScriptedProjectileBuilder spawnProjectile() {
     return new ScriptedProjectileBuilder(this.environment());
   }
 
   /// Returns the scripted UI overlay service owned by this context.
+  ///
+  /// @return The lazily created overlay service.
   public synchronized ScriptUiOverlay ui() {
     if (this.uiOverlay == null) {
       this.uiOverlay = new ScriptUiOverlay();
@@ -114,6 +202,8 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Returns the active camera from the game world.
+  ///
+  /// @return The active camera, or `null` if none is configured.
   public ICamera camera() {
     return Game.world().camera();
   }
@@ -121,6 +211,8 @@ public final class ScriptContext<T> implements AutoCloseable {
   private ScriptInput scriptInput;
 
   /// Returns the managed input helper owned by this context.
+  ///
+  /// @return The lazily created input helper.
   public synchronized ScriptInput input() {
     if (this.scriptInput == null) {
       this.scriptInput = new ScriptInput(this);
@@ -129,6 +221,9 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Returns a fluent spawner for creating entities in the current environment.
+  ///
+  /// @return A spawner bound to the current environment.
+  /// @throws IllegalStateException if no environment is active.
   public ScriptedSpawner spawner() {
     Environment environment = this.environment();
     if (environment == null) throw new IllegalStateException("No environment is currently active to spawn entities into.");
@@ -136,51 +231,100 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Spawns a creature with the given sprite prefix at the specified coordinates.
+  ///
+  /// @param spritePrefix The animation sprite prefix.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @return The spawned creature.
   public Creature spawnCreature(String spritePrefix, double x, double y) {
     return this.spawner().creature(spritePrefix).at(x, y).spawn();
   }
 
   /// Spawns a creature with the given sprite prefix at the specified location.
+  ///
+  /// @param spritePrefix The animation sprite prefix.
+  /// @param location The location in map coordinates.
+  /// @return The spawned creature.
   public Creature spawnCreature(String spritePrefix, java.awt.geom.Point2D location) {
     return this.spawner().creature(spritePrefix).at(location).spawn();
   }
 
   /// Spawns a prop with the given spritesheet at the specified coordinates.
+  ///
+  /// @param spriteSheet The spritesheet name.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @return The spawned prop.
   public de.gurkenlabs.litiengine.entities.Prop spawnProp(String spriteSheet, double x, double y) {
     return this.spawner().prop(spriteSheet).at(x, y).spawn();
   }
 
   /// Spawns a prop with the given spritesheet at the specified location.
+  ///
+  /// @param spriteSheet The spritesheet name.
+  /// @param location The location in map coordinates.
+  /// @return The spawned prop.
   public de.gurkenlabs.litiengine.entities.Prop spawnProp(String spriteSheet, java.awt.geom.Point2D location) {
     return this.spawner().prop(spriteSheet).at(location).spawn();
   }
 
   /// Spawns an entity of the given type at the specified coordinates.
+  ///
+  /// @param entityType The concrete type, which must have a no-argument constructor.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @param <E> The entity type.
+  /// @return The spawned entity.
   public <E extends IEntity> E spawn(Class<E> entityType, double x, double y) {
     return this.spawner().entity(entityType).at(x, y).spawn();
   }
 
   /// Spawns an entity of the given type at the specified location.
+  ///
+  /// @param entityType The concrete type, which must have a no-argument constructor.
+  /// @param location The location in map coordinates.
+  /// @param <E> The entity type.
+  /// @return The spawned entity.
   public <E extends IEntity> E spawn(Class<E> entityType, java.awt.geom.Point2D location) {
     return this.spawner().entity(entityType).at(location).spawn();
   }
 
   /// Spawns the given entity at the specified coordinates.
+  ///
+  /// @param entity The entity to add to the environment.
+  /// @param x The map x-coordinate.
+  /// @param y The map y-coordinate.
+  /// @param <E> The entity type.
+  /// @return The supplied entity.
   public <E extends IEntity> E spawn(E entity, double x, double y) {
     return this.spawner().entity(entity).at(x, y).spawn();
   }
 
   /// Spawns the given entity at the specified location.
+  ///
+  /// @param entity The entity to add to the environment.
+  /// @param location The location in map coordinates.
+  /// @param <E> The entity type.
+  /// @return The supplied entity.
   public <E extends IEntity> E spawn(E entity, java.awt.geom.Point2D location) {
     return this.spawner().entity(entity).at(location).spawn();
   }
 
   /// Adds a registration that will be released when the script is detached or reloaded.
+  ///
+  /// @param subscription The subscription to own.
+  /// @param <S> The subscription type.
+  /// @return The supplied subscription.
   public <S extends Subscription> S manage(S subscription) {
     return this.subscriptions.add(subscription);
   }
 
   /// Owns an arbitrary resource and invokes its release action when the script detaches or reloads.
+  ///
+  /// @param resource The resource to own.
+  /// @param release The action that releases it.
+  /// @param <R> The resource type.
+  /// @return The supplied resource.
   public <R> R manage(R resource, Consumer<? super R> release) {
     Objects.requireNonNull(release);
     this.manage(() -> release.accept(resource));
@@ -188,6 +332,12 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Registers a listener and automatically removes it when the script detaches or reloads.
+  ///
+  /// @param add The operation that registers the listener.
+  /// @param remove The operation that unregisters it.
+  /// @param listener The listener instance.
+  /// @param <L> The listener type.
+  /// @return The supplied listener.
   public <L> L listen(Consumer<? super L> add, Consumer<? super L> remove, L listener) {
     Objects.requireNonNull(add);
     Objects.requireNonNull(remove);
@@ -198,6 +348,10 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Schedules a cancellable action on the game loop.
+  ///
+  /// @param delay The delay in milliseconds.
+  /// @param action The action to invoke.
+  /// @return A subscription that cancels the scheduled action.
   public Subscription schedule(int delay, Runnable action) {
     Objects.requireNonNull(action);
     int id = Game.loop().perform(delay, action);
@@ -205,6 +359,8 @@ public final class ScriptContext<T> implements AutoCloseable {
   }
 
   /// Creates an ordered, cancellable sequence of actions and delays owned by this context.
+  ///
+  /// @return A new sequence owned by this context.
   public ScriptSequence sequence() {
     return new ScriptSequence(this);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDefinition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDefinition.java
@@ -8,6 +8,10 @@ import java.util.List;
 import java.util.Objects;
 
 /// Describes a reusable script source and its implementation class.
+///
+/// Definitions are registered with [ScriptManager#setDefinitions(Collection)] and referenced by
+/// [ScriptBinding#getScript()]. Source resolution and compilation are delegated to the selected
+/// [ScriptProvider].
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class ScriptDefinition {
   @XmlAttribute(required = true) private String id;
@@ -18,8 +22,16 @@ public final class ScriptDefinition {
   @XmlAttribute private ScriptHostType host = ScriptHostType.ENTITY;
   @XmlAttribute private String targetType;
 
+  /// Creates an empty JAXB definition.
   public ScriptDefinition() {}
 
+  /// Creates a definition.
+  ///
+  /// @param id The unique definition identifier.
+  /// @param language The provider language identifier.
+  /// @param source The source path or resource name.
+  /// @param implementation The fully qualified implementation class name.
+  /// @param host The required host category.
   public ScriptDefinition(String id, String language, String source, String implementation, ScriptHostType host) {
     this.id = id;
     this.language = language;
@@ -29,6 +41,8 @@ public final class ScriptDefinition {
   }
 
   /// Creates an independent snapshot of another definition.
+  ///
+  /// @param definition The definition to copy.
   public ScriptDefinition(ScriptDefinition definition) {
     this(
       definition.id,
@@ -51,6 +65,9 @@ public final class ScriptDefinition {
       && Objects.equals(this.targetType, definition.targetType);
   }
 
+  /// Validates fields required for registration.
+  ///
+  /// @return Human-readable validation errors; empty when valid.
   public List<String> validate() {
     List<String> errors = new ArrayList<>();
     if (this.id == null || this.id.isBlank()) errors.add("Script id must not be blank.");
@@ -60,18 +77,46 @@ public final class ScriptDefinition {
     return List.copyOf(errors);
   }
 
+  /// Returns the unique identifier.
+  /// @return The identifier.
   public String getId() { return this.id; }
+  /// Returns the display name.
+  /// @return The name, or `null`.
   public String getName() { return this.name; }
+  /// Returns the provider language identifier.
+  /// @return The language identifier.
   public String getLanguage() { return this.language; }
+  /// Returns the source path or resource name.
+  /// @return The source, or `null` for precompiled code.
   public String getSource() { return this.source; }
+  /// Returns the implementation class name.
+  /// @return The fully qualified class name.
   public String getImplementation() { return this.implementation; }
+  /// Returns the required host category.
+  /// @return The host category.
   public ScriptHostType getHost() { return this.host; }
+  /// Returns an optional required host class.
+  /// @return The fully qualified type name, or `null`.
   public String getTargetType() { return this.targetType; }
+  /// Sets the unique identifier.
+  /// @param id The identifier.
   public void setId(String id) { this.id = id; }
+  /// Sets the display name.
+  /// @param name The name.
   public void setName(String name) { this.name = name; }
+  /// Sets the provider language identifier.
+  /// @param language The language identifier.
   public void setLanguage(String language) { this.language = language; }
+  /// Sets the source path or resource name.
+  /// @param source The source.
   public void setSource(String source) { this.source = source; }
+  /// Sets the implementation class name.
+  /// @param implementation The fully qualified class name.
   public void setImplementation(String implementation) { this.implementation = implementation; }
+  /// Sets the required host category.
+  /// @param host The host category.
   public void setHost(ScriptHostType host) { this.host = host; }
+  /// Sets an optional required host class.
+  /// @param targetType The fully qualified type name.
   public void setTargetType(String targetType) { this.targetType = targetType; }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDefinition.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDefinition.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** Describes a reusable script source and its implementation class. */
+/// Describes a reusable script source and its implementation class.
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class ScriptDefinition {
   @XmlAttribute(required = true) private String id;
@@ -28,7 +28,7 @@ public final class ScriptDefinition {
     this.host = host;
   }
 
-  /** Creates an independent snapshot of another definition. */
+  /// Creates an independent snapshot of another definition.
   public ScriptDefinition(ScriptDefinition definition) {
     this(
       definition.id,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDiagnostic.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDiagnostic.java
@@ -1,10 +1,21 @@
 package de.gurkenlabs.litiengine.scripting;
 
 /// A compile-time or runtime diagnostic associated with a script.
+///
+/// @param severity The diagnostic severity.
+/// @param scriptId The identifier of the affected script.
+/// @param source The source location, when known.
+/// @param line The one-based source line, or a negative value when unavailable.
+/// @param column The one-based source column, or a negative value when unavailable.
+/// @param message The human-readable diagnostic message.
 public record ScriptDiagnostic(Severity severity, String scriptId, String source, int line, int column, String message) {
+  /// Indicates how a diagnostic should be presented to the user.
   public enum Severity {
+    /// Informational feedback that does not prevent execution.
     INFO,
+    /// A potential problem that does not prevent execution.
     WARNING,
+    /// A problem that prevents compilation or execution.
     ERROR
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDiagnostic.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDiagnostic.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.scripting;
 
-/** A compile-time or runtime diagnostic associated with a script. */
+/// A compile-time or runtime diagnostic associated with a script.
 public record ScriptDiagnostic(Severity severity, String scriptId, String source, int line, int column, String message) {
   public enum Severity {
     INFO,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDocumentation.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptDocumentation.java
@@ -3,7 +3,7 @@ package de.gurkenlabs.litiengine.scripting;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Central documentation catalog for LITIENGINE scripting API, classes, annotations, and lifecycle events. */
+/// Central documentation catalog for LITIENGINE scripting API, classes, annotations, and lifecycle events.
 public final class ScriptDocumentation {
   private static final Map<String, String> CLASS_DOCS = new HashMap<>();
   private static final Map<String, String> METHOD_DOCS = new HashMap<>();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptException.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptException.java
@@ -2,7 +2,7 @@ package de.gurkenlabs.litiengine.scripting;
 
 import java.util.List;
 
-/** Indicates that a script could not be compiled, instantiated, configured, or executed. */
+/// Indicates that a script could not be compiled, instantiated, configured, or executed.
 public class ScriptException extends Exception {
   private final List<ScriptDiagnostic> diagnostics;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptGlobals.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptGlobals.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 
-/** Global thread-safe shared state store accessible across entity, game, and behavior scripts. */
+/// Global thread-safe shared state store accessible across entity, game, and behavior scripts.
 public final class ScriptGlobals {
   private final Map<String, Object> values = new ConcurrentHashMap<>();
   private final Map<String, List<BiConsumer<Object, Object>>> listeners = new ConcurrentHashMap<>();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptHostType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptHostType.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.scripting;
 
-/** Identifies the lifecycle host to which a script can be bound. */
+/// Identifies the lifecycle host to which a script can be bound.
 public enum ScriptHostType {
   GAME,
   ENVIRONMENT,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInfo.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInfo.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Describes an editor-visible Java script implementation. */
+/// Describes an editor-visible Java script implementation.
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface ScriptInfo {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInput.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInput.java
@@ -25,22 +25,31 @@ public final class ScriptInput {
   }
 
   /// Checks whether the key with the specified `keyCode` is currently pressed.
+  /// @param keyCode An AWT virtual key code.
+  /// @return `true` while the key is pressed.
   public boolean isPressed(int keyCode) {
     return Input.keyboard() != null && Input.keyboard().isPressed(keyCode);
   }
 
   /// Checks whether the key with the specified name (e.g., "SPACE", "W", "ENTER", "ESCAPE") is currently pressed.
+  /// @param keyName A case-insensitive [KeyEvent] `VK_` field name, with or without the prefix.
+  /// @return `true` while the resolved key is pressed.
   public boolean isPressed(String keyName) {
     int keyCode = resolveKeyCode(keyName);
     return keyCode != KeyEvent.VK_UNDEFINED && isPressed(keyCode);
   }
 
   /// Checks whether the key with the specified `keyCode` was recently released.
+  /// @param keyCode An AWT virtual key code.
+  /// @return `true` if the key was recently released.
   public boolean wasReleased(int keyCode) {
     return Input.keyboard() != null && Input.keyboard().wasReleased(keyCode);
   }
 
   /// Binds an action to be executed when the specified key is pressed.
+  /// @param keyCode An AWT virtual key code.
+  /// @param onPress The action to invoke.
+  /// @return A subscription that removes the listener.
   public Subscription bindKey(int keyCode, Runnable onPress) {
     Objects.requireNonNull(onPress, "onPress must not be null.");
     IKeyboard.KeyPressedListener listener = e -> {
@@ -58,6 +67,10 @@ public final class ScriptInput {
   }
 
   /// Binds actions to be executed when the specified key is pressed and released.
+  /// @param keyCode An AWT virtual key code.
+  /// @param onPress The press action, or `null` for none.
+  /// @param onRelease The release action, or `null` for none.
+  /// @return A subscription that removes both listeners.
   public Subscription bindKey(int keyCode, Runnable onPress, Runnable onRelease) {
     Subscription pressSub = onPress != null ? bindKey(keyCode, onPress) : () -> {};
     Subscription releaseSub = () -> {};
@@ -80,6 +93,9 @@ public final class ScriptInput {
   }
 
   /// Binds a consumer to receive key press events for the specified key code.
+  /// @param keyCode An AWT virtual key code.
+  /// @param onPress The event consumer.
+  /// @return A subscription that removes the listener.
   public Subscription bindKey(int keyCode, Consumer<KeyEvent> onPress) {
     Objects.requireNonNull(onPress, "onPress must not be null.");
     IKeyboard.KeyPressedListener listener = e -> {
@@ -95,6 +111,9 @@ public final class ScriptInput {
   }
 
   /// Binds a consumer to receive key typed events for the specified key code.
+  /// @param keyCode An AWT virtual key code.
+  /// @param onTyped The event consumer.
+  /// @return A subscription that removes the listener.
   public Subscription bindKeyTyped(int keyCode, Consumer<KeyEvent> onTyped) {
     Objects.requireNonNull(onTyped, "onTyped must not be null.");
     IKeyboard.KeyTypedListener listener = e -> {
@@ -110,36 +129,45 @@ public final class ScriptInput {
   }
 
   /// Checks whether any mouse button is currently pressed.
+  /// @return `true` while a mouse button is pressed.
   public boolean isMouseButtonPressed() {
     return Input.mouse() != null && Input.mouse().isPressed();
   }
 
   /// Checks whether the left mouse button is currently pressed.
+  /// @return `true` while the left button is pressed.
   public boolean isLeftMouseButtonPressed() {
     return Input.mouse() != null && Input.mouse().isLeftButtonPressed();
   }
 
   /// Checks whether the right mouse button is currently pressed.
+  /// @return `true` while the right button is pressed.
   public boolean isRightMouseButtonPressed() {
     return Input.mouse() != null && Input.mouse().isRightButtonPressed();
   }
 
   /// Gets the current mouse screen location relative to the game window.
+  /// @return The screen location, or `(0,0)` when no mouse is available.
   public Point2D mouseLocation() {
     return Input.mouse() != null ? Input.mouse().getLocation() : new Point2D.Double(0, 0);
   }
 
   /// Gets the current mouse world/map location translated via camera.
+  /// @return The map location, or `(0,0)` when no mouse is available.
   public Point2D mouseWorldLocation() {
     return Input.mouse() != null ? Input.mouse().getMapLocation() : new Point2D.Double(0, 0);
   }
 
   /// Gets the map tile coordinate currently under the mouse.
+  /// @return The tile coordinate, or `(0,0)` when no mouse is available.
   public Point mouseTile() {
     return Input.mouse() != null ? Input.mouse().getTile() : new Point(0, 0);
   }
 
   /// Binds an action to be executed when the specified mouse button is pressed (e.g. [MouseEvent#BUTTON1]).
+  /// @param button An AWT mouse button identifier.
+  /// @param onPress The action to invoke.
+  /// @return A subscription that removes the listener.
   public Subscription bindMouse(int button, Runnable onPress) {
     Objects.requireNonNull(onPress, "onPress must not be null.");
     IMouse.MousePressedListener listener = e -> {
@@ -157,6 +185,10 @@ public final class ScriptInput {
   }
 
   /// Binds actions for when the specified mouse button is pressed and released.
+  /// @param button An AWT mouse button identifier.
+  /// @param onPress The press action, or `null` for none.
+  /// @param onRelease The release action, or `null` for none.
+  /// @return A subscription that removes both listeners.
   public Subscription bindMouse(int button, Runnable onPress, Runnable onRelease) {
     Subscription pressSub = onPress != null ? bindMouse(button, onPress) : () -> {};
     Subscription releaseSub = () -> {};
@@ -179,6 +211,8 @@ public final class ScriptInput {
   }
 
   /// Resolves a key name like "SPACE", "ESCAPE", "W" to a [KeyEvent] VK_ constant code.
+  /// @param name The case-insensitive key name.
+  /// @return The virtual key code, or [KeyEvent#VK_UNDEFINED] if it cannot be resolved.
   public static int resolveKeyCode(String name) {
     if (name == null || name.isBlank()) return KeyEvent.VK_UNDEFINED;
     String formatted = name.trim().toUpperCase();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInput.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInput.java
@@ -13,12 +13,10 @@ import java.lang.reflect.Field;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-/**
- * Convenient, managed input helper for scripts.
- *
- * <p>All listeners registered through this class are automatically cleaned up when the owning
- * {@link ScriptContext} is detached or reloaded.
- */
+/// Convenient, managed input helper for scripts.
+///
+/// All listeners registered through this class are automatically cleaned up when the owning
+/// [ScriptContext] is detached or reloaded.
 public final class ScriptInput {
   private final ScriptContext<?> context;
 
@@ -26,25 +24,23 @@ public final class ScriptInput {
     this.context = Objects.requireNonNull(context, "ScriptContext must not be null.");
   }
 
-  /** Checks whether the key with the specified {@code keyCode} is currently pressed. */
+  /// Checks whether the key with the specified `keyCode` is currently pressed.
   public boolean isPressed(int keyCode) {
     return Input.keyboard() != null && Input.keyboard().isPressed(keyCode);
   }
 
-  /**
-   * Checks whether the key with the specified name (e.g., "SPACE", "W", "ENTER", "ESCAPE") is currently pressed.
-   */
+  /// Checks whether the key with the specified name (e.g., "SPACE", "W", "ENTER", "ESCAPE") is currently pressed.
   public boolean isPressed(String keyName) {
     int keyCode = resolveKeyCode(keyName);
     return keyCode != KeyEvent.VK_UNDEFINED && isPressed(keyCode);
   }
 
-  /** Checks whether the key with the specified {@code keyCode} was recently released. */
+  /// Checks whether the key with the specified `keyCode` was recently released.
   public boolean wasReleased(int keyCode) {
     return Input.keyboard() != null && Input.keyboard().wasReleased(keyCode);
   }
 
-  /** Binds an action to be executed when the specified key is pressed. */
+  /// Binds an action to be executed when the specified key is pressed.
   public Subscription bindKey(int keyCode, Runnable onPress) {
     Objects.requireNonNull(onPress, "onPress must not be null.");
     IKeyboard.KeyPressedListener listener = e -> {
@@ -61,7 +57,7 @@ public final class ScriptInput {
     return () -> {};
   }
 
-  /** Binds actions to be executed when the specified key is pressed and released. */
+  /// Binds actions to be executed when the specified key is pressed and released.
   public Subscription bindKey(int keyCode, Runnable onPress, Runnable onRelease) {
     Subscription pressSub = onPress != null ? bindKey(keyCode, onPress) : () -> {};
     Subscription releaseSub = () -> {};
@@ -83,7 +79,7 @@ public final class ScriptInput {
     };
   }
 
-  /** Binds a consumer to receive key press events for the specified key code. */
+  /// Binds a consumer to receive key press events for the specified key code.
   public Subscription bindKey(int keyCode, Consumer<KeyEvent> onPress) {
     Objects.requireNonNull(onPress, "onPress must not be null.");
     IKeyboard.KeyPressedListener listener = e -> {
@@ -98,7 +94,7 @@ public final class ScriptInput {
     return () -> {};
   }
 
-  /** Binds a consumer to receive key typed events for the specified key code. */
+  /// Binds a consumer to receive key typed events for the specified key code.
   public Subscription bindKeyTyped(int keyCode, Consumer<KeyEvent> onTyped) {
     Objects.requireNonNull(onTyped, "onTyped must not be null.");
     IKeyboard.KeyTypedListener listener = e -> {
@@ -113,37 +109,37 @@ public final class ScriptInput {
     return () -> {};
   }
 
-  /** Checks whether any mouse button is currently pressed. */
+  /// Checks whether any mouse button is currently pressed.
   public boolean isMouseButtonPressed() {
     return Input.mouse() != null && Input.mouse().isPressed();
   }
 
-  /** Checks whether the left mouse button is currently pressed. */
+  /// Checks whether the left mouse button is currently pressed.
   public boolean isLeftMouseButtonPressed() {
     return Input.mouse() != null && Input.mouse().isLeftButtonPressed();
   }
 
-  /** Checks whether the right mouse button is currently pressed. */
+  /// Checks whether the right mouse button is currently pressed.
   public boolean isRightMouseButtonPressed() {
     return Input.mouse() != null && Input.mouse().isRightButtonPressed();
   }
 
-  /** Gets the current mouse screen location relative to the game window. */
+  /// Gets the current mouse screen location relative to the game window.
   public Point2D mouseLocation() {
     return Input.mouse() != null ? Input.mouse().getLocation() : new Point2D.Double(0, 0);
   }
 
-  /** Gets the current mouse world/map location translated via camera. */
+  /// Gets the current mouse world/map location translated via camera.
   public Point2D mouseWorldLocation() {
     return Input.mouse() != null ? Input.mouse().getMapLocation() : new Point2D.Double(0, 0);
   }
 
-  /** Gets the map tile coordinate currently under the mouse. */
+  /// Gets the map tile coordinate currently under the mouse.
   public Point mouseTile() {
     return Input.mouse() != null ? Input.mouse().getTile() : new Point(0, 0);
   }
 
-  /** Binds an action to be executed when the specified mouse button is pressed (e.g. {@link MouseEvent#BUTTON1}). */
+  /// Binds an action to be executed when the specified mouse button is pressed (e.g. [MouseEvent#BUTTON1]).
   public Subscription bindMouse(int button, Runnable onPress) {
     Objects.requireNonNull(onPress, "onPress must not be null.");
     IMouse.MousePressedListener listener = e -> {
@@ -160,7 +156,7 @@ public final class ScriptInput {
     return () -> {};
   }
 
-  /** Binds actions for when the specified mouse button is pressed and released. */
+  /// Binds actions for when the specified mouse button is pressed and released.
   public Subscription bindMouse(int button, Runnable onPress, Runnable onRelease) {
     Subscription pressSub = onPress != null ? bindMouse(button, onPress) : () -> {};
     Subscription releaseSub = () -> {};
@@ -182,7 +178,7 @@ public final class ScriptInput {
     };
   }
 
-  /** Resolves a key name like "SPACE", "ESCAPE", "W" to a {@link KeyEvent} VK_ constant code. */
+  /// Resolves a key name like "SPACE", "ESCAPE", "W" to a [KeyEvent] VK_ constant code.
   public static int resolveKeyCode(String name) {
     if (name == null || name.isBlank()) return KeyEvent.VK_UNDEFINED;
     String formatted = name.trim().toUpperCase();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInstance.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInstance.java
@@ -2,7 +2,7 @@ package de.gurkenlabs.litiengine.scripting;
 
 import java.awt.Graphics2D;
 
-/** One configured runtime instance of a script. */
+/// One configured runtime instance of a script.
 public interface ScriptInstance {
   void attach(ScriptContext<?> context) throws Exception;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInstance.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptInstance.java
@@ -3,13 +3,30 @@ package de.gurkenlabs.litiengine.scripting;
 import java.awt.Graphics2D;
 
 /// One configured runtime instance of a script.
+///
+/// Instances are created by a [CompiledScript] and owned by [ScriptManager]. Implementations should
+/// acquire host-specific resources in [#attach(ScriptContext)] and release them in [#detach()].
 public interface ScriptInstance {
+  /// Attaches this instance to a host context.
+  ///
+  /// @param context The context for this attachment.
+  /// @throws Exception if initialization fails.
   void attach(ScriptContext<?> context) throws Exception;
 
+  /// Processes one game-loop update.
+  ///
+  /// @throws Exception if script execution fails.
   default void update() throws Exception {}
 
+  /// Renders script-owned content.
+  ///
+  /// @param g The current graphics context.
+  /// @throws Exception if script rendering fails.
   default void render(Graphics2D g) throws Exception {}
 
+  /// Releases resources acquired by this attachment.
+  ///
+  /// @throws Exception if cleanup fails.
   void detach() throws Exception;
 }
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptLanguageService.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptLanguageService.java
@@ -6,12 +6,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * Editor-independent semantic tooling for a scripting language.
- *
- * <p>Implementations analyze source text only and must never execute a script. Positions are
- * zero-based so the API maps directly to editor and language-server protocols.
- */
+/// Editor-independent semantic tooling for a scripting language.
+///
+/// Implementations analyze source text only and must never execute a script. Positions are
+/// zero-based so the API maps directly to editor and language-server protocols.
 public interface ScriptLanguageService extends AutoCloseable {
   Analysis analyze(Document document);
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptManager.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptManager.java
@@ -44,8 +44,18 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/// Coordinates script providers, definitions, bindings, lifecycles, and explicit reloads.
+/// Coordinates script providers, definitions, bindings, lifecycles, diagnostics, and explicit reloads.
+///
+/// The game-wide instance is available from [Game#scripts()]. It attaches game bindings when the
+/// game starts, configures entity bindings when matching entities are loaded, and releases managed
+/// resources when their host is detached. After a failed [#reload(String)], the manager attempts to
+/// restore the previous compiled generation and records any attachment failures as diagnostics.
+///
+/// @see ScriptDefinition
+/// @see ScriptBinding
+/// @see ScriptContext
 public final class ScriptManager implements IUpdateable {
+  /// Map property containing serialized entity script bindings.
   public static final String BINDINGS_PROPERTY = "scriptBindings";
   private static final Logger log = Logger.getLogger(ScriptManager.class.getName());
 
@@ -68,6 +78,7 @@ public final class ScriptManager implements IUpdateable {
   private final de.gurkenlabs.litiengine.environment.EnvironmentLoadedListener environmentLoadedListener = this::environmentLoaded;
   private final de.gurkenlabs.litiengine.environment.EnvironmentUnloadedListener environmentUnloadedListener = this::detach;
 
+  /// Creates a manager with Java support and discovers additional providers through [ServiceLoader].
   public ScriptManager() {
     this.registerProvider(new JavaScriptProvider());
     ServiceLoader.load(ScriptProvider.class).forEach(this::registerProvider);
@@ -85,10 +96,16 @@ public final class ScriptManager implements IUpdateable {
     Game.world().onUnloaded(this.environmentUnloadedListener);
   }
 
+  /// Returns whether lifecycle callbacks are dispatched to attached scripts.
+  ///
+  /// @return `true` when dispatch is enabled.
   public boolean isEnabled() {
     return this.enabled;
   }
 
+  /// Enables or pauses callback dispatch without detaching scripts.
+  ///
+  /// @param enabled `true` to dispatch callbacks.
   public void setEnabled(boolean enabled) {
     this.enabled = enabled;
   }
@@ -97,20 +114,33 @@ public final class ScriptManager implements IUpdateable {
     return this.enabled && !attachment.faulted;
   }
 
+  /// Returns the values shared by all managed scripts.
+  ///
+  /// @return The mutable global binding registry.
   public ScriptGlobals globals() {
     return this.globals;
   }
 
+  /// Registers or replaces the provider for its case-insensitive language identifier.
+  ///
+  /// @param provider The provider to register.
+  /// @throws NullPointerException if `provider` is `null`.
   public void registerProvider(ScriptProvider provider) {
     Objects.requireNonNull(provider);
     this.providers.put(provider.language().toLowerCase(), provider);
   }
 
+  /// Returns a snapshot of registered language providers.
+  ///
+  /// @return The registered providers in unspecified order.
   public Collection<ScriptProvider> getProviders() {
     return List.copyOf(this.providers.values());
   }
 
   /// Creates non-executing semantic tooling backed by the registered provider for a language.
+  ///
+  /// @param language The case-insensitive language identifier.
+  /// @return A language service, or an empty optional if the language is unknown or unsupported.
   public Optional<ScriptLanguageService> createLanguageService(String language) {
     if (language == null || language.isBlank()) return Optional.empty();
     ScriptProvider provider = this.providers.get(language.toLowerCase());
@@ -121,6 +151,12 @@ public final class ScriptManager implements IUpdateable {
     return provider.createLanguageService(new ScriptLanguageService.Workspace(this.projectRoot, loader, this.projectClasspath, Map.of()));
   }
 
+  /// Replaces all registered definitions with validated defensive copies.
+  ///
+  /// Invalid or duplicate definitions are skipped and recorded as diagnostics. Removing a
+  /// definition detaches its instances and closes its compiled generation.
+  ///
+  /// @param definitions The replacement definitions, or `null` to clear them.
   public void setDefinitions(Collection<ScriptDefinition> definitions) {
     Map<String, ScriptDefinition> replacements = new LinkedHashMap<>();
     if (definitions != null) for (ScriptDefinition definition : definitions) {
@@ -155,6 +191,9 @@ public final class ScriptManager implements IUpdateable {
     this.definitions.putAll(replacements);
   }
 
+  /// Returns defensive copies of all definitions, sorted by identifier.
+  ///
+  /// @return An unmodifiable definition snapshot.
   public Collection<ScriptDefinition> getDefinitions() {
     return this.definitions.values().stream()
       .sorted(Comparator.comparing(ScriptDefinition::getId))
@@ -162,12 +201,19 @@ public final class ScriptManager implements IUpdateable {
       .toList();
   }
 
+  /// Finds a registered definition.
+  ///
+  /// @param id The definition identifier.
+  /// @return A defensive copy, or `null` if no definition is registered.
   public ScriptDefinition getDefinition(String id) {
     ScriptDefinition definition = this.definitions.get(id);
     return definition != null ? new ScriptDefinition(definition) : null;
   }
 
   /// Returns configurable fields from the currently compiled generation without compiling or executing new code.
+  ///
+  /// @param scriptId The script identifier.
+  /// @return The configurable properties, or an empty list if the script has not been compiled.
   public List<ScriptPropertyMetadata> getPropertyMetadata(String scriptId) {
     CompiledScript compiledScript = this.compiled.get(scriptId);
     if (compiledScript == null) return List.of();
@@ -183,6 +229,11 @@ public final class ScriptManager implements IUpdateable {
       .thenComparing(ScriptPropertyMetadata::displayName)).toList();
   }
 
+  /// Replaces scripts attached to the game lifecycle.
+  ///
+  /// If the game is running, existing game scripts are detached and replacements attach immediately.
+  ///
+  /// @param bindings The replacement bindings, or `null` to clear them.
   public void setGameBindings(Collection<ScriptBinding> bindings) {
     this.gameBindings.clear();
     if (bindings != null) {
@@ -197,22 +248,33 @@ public final class ScriptManager implements IUpdateable {
     }
   }
 
+  /// Returns defensive copies of the configured game bindings.
+  ///
+  /// @return An unmodifiable binding snapshot.
   public List<ScriptBinding> getGameBindings() {
     return this.gameBindings.stream().map(ScriptBinding::new).toList();
   }
 
   /// Replaces reusable bindings that are automatically applied when matching entities are loaded.
+  ///
+  /// @param bindings The replacement bindings, or `null` to clear them.
   public void setEntityBindings(Collection<EntityScriptBinding> bindings) {
     this.entityBindings.clear();
     if (bindings != null) bindings.stream().filter(Objects::nonNull)
       .map(EntityScriptBinding::new).forEach(this.entityBindings::add);
   }
 
+  /// Returns defensive copies of the configured entity binding rules.
+  ///
+  /// @return An unmodifiable binding snapshot.
   public List<EntityScriptBinding> getEntityBindings() {
     return this.entityBindings.stream().map(EntityScriptBinding::new).toList();
   }
 
   /// Adds or refreshes the script controller that owns the default bindings for an entity type.
+  ///
+  /// @param entity The entity to configure.
+  /// @throws NullPointerException if `entity` is `null`.
   public void configure(IEntity entity) {
     Objects.requireNonNull(entity);
     List<ScriptBinding> defaults = this.resolveEntityBindings(entity);
@@ -228,39 +290,61 @@ public final class ScriptManager implements IUpdateable {
   }
 
   /// Sets the directory against which relative development-time source paths are resolved.
+  ///
+  /// @param projectRoot The project root, or `null` to clear it.
   public void setProjectRoot(Path projectRoot) {
     this.projectRoot = projectRoot == null ? null : projectRoot.toAbsolutePath().normalize();
   }
 
+  /// Returns the normalized project root used to resolve script source paths.
+  ///
+  /// @return The project root, or `null` when none is configured.
   public Path getProjectRoot() {
     return this.projectRoot;
   }
 
   /// Sets the compiled project class loader used as the parent of runtime-compiled scripts.
+  ///
+  /// @param projectClassLoader The parent loader, or `null` to use the context or engine loader.
   public void setProjectClassLoader(ClassLoader projectClassLoader) {
     this.projectClassLoader = projectClassLoader;
   }
 
   /// Sets build-resolved locations used by development-time source compilation.
+  ///
+  /// @param projectClasspath The class-path entries; `null` clears the class path.
   public void setProjectClasspath(Collection<Path> projectClasspath) {
     this.projectClasspath = projectClasspath == null
       ? List.of()
       : projectClasspath.stream().filter(Objects::nonNull).map(Path::toAbsolutePath).map(Path::normalize).distinct().toList();
   }
 
+  /// Returns a snapshot of compilation and lifecycle diagnostics.
+  ///
+  /// @return The diagnostics in reporting order.
   public List<ScriptDiagnostic> getDiagnostics() {
     return List.copyOf(this.diagnostics);
   }
 
+  /// Removes all recorded diagnostics.
   public void clearDiagnostics() {
     this.diagnostics.clear();
   }
 
+  /// Removes diagnostics associated with a script identifier.
+  ///
+  /// @param scriptId The identifier to clear; `null` has no effect.
   public void clearDiagnostics(String scriptId) {
     if (scriptId == null) return;
     this.diagnostics.removeIf(d -> Objects.equals(d.scriptId(), scriptId));
   }
 
+  /// Removes diagnostics whose messages identify an entity host.
+  ///
+  /// Diagnostics for other host types are not associated with their host and cannot be cleared by
+  /// this method.
+  ///
+  /// @param host The entity host to clear; other values, including `null`, have no effect.
   public void clearDiagnostics(Object host) {
     if (host == null) return;
     if (host instanceof IEntity entity) {
@@ -270,6 +354,13 @@ public final class ScriptManager implements IUpdateable {
   }
 
 
+  /// Attaches all enabled bindings to a host in ascending binding order.
+  ///
+  /// Failures are reported through [#getDiagnostics()] and omitted from the result.
+  ///
+  /// @param host The object exposed as the script host.
+  /// @param bindings The bindings to attach, or `null` for none.
+  /// @return An unmodifiable list of successfully attached instances.
   public List<ScriptInstance> attachAll(Object host, Collection<ScriptBinding> bindings) {
     return this.attachAll(host, bindings, false);
   }
@@ -285,6 +376,12 @@ public final class ScriptManager implements IUpdateable {
     return List.copyOf(instances);
   }
 
+  /// Attaches one binding to a host.
+  ///
+  /// @param host The object exposed as the script host.
+  /// @param binding The binding to attach.
+  /// @return The attached instance, or `null` when attachment failed.
+  /// @throws NullPointerException if `host` or `binding` is `null`.
   public ScriptInstance attach(Object host, ScriptBinding binding) {
     return this.attach(host, binding, false);
   }
@@ -343,6 +440,15 @@ public final class ScriptManager implements IUpdateable {
     return null;
   }
 
+  /// Recompiles a script and replaces all of its active attachments.
+  ///
+  /// Existing instances are detached before the replacement instances attach. If compilation or
+  /// attachment fails, the replacement is discarded and the manager attempts to reattach the
+  /// previous generation. Rollback attachment failures are recorded as diagnostics. Lifecycle
+  /// callbacks therefore run during both replacement and rollback.
+  ///
+  /// @param scriptId The identifier of the script to reload.
+  /// @return `true` if the replacement compiled and all desired bindings were attached.
   public boolean reload(String scriptId) {
     ScriptDefinition definition = this.definitions.get(scriptId);
     if (definition == null) return false;
@@ -390,6 +496,9 @@ public final class ScriptManager implements IUpdateable {
     return success;
   }
 
+  /// Detaches every script attached to a host and forgets its desired bindings.
+  ///
+  /// @param host The host identified by object identity.
   public void detach(Object host) {
     this.clearDiagnostics(host);
     this.attachments.stream().filter(attachment -> attachment.host == host).toList().forEach(this::detachAttachment);
@@ -405,11 +514,15 @@ public final class ScriptManager implements IUpdateable {
   }
 
   /// Sets the Java language level used for development-time source compilation.
+  ///
+  /// @param projectJavaVersion The positive Java feature version.
+  /// @throws IllegalArgumentException if the version is not positive.
   public void setProjectJavaVersion(int projectJavaVersion) {
     if (projectJavaVersion <= 0) throw new IllegalArgumentException("Project Java version must be positive.");
     this.projectJavaVersion = projectJavaVersion;
   }
 
+  /// Detaches all scripts, closes compiled generations, and unregisters from the update loop.
   public void detachAll() {
     List.copyOf(this.attachments).forEach(this::detachAttachment);
     this.desiredBindings.clear();
@@ -418,6 +531,7 @@ public final class ScriptManager implements IUpdateable {
     this.detachUpdateLoop();
   }
 
+  /// Dispatches one update to non-controller-managed script attachments.
   @Override
   public void update() {
     this.updateAttachments(null, false);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptManager.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptManager.java
@@ -44,7 +44,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/** Coordinates script providers, definitions, bindings, lifecycles, and explicit reloads. */
+/// Coordinates script providers, definitions, bindings, lifecycles, and explicit reloads.
 public final class ScriptManager implements IUpdateable {
   public static final String BINDINGS_PROPERTY = "scriptBindings";
   private static final Logger log = Logger.getLogger(ScriptManager.class.getName());
@@ -110,7 +110,7 @@ public final class ScriptManager implements IUpdateable {
     return List.copyOf(this.providers.values());
   }
 
-  /** Creates non-executing semantic tooling backed by the registered provider for a language. */
+  /// Creates non-executing semantic tooling backed by the registered provider for a language.
   public Optional<ScriptLanguageService> createLanguageService(String language) {
     if (language == null || language.isBlank()) return Optional.empty();
     ScriptProvider provider = this.providers.get(language.toLowerCase());
@@ -167,7 +167,7 @@ public final class ScriptManager implements IUpdateable {
     return definition != null ? new ScriptDefinition(definition) : null;
   }
 
-  /** Returns configurable fields from the currently compiled generation without compiling or executing new code. */
+  /// Returns configurable fields from the currently compiled generation without compiling or executing new code.
   public List<ScriptPropertyMetadata> getPropertyMetadata(String scriptId) {
     CompiledScript compiledScript = this.compiled.get(scriptId);
     if (compiledScript == null) return List.of();
@@ -201,7 +201,7 @@ public final class ScriptManager implements IUpdateable {
     return this.gameBindings.stream().map(ScriptBinding::new).toList();
   }
 
-  /** Replaces reusable bindings that are automatically applied when matching entities are loaded. */
+  /// Replaces reusable bindings that are automatically applied when matching entities are loaded.
   public void setEntityBindings(Collection<EntityScriptBinding> bindings) {
     this.entityBindings.clear();
     if (bindings != null) bindings.stream().filter(Objects::nonNull)
@@ -212,7 +212,7 @@ public final class ScriptManager implements IUpdateable {
     return this.entityBindings.stream().map(EntityScriptBinding::new).toList();
   }
 
-  /** Adds or refreshes the script controller that owns the default bindings for an entity type. */
+  /// Adds or refreshes the script controller that owns the default bindings for an entity type.
   public void configure(IEntity entity) {
     Objects.requireNonNull(entity);
     List<ScriptBinding> defaults = this.resolveEntityBindings(entity);
@@ -227,7 +227,7 @@ public final class ScriptManager implements IUpdateable {
     controller.setDefaultBindings(defaults);
   }
 
-  /** Sets the directory against which relative development-time source paths are resolved. */
+  /// Sets the directory against which relative development-time source paths are resolved.
   public void setProjectRoot(Path projectRoot) {
     this.projectRoot = projectRoot == null ? null : projectRoot.toAbsolutePath().normalize();
   }
@@ -236,12 +236,12 @@ public final class ScriptManager implements IUpdateable {
     return this.projectRoot;
   }
 
-  /** Sets the compiled project class loader used as the parent of runtime-compiled scripts. */
+  /// Sets the compiled project class loader used as the parent of runtime-compiled scripts.
   public void setProjectClassLoader(ClassLoader projectClassLoader) {
     this.projectClassLoader = projectClassLoader;
   }
 
-  /** Sets build-resolved locations used by development-time source compilation. */
+  /// Sets build-resolved locations used by development-time source compilation.
   public void setProjectClasspath(Collection<Path> projectClasspath) {
     this.projectClasspath = projectClasspath == null
       ? List.of()
@@ -404,7 +404,7 @@ public final class ScriptManager implements IUpdateable {
     this.desiredBindings.removeIf(b -> b.host() == host && b.controllerManaged() == controllerManaged);
   }
 
-  /** Sets the Java language level used for development-time source compilation. */
+  /// Sets the Java language level used for development-time source compilation.
   public void setProjectJavaVersion(int projectJavaVersion) {
     if (projectJavaVersion <= 0) throw new IllegalArgumentException("Project Java version must be positive.");
     this.projectJavaVersion = projectJavaVersion;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterNamer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterNamer.java
@@ -42,7 +42,8 @@ final class ScriptParameterNamer {
       case "Sound" -> "sound";
       case "Graphics2D" -> "g";
       case "int" -> {
-        if (methodName.contains("Pan") || methodName.contains("Shake") || methodName.contains("Duration")) yield "durationTicks";
+        if (methodName.contains("Shake")) yield index == total - 1 ? "durationMs" : "intervalMs";
+        if (methodName.contains("Pan") || methodName.contains("Duration")) yield "durationTicks";
         if (methodName.contains("Zoom") || methodName.contains("Delay") || methodName.contains("Time") || methodName.contains("Text") || methodName.contains("Banner")) yield "durationMs";
         if (index == 0 && total >= 2) yield "x";
         if (index == 1 && total >= 2) yield "y";

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterNamer.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterNamer.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Provides descriptive parameter names for reflected methods in script intellisense. */
+/// Provides descriptive parameter names for reflected methods in script intellisense.
 final class ScriptParameterNamer {
   private ScriptParameterNamer() {}
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterSuggestionProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterSuggestionProvider.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** Suggests context-aware values and constants for active method parameter types. */
+/// Suggests context-aware values and constants for active method parameter types.
 final class ScriptParameterSuggestionProvider {
   private static final List<String> COLOR_NAMES = List.of(
     "RED", "GREEN", "BLUE", "YELLOW", "WHITE", "BLACK", "ORANGE", "CYAN", "MAGENTA", "GRAY", "DARK_GRAY", "LIGHT_GRAY", "PINK"

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterValue.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptParameterValue.java
@@ -4,7 +4,7 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 
-/** A persisted string representation of a typed script parameter. */
+/// A persisted string representation of a typed script parameter.
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class ScriptParameterValue {
   @XmlAttribute(required = true) private String name;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptProperty.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptProperty.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Marks a script field as configurable by bindings and utiLITI. */
+/// Marks a script field as configurable by bindings and utiLITI.
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ScriptProperty {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptPropertyMetadata.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptPropertyMetadata.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.scripting;
 
-/** Editor-facing description of one configurable script field discovered from its implementation. */
+/// Editor-facing description of one configurable script field discovered from its implementation.
 public record ScriptPropertyMetadata(String name, String displayName, String description, String category,
                                      String type, String defaultValue, double min, double max, String unit,
                                      boolean required) {}

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptPropertyMetadata.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptPropertyMetadata.java
@@ -1,6 +1,17 @@
 package de.gurkenlabs.litiengine.scripting;
 
 /// Editor-facing description of one configurable script field discovered from its implementation.
+///
+/// @param name The Java field name used for binding.
+/// @param displayName The label intended for editors and tools.
+/// @param description Explanatory text for users configuring the field.
+/// @param category The optional group under which an editor should display the field.
+/// @param type The configured editor type identifier, or the Java field type name when no override is configured.
+/// @param defaultValue The default value represented as text.
+/// @param min The inclusive suggested minimum, or [Double#NEGATIVE_INFINITY] when unspecified.
+/// @param max The inclusive suggested maximum, or [Double#POSITIVE_INFINITY] when unspecified.
+/// @param unit The optional unit displayed with numeric values.
+/// @param required Whether a binding must provide a value.
 public record ScriptPropertyMetadata(String name, String displayName, String description, String category,
                                      String type, String defaultValue, double min, double max, String unit,
                                      boolean required) {}

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptProvider.java
@@ -3,19 +3,19 @@ package de.gurkenlabs.litiengine.scripting;
 import java.net.URL;
 import java.util.Optional;
 
-/** Compiles or resolves scripts for one source language. */
+/// Compiles or resolves scripts for one source language.
 public interface ScriptProvider {
   String language();
 
   CompiledScript compile(ScriptDefinition definition, URL source, ClassLoader parent) throws ScriptException;
 
-  /** Compiles a script with classpath and language-level information supplied by the project build. */
+  /// Compiles a script with classpath and language-level information supplied by the project build.
   default CompiledScript compile(ScriptDefinition definition, URL source, ScriptCompilationContext context)
       throws ScriptException {
     return this.compile(definition, source, context.parent());
   }
 
-  /** Creates semantic tooling for this language when the provider supports editor integration. */
+  /// Creates semantic tooling for this language when the provider supports editor integration.
   default Optional<ScriptLanguageService> createLanguageService(ScriptLanguageService.Workspace workspace) {
     return Optional.empty();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptScope.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptScope.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/** Manages script execution scope, global helper bindings, and type inference. */
+/// Manages script execution scope, global helper bindings, and type inference.
 final class ScriptScope {
   record RootFunction(String name, Class<?> returnType, String returnTypeSimple, String documentation) {}
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptSequence.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptSequence.java
@@ -148,7 +148,7 @@ public final class ScriptSequence implements Subscription {
   ///
   /// @return `true` while a started sequence has not completed or been closed.
   public boolean isRunning() {
-    return this.started && !this.closed && this.index < this.steps.size();
+    return this.started && !this.closed;
   }
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptSequence.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptSequence.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-/** A cancellable ordered sequence of delayed actions owned by a script context. */
+/// A cancellable ordered sequence of delayed actions owned by a script context.
 public final class ScriptSequence implements Subscription {
   private final ScriptContext<?> context;
   private final List<Step> steps = new ArrayList<>();
@@ -37,7 +37,7 @@ public final class ScriptSequence implements Subscription {
     return this;
   }
 
-  /** Schedules a camera pan to a given map location. */
+  /// Schedules a camera pan to a given map location.
   public ScriptSequence cameraPanTo(Point2D target, int durationTicks) {
     Objects.requireNonNull(target, "Target location must not be null.");
     return this.then(() -> {
@@ -47,7 +47,7 @@ public final class ScriptSequence implements Subscription {
     });
   }
 
-  /** Schedules a camera pan to center on a target entity. */
+  /// Schedules a camera pan to center on a target entity.
   public ScriptSequence cameraPanTo(IEntity target, int durationTicks) {
     Objects.requireNonNull(target, "Target entity must not be null.");
     return this.then(() -> {
@@ -57,7 +57,7 @@ public final class ScriptSequence implements Subscription {
     });
   }
 
-  /** Schedules a smooth camera zoom transition. */
+  /// Schedules a smooth camera zoom transition.
   public ScriptSequence cameraZoom(float targetZoom, int delayMs) {
     return this.then(() -> {
       if (Game.world().camera() != null) {
@@ -66,7 +66,7 @@ public final class ScriptSequence implements Subscription {
     });
   }
 
-  /** Schedules a screen shake effect. */
+  /// Schedules a screen shake effect.
   public ScriptSequence screenShake(double intensity, int delayMs, int durationTicks) {
     return this.then(() -> {
       if (Game.world().camera() != null) {
@@ -75,7 +75,7 @@ public final class ScriptSequence implements Subscription {
     });
   }
 
-  /** Schedules playing a sound effect by resource name. */
+  /// Schedules playing a sound effect by resource name.
   public ScriptSequence playSound(String soundName) {
     Objects.requireNonNull(soundName, "Sound name must not be null.");
     return this.then(() -> {
@@ -86,7 +86,7 @@ public final class ScriptSequence implements Subscription {
     });
   }
 
-  /** Schedules playing a sound effect. */
+  /// Schedules playing a sound effect.
   public ScriptSequence playSound(Sound sound) {
     Objects.requireNonNull(sound, "Sound must not be null.");
     return this.then(() -> Game.audio().playSound(sound));

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptSequence.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptSequence.java
@@ -10,6 +10,9 @@ import java.util.List;
 import java.util.Objects;
 
 /// A cancellable ordered sequence of delayed actions owned by a script context.
+///
+/// Build a sequence with [#then(Runnable)] and [#waitFor(int)], then call [#start()]. Delays are
+/// accumulated until the next action. Closing the sequence cancels its pending scheduled action.
 public final class ScriptSequence implements Subscription {
   private final ScriptContext<?> context;
   private final List<Step> steps = new ArrayList<>();
@@ -23,6 +26,11 @@ public final class ScriptSequence implements Subscription {
     this.context = context;
   }
 
+  /// Appends an action after the currently accumulated delay.
+  ///
+  /// @param action The action to invoke.
+  /// @return This sequence.
+  /// @throws IllegalStateException if the sequence has started.
   public ScriptSequence then(Runnable action) {
     if (this.started) throw new IllegalStateException("A running sequence cannot be changed.");
     this.steps.add(new Step(this.pendingDelay, Objects.requireNonNull(action)));
@@ -30,6 +38,13 @@ public final class ScriptSequence implements Subscription {
     return this;
   }
 
+  /// Adds a delay before the next appended action.
+  ///
+  /// @param delay The non-negative delay in milliseconds.
+  /// @return This sequence.
+  /// @throws IllegalStateException if the sequence has started.
+  /// @throws IllegalArgumentException if `delay` is negative.
+  /// @throws ArithmeticException if the accumulated delay overflows.
   public ScriptSequence waitFor(int delay) {
     if (this.started) throw new IllegalStateException("A running sequence cannot be changed.");
     if (delay < 0) throw new IllegalArgumentException("Delay must not be negative.");
@@ -38,6 +53,10 @@ public final class ScriptSequence implements Subscription {
   }
 
   /// Schedules a camera pan to a given map location.
+  ///
+  /// @param target The target in map coordinates.
+  /// @param durationTicks The transition duration in update ticks.
+  /// @return This sequence.
   public ScriptSequence cameraPanTo(Point2D target, int durationTicks) {
     Objects.requireNonNull(target, "Target location must not be null.");
     return this.then(() -> {
@@ -48,6 +67,10 @@ public final class ScriptSequence implements Subscription {
   }
 
   /// Schedules a camera pan to center on a target entity.
+  ///
+  /// @param target The target entity.
+  /// @param durationTicks The transition duration in update ticks.
+  /// @return This sequence.
   public ScriptSequence cameraPanTo(IEntity target, int durationTicks) {
     Objects.requireNonNull(target, "Target entity must not be null.");
     return this.then(() -> {
@@ -58,6 +81,10 @@ public final class ScriptSequence implements Subscription {
   }
 
   /// Schedules a smooth camera zoom transition.
+  ///
+  /// @param targetZoom The target zoom factor.
+  /// @param delayMs The transition duration in milliseconds.
+  /// @return This sequence.
   public ScriptSequence cameraZoom(float targetZoom, int delayMs) {
     return this.then(() -> {
       if (Game.world().camera() != null) {
@@ -67,15 +94,25 @@ public final class ScriptSequence implements Subscription {
   }
 
   /// Schedules a screen shake effect.
-  public ScriptSequence screenShake(double intensity, int delayMs, int durationTicks) {
+  ///
+  /// @param intensity The shake intensity.
+  /// @param intervalMs The minimum interval between generated shake offsets, in milliseconds.
+  /// @param durationMs The shake duration in milliseconds.
+  /// @return This sequence.
+  public ScriptSequence screenShake(double intensity, int intervalMs, int durationMs) {
     return this.then(() -> {
       if (Game.world().camera() != null) {
-        Game.world().camera().shake(intensity, delayMs, durationTicks);
+        Game.world().camera().shake(intensity, intervalMs, durationMs);
       }
     });
   }
 
   /// Schedules playing a sound effect by resource name.
+  ///
+  /// Missing resources are silently skipped when the action runs.
+  ///
+  /// @param soundName The sound resource name.
+  /// @return This sequence.
   public ScriptSequence playSound(String soundName) {
     Objects.requireNonNull(soundName, "Sound name must not be null.");
     return this.then(() -> {
@@ -87,11 +124,18 @@ public final class ScriptSequence implements Subscription {
   }
 
   /// Schedules playing a sound effect.
+  ///
+  /// @param sound The sound to play.
+  /// @return This sequence.
   public ScriptSequence playSound(Sound sound) {
     Objects.requireNonNull(sound, "Sound must not be null.");
     return this.then(() -> Game.audio().playSound(sound));
   }
 
+  /// Starts the sequence and transfers cancellation ownership to its context.
+  ///
+  /// @return This sequence as a cancellable subscription.
+  /// @throws IllegalStateException if it has already started.
   public Subscription start() {
     if (this.started) throw new IllegalStateException("The sequence has already started.");
     this.started = true;
@@ -100,6 +144,9 @@ public final class ScriptSequence implements Subscription {
     return this;
   }
 
+  /// Returns whether the sequence has pending actions.
+  ///
+  /// @return `true` while a started sequence has not completed or been closed.
   public boolean isRunning() {
     return this.started && !this.closed && this.index < this.steps.size();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptedSpawner.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptedSpawner.java
@@ -22,16 +22,26 @@ public final class ScriptedSpawner {
   }
 
   /// Starts building a [Creature] to spawn.
+  ///
+  /// @param spritePrefix The animation sprite prefix.
+  /// @return A creature builder.
   public CreatureBuilder creature(String spritePrefix) {
     return new CreatureBuilder(this.environment, spritePrefix);
   }
 
   /// Starts building a [Prop] to spawn.
+  ///
+  /// @param spriteSheet The spritesheet name.
+  /// @return A prop builder.
   public PropBuilder prop(String spriteSheet) {
     return new PropBuilder(this.environment, spriteSheet);
   }
 
   /// Starts building an entity of arbitrary type via reflection.
+  ///
+  /// @param type The concrete type, which must declare a no-argument constructor that reflection is permitted to open.
+  /// @param <T> The entity type.
+  /// @return A builder using reflective construction.
   public <T extends IEntity> EntityBuilder<T> entity(Class<T> type) {
     Objects.requireNonNull(type, "Entity class must not be null.");
     return new EntityBuilder<>(this.environment, () -> {
@@ -46,16 +56,29 @@ public final class ScriptedSpawner {
   }
 
   /// Starts building an entity supplied by a factory.
+  ///
+  /// @param factory The factory invoked for each [EntityBuilder#spawn()] call.
+  /// @param <T> The entity type.
+  /// @return A builder using the factory.
   public <T extends IEntity> EntityBuilder<T> entity(Supplier<T> factory) {
     return new EntityBuilder<>(this.environment, factory);
   }
 
   /// Starts configuring an existing entity instance to spawn.
+  ///
+  /// @param entity The entity to configure and add.
+  /// @param <T> The entity type.
+  /// @return A builder that returns the supplied instance.
   public <T extends IEntity> EntityBuilder<T> entity(T entity) {
     Objects.requireNonNull(entity, "Entity must not be null.");
     return new EntityBuilder<>(this.environment, () -> entity);
   }
 
+  /// Configures an entity before adding it to an environment.
+  ///
+  /// Builders are reusable when their factory creates a fresh entity for every invocation.
+  ///
+  /// @param <T> The entity type.
   public static class EntityBuilder<T extends IEntity> {
     protected final Environment env;
     protected final Supplier<T> factory;
@@ -66,46 +89,82 @@ public final class ScriptedSpawner {
     protected Integer health;
     protected Consumer<T> customizer;
 
+    /// Creates an entity builder.
+    ///
+    /// @param env The destination environment.
+    /// @param factory The entity factory.
     public EntityBuilder(Environment env, Supplier<T> factory) {
       this.env = Objects.requireNonNull(env);
       this.factory = Objects.requireNonNull(factory);
     }
 
+    /// Sets the spawn coordinates.
+    ///
+    /// @param x The map x-coordinate.
+    /// @param y The map y-coordinate.
+    /// @return This builder.
     public EntityBuilder<T> at(double x, double y) {
       this.location = new Point2D.Double(x, y);
       return this;
     }
 
+    /// Sets the spawn location.
+    ///
+    /// @param location The location in map coordinates; `null` leaves it unchanged.
+    /// @return This builder.
     public EntityBuilder<T> at(Point2D location) {
       if (location != null) this.location = location;
       return this;
     }
 
+    /// Sets the entity name.
+    ///
+    /// @param name The name to assign.
+    /// @return This builder.
     public EntityBuilder<T> withName(String name) {
       this.name = name;
       return this;
     }
 
+    /// Sets tags to add to the entity.
+    ///
+    /// @param tags The tags; null entries are ignored.
+    /// @return This builder.
     public EntityBuilder<T> withTags(String... tags) {
       this.tags = tags;
       return this;
     }
 
+    /// Sets the entity's render layer.
+    ///
+    /// @param renderType The render type, or `null` to preserve the entity default.
+    /// @return This builder.
     public EntityBuilder<T> withRenderType(RenderType renderType) {
       this.renderType = renderType;
       return this;
     }
 
+    /// Sets current and maximum hit points when the entity supports combat.
+    ///
+    /// @param health The hit-point value.
+    /// @return This builder.
     public EntityBuilder<T> withHealth(int health) {
       this.health = health;
       return this;
     }
 
+    /// Sets an operation invoked after standard configuration but before insertion.
+    ///
+    /// @param customizer The customizer, or `null` for none.
+    /// @return This builder.
     public EntityBuilder<T> configure(Consumer<T> customizer) {
       this.customizer = customizer;
       return this;
     }
 
+    /// Creates, configures, and adds an entity to the environment.
+    ///
+    /// @return The spawned entity, or `null` if the factory returned `null`.
     public T spawn() {
       T instance = this.factory.get();
       if (instance == null) return null;
@@ -129,9 +188,14 @@ public final class ScriptedSpawner {
     }
   }
 
+  /// Type-preserving builder for creatures.
   public static final class CreatureBuilder extends EntityBuilder<Creature> {
     private final String spritePrefix;
 
+    /// Creates a creature builder.
+    ///
+    /// @param env The destination environment.
+    /// @param spritePrefix The animation sprite prefix.
     public CreatureBuilder(Environment env, String spritePrefix) {
       super(env, () -> new Creature(spritePrefix));
       this.spritePrefix = spritePrefix;
@@ -174,9 +238,14 @@ public final class ScriptedSpawner {
     }
   }
 
+  /// Type-preserving builder for props.
   public static final class PropBuilder extends EntityBuilder<Prop> {
     private final String spriteSheet;
 
+    /// Creates a prop builder.
+    ///
+    /// @param env The destination environment.
+    /// @param spriteSheet The spritesheet name.
     public PropBuilder(Environment env, String spriteSheet) {
       super(env, () -> new Prop(spriteSheet));
       this.spriteSheet = spriteSheet;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptedSpawner.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ScriptedSpawner.java
@@ -13,9 +13,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-/**
- * Fluent builder for spawning typed entities directly into an environment from scripts.
- */
+/// Fluent builder for spawning typed entities directly into an environment from scripts.
 public final class ScriptedSpawner {
   private final Environment environment;
 
@@ -23,17 +21,17 @@ public final class ScriptedSpawner {
     this.environment = Objects.requireNonNull(environment, "Environment must not be null.");
   }
 
-  /** Starts building a {@link Creature} to spawn. */
+  /// Starts building a [Creature] to spawn.
   public CreatureBuilder creature(String spritePrefix) {
     return new CreatureBuilder(this.environment, spritePrefix);
   }
 
-  /** Starts building a {@link Prop} to spawn. */
+  /// Starts building a [Prop] to spawn.
   public PropBuilder prop(String spriteSheet) {
     return new PropBuilder(this.environment, spriteSheet);
   }
 
-  /** Starts building an entity of arbitrary type via reflection. */
+  /// Starts building an entity of arbitrary type via reflection.
   public <T extends IEntity> EntityBuilder<T> entity(Class<T> type) {
     Objects.requireNonNull(type, "Entity class must not be null.");
     return new EntityBuilder<>(this.environment, () -> {
@@ -47,12 +45,12 @@ public final class ScriptedSpawner {
     });
   }
 
-  /** Starts building an entity supplied by a factory. */
+  /// Starts building an entity supplied by a factory.
   public <T extends IEntity> EntityBuilder<T> entity(Supplier<T> factory) {
     return new EntityBuilder<>(this.environment, factory);
   }
 
-  /** Starts configuring an existing entity instance to spawn. */
+  /// Starts configuring an existing entity instance to spawn.
   public <T extends IEntity> EntityBuilder<T> entity(T entity) {
     Objects.requireNonNull(entity, "Entity must not be null.");
     return new EntityBuilder<>(this.environment, () -> entity);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/Subscription.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/Subscription.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.scripting;
 
-/** A removable event or runtime registration. */
+/// A removable event or runtime registration.
 @FunctionalInterface
 public interface Subscription extends AutoCloseable {
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/Subscriptions.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/Subscriptions.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/** Owns a collection of registrations and releases them together. */
+/// Owns a collection of registrations and releases them together.
 public final class Subscriptions implements AutoCloseable {
   private static final Logger log = Logger.getLogger(Subscriptions.class.getName());
   private final Collection<Subscription> subscriptions = ConcurrentHashMap.newKeySet();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedAbility.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedAbility.java
@@ -3,7 +3,7 @@ package de.gurkenlabs.litiengine.scripting.combat;
 import de.gurkenlabs.litiengine.abilities.DynamicAbility;
 import de.gurkenlabs.litiengine.entities.Creature;
 
-/** An ability implementation configured fluently and executed via script callbacks. */
+/// An ability implementation configured fluently and executed via script callbacks.
 public class ScriptedAbility extends DynamicAbility {
 
   public ScriptedAbility(Creature executor, String name) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedAbilityBuilder.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedAbilityBuilder.java
@@ -7,7 +7,7 @@ import de.gurkenlabs.litiengine.abilities.effects.Effect;
 import de.gurkenlabs.litiengine.entities.Creature;
 import java.util.function.Consumer;
 
-/** Fluent builder for constructing and registering {@link ScriptedAbility} instances. */
+/// Fluent builder for constructing and registering [ScriptedAbility] instances.
 public final class ScriptedAbilityBuilder extends AbilityBuilder {
 
   public ScriptedAbilityBuilder(Creature executor, String name) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedProjectile.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedProjectile.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-/** A projectile entity created dynamically via scripting that moves, impacts targets, and handles collision. */
+/// A projectile entity created dynamically via scripting that moves, impacts targets, and handles collision.
 public class ScriptedProjectile extends Creature implements IUpdateable {
   private final Environment environment;
   private final ICombatEntity sourceEntity;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedProjectileBuilder.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/combat/ScriptedProjectileBuilder.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-/** Fluent builder to configure and spawn {@link ScriptedProjectile} instances. */
+/// Fluent builder to configure and spawn [ScriptedProjectile] instances.
 public final class ScriptedProjectileBuilder {
   private final Environment environment;
   private String spritePrefix = "projectile";

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/package-info.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/package-info.java
@@ -1,0 +1,6 @@
+/// Runtime Java scripting, lifecycle bindings, managed services, diagnostics, and editor metadata.
+///
+/// Register definitions and bindings with [de.gurkenlabs.litiengine.scripting.ScriptManager]. A
+/// [de.gurkenlabs.litiengine.scripting.ScriptContext] exposes the host and automatically releases
+/// resources owned by an attached script.
+package de.gurkenlabs.litiengine.scripting;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ui/FloatingText.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ui/FloatingText.java
@@ -4,7 +4,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.geom.Point2D;
 
-/** Represents a transient floating text item displayed in the game world. */
+/// Represents a transient floating text item displayed in the game world.
 public final class FloatingText {
   private final String text;
   private final Point2D location;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ui/ScriptUiOverlay.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/scripting/ui/ScriptUiOverlay.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/** Manages transient UI elements, floating combat text, banners, and script-driven overlays. */
+/// Manages transient UI elements, floating combat text, banners, and script-driven overlays.
 public final class ScriptUiOverlay implements IUpdateable, Subscription {
   private final List<FloatingText> floatingTexts = new CopyOnWriteArrayList<>();
   private final List<ScreenText> screenTexts = new CopyOnWriteArrayList<>();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/IntroTrack.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/IntroTrack.java
@@ -5,49 +5,39 @@ import java.util.Iterator;
 import java.util.Objects;
 import javax.sound.sampled.AudioFormat;
 
-/**
- * A {@code Track} that plays an intro sound and then loops the specified music sound.
- */
+/// A `Track` that plays an intro sound and then loops the specified music sound.
 public class IntroTrack implements Track {
   private final Sound intro;
   private final Sound loop;
 
-  /**
-   * Initializes a new {@code IntroTrack} for the specified sound.
-   *
-   * @param intro The name of the sound to be played as intro.
-   * @param loop  The name of the sound to be looped.
-   */
+  /// Initializes a new `IntroTrack` for the specified sound.
+  ///
+  /// @param intro The name of the sound to be played as intro.
+  /// @param loop  The name of the sound to be looped.
   public IntroTrack(String intro, String loop) {
     this(Resources.sounds().get(intro), Resources.sounds().get(loop));
   }
 
-  /**
-   * Initializes a new {@code IntroTrack} for the specified sound.
-   *
-   * @param intro The sound to be played as intro.
-   * @param loop  The name of the sound to be looped.
-   */
+  /// Initializes a new `IntroTrack` for the specified sound.
+  ///
+  /// @param intro The sound to be played as intro.
+  /// @param loop  The name of the sound to be looped.
   public IntroTrack(Sound intro, String loop) {
     this(intro, Resources.sounds().get(loop));
   }
 
-  /**
-   * Initializes a new {@code IntroTrack} for the specified sound.
-   *
-   * @param intro The name of the sound to be played as intro.
-   * @param loop  The sound to be looped.
-   */
+  /// Initializes a new `IntroTrack` for the specified sound.
+  ///
+  /// @param intro The name of the sound to be played as intro.
+  /// @param loop  The sound to be looped.
   public IntroTrack(String intro, Sound loop) {
     this(Resources.sounds().get(intro), loop);
   }
 
-  /**
-   * Initializes a new {@code IntroTrack} for the specified sound.
-   *
-   * @param intro The sound to be played as intro.
-   * @param loop  The sound to be looped.
-   */
+  /// Initializes a new `IntroTrack` for the specified sound.
+  ///
+  /// @param intro The sound to be played as intro.
+  /// @param loop  The sound to be looped.
   public IntroTrack(Sound intro, Sound loop) {
     Objects.requireNonNull(intro);
     Objects.requireNonNull(loop);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/LoopedTrack.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/LoopedTrack.java
@@ -9,20 +9,16 @@ import javax.sound.sampled.AudioFormat;
 public class LoopedTrack implements Track, Iterator<Sound> {
   private final Sound track;
 
-  /**
-   * Initializes a new {@code LoopedTrack} for the specified sound.
-   *
-   * @param soundName The name of the sound to be played by this track.
-   */
+  /// Initializes a new `LoopedTrack` for the specified sound.
+  ///
+  /// @param soundName The name of the sound to be played by this track.
   public LoopedTrack(String soundName) {
     this(Resources.sounds().get(soundName));
   }
 
-  /**
-   * Initializes a new {@code LoopedTrack} for the specified sound.
-   *
-   * @param sound The sound to be played by this track.
-   */
+  /// Initializes a new `LoopedTrack` for the specified sound.
+  ///
+  /// @param sound The sound to be played by this track.
   public LoopedTrack(Sound sound) {
     this.track = Objects.requireNonNull(sound);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/MusicPlayback.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/MusicPlayback.java
@@ -3,7 +3,7 @@ package de.gurkenlabs.litiengine.sound;
 import de.gurkenlabs.litiengine.Game;
 import javax.sound.sampled.LineUnavailableException;
 
-/** A {@code SoundPlayback} implementation for the playback music. */
+/// A `SoundPlayback` implementation for the playback music.
 public class MusicPlayback extends SoundPlayback {
   private final Track track;
   private final VolumeControl musicVolume;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SFXPlayback.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SFXPlayback.java
@@ -6,7 +6,7 @@ import java.util.function.Supplier;
 import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.LineUnavailableException;
 
-/** A {@code SoundPlayback} implementation for the playback of sound effects. */
+/// A `SoundPlayback` implementation for the playback of sound effects.
 public class SFXPlayback extends SoundPlayback {
   private final Sound sound;
   private final FloatControl panControl;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SinglePlayTrack.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SinglePlayTrack.java
@@ -5,9 +5,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import javax.sound.sampled.AudioFormat;
 
-/**
- * A {@code Track} that plays a sound once and then stops.
- */
+/// A `Track` that plays a sound once and then stops.
 public class SinglePlayTrack implements Track {
   private Sound sound;
 
@@ -29,20 +27,16 @@ public class SinglePlayTrack implements Track {
     }
   }
 
-  /**
-   * Initializes a new {@code SinglePlayTrack} for the specified sound.
-   *
-   * @param soundName The name of the sound to be played by this track.
-   */
+  /// Initializes a new `SinglePlayTrack` for the specified sound.
+  ///
+  /// @param soundName The name of the sound to be played by this track.
   public SinglePlayTrack(String soundName) {
     this(Resources.sounds().get(soundName));
   }
 
-  /**
-   * Initializes a new {@code SinglePlayTrack} for the specified sound.
-   *
-   * @param sound The sound to be played by this track.
-   */
+  /// Initializes a new `SinglePlayTrack` for the specified sound.
+  ///
+  /// @param sound The sound to be played by this track.
   public SinglePlayTrack(Sound sound) {
     this.sound = sound;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/Sound.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/Sound.java
@@ -8,10 +8,8 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.UnsupportedAudioFileException;
 
-/**
- * This class implements all required functionality to load sounds from the file system and provide a stream that can
- * later on be used for the sound playback.
- */
+/// This class implements all required functionality to load sounds from the file system and provide a stream that can
+/// later on be used for the sound playback.
 public final class Sound {
 
   private final AudioFormat format;
@@ -22,23 +20,19 @@ public final class Sound {
 
   private final byte[] data;
 
-  /**
-   * Creates a new Sound instance by the specified file path. Loads the sound data into a byte array and also retrieves
-   * information about the format of the sound file.
-   *
-   * <p>
-   * Note that the constructor is private. In order to load files use the static {@code
-   * Resources.sounds().get(String)} method.
-   *
-   * @param is
-   *          The input stream to load the sound from.
-   * @param name
-   *          The name of this sound file.
-   * @throws IOException
-   *           If something went wrong loading the file
-   * @throws UnsupportedAudioFileException
-   *           If the audio format is not supported
-   */
+  /// Creates a new Sound instance by the specified file path. Loads the sound data into a byte array and also retrieves
+  /// information about the format of the sound file.
+  ///
+  /// Note that the constructor is private. In order to load files use the static `Resources.sounds().get(String)` method.
+  ///
+  /// @param is
+  /// The input stream to load the sound from.
+  /// @param name
+  /// The name of this sound file.
+  /// @throws IOException
+  /// If something went wrong loading the file
+  /// @throws UnsupportedAudioFileException
+  /// If the audio format is not supported
   public Sound(InputStream is, String name) throws IOException, UnsupportedAudioFileException {
     this.name = name;
 
@@ -52,32 +46,25 @@ public final class Sound {
     }
   }
 
-  /**
-   * Gets the audio format of this sound instance.
-   *
-   * @return The audio format of this instance.
-   */
+  /// Gets the audio format of this sound instance.
+  ///
+  /// @return The audio format of this instance.
   public AudioFormat getFormat() {
     return this.format;
   }
 
-  /**
-   * Gets the name of this instance that is used to uniquely identify the resource of this sound.
-   *
-   * @return The name of this sound.
-   */
+  /// Gets the name of this instance that is used to uniquely identify the resource of this sound.
+  ///
+  /// @return The name of this sound.
   public String getName() {
     return this.name;
   }
 
-  /**
-   * Gets the raw data of this sound as byte array.
-   *
-   * <p>
-   * This is used during resource serialization.
-   *
-   * @return The raw data of this sound as byte array.
-   */
+  /// Gets the raw data of this sound as byte array.
+  ///
+  /// This is used during resource serialization.
+  ///
+  /// @return The raw data of this sound as byte array.
   public byte[] getRawData() {
     return this.data;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundEngine.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundEngine.java
@@ -21,15 +21,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.sound.sampled.LineUnavailableException;
 
-/**
- * This {@code SoundEngine} class provides all methods to play back sounds and music in your game.
- * It allows to define the 2D coordinates of the sound or even pass in the source entity of the
- * sound which will adjust the position according to the position of the entity.
- *
- * <p>
- * The sound engine supports .wav, .mp3 and .ogg by default. If you need other file extensions, you
- * have to write an own SPI implementation and inject it in your project.
- */
+/// This `SoundEngine` class provides all methods to play back sounds and music in your game.
+/// It allows to define the 2D coordinates of the sound or even pass in the source entity of the
+/// sound which will adjust the position according to the position of the entity.
+///
+/// The sound engine supports .wav, .mp3 and .ogg by default. If you need other file extensions, you
+/// have to write an own SPI implementation and inject it in your project.
 public final class SoundEngine implements IUpdateable, ILaunchable {
 
   public static final int DEFAULT_MAX_DISTANCE = 150;
@@ -55,11 +52,9 @@ public final class SoundEngine implements IUpdateable, ILaunchable {
   private final Collection<MusicPlayback> allMusic = ConcurrentHashMap.newKeySet();
   private final Collection<SFXPlayback> sounds = ConcurrentHashMap.newKeySet();
 
-  /**
-   * <b>You should never call this manually! Instead use the {@code Game.audio()} instance.</b>
-   *
-   * @see Game#audio()
-   */
+  /// **You should never call this manually! Instead use the `Game.audio()` instance.**
+  ///
+  /// @see Game#audio()
   public SoundEngine() {
     if (Game.audio() != null) {
       throw new UnsupportedOperationException(
@@ -67,83 +62,69 @@ public final class SoundEngine implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Gets the maximum distance from the listener at which a sound source can still be heard.
-   *
-   * @return The maximum distance at which a sound can be heard.
-   */
+  /// Gets the maximum distance from the listener at which a sound source can still be heard.
+  ///
+  /// @return The maximum distance at which a sound can be heard.
   public int getMaxDistance() {
     return maxDist;
   }
 
-  /**
-   * Sets the currently playing track to a {@code LoopedTrack} with the sound defined by the
-   * specified music name. This has no effect if the specified track is already playing.
-   *
-   * @param musicName The name of the {@code Sound} to be played.
-   * @return The playback of the music
-   */
+  /// Sets the currently playing track to a `LoopedTrack` with the sound defined by the
+  /// specified music name. This has no effect if the specified track is already playing.
+  ///
+  /// @param musicName The name of the `Sound` to be played.
+  /// @return The playback of the music
   public MusicPlayback playMusic(String musicName) {
     return playMusic(Resources.sounds().get(musicName));
   }
 
-  /**
-   * Sets the currently playing track to a {@code LoopedTrack} with the specified music
-   * {@code Sound}. This has no effect if the specified track is already playing.
-   *
-   * @param music The {@code Sound} to be played.
-   * @return The playback of the music
-   */
+  /// Sets the currently playing track to a `LoopedTrack` with the specified music
+  /// `Sound`. This has no effect if the specified track is already playing.
+  ///
+  /// @param music The `Sound` to be played.
+  /// @return The playback of the music
   public MusicPlayback playMusic(Sound music) {
     return playMusic(new LoopedTrack(music));
   }
 
-  /**
-   * Sets the currently playing track to the specified track. This has no effect if the specified
-   * track is already playing.
-   *
-   * @param track The track to play
-   * @return The playback of the music
-   */
+  /// Sets the currently playing track to the specified track. This has no effect if the specified
+  /// track is already playing.
+  ///
+  /// @param track The track to play
+  /// @return The playback of the music
   public MusicPlayback playMusic(Track track) {
     return playMusic(track, null, false, true);
   }
 
-  /**
-   * Sets the currently playing track to the specified track.
-   *
-   * @param track   The track to play
-   * @param restart Whether to restart if the specified track is already playing, determined by
-   *                {@link Object#equals(Object)}
-   * @return The playback of the music
-   */
+  /// Sets the currently playing track to the specified track.
+  ///
+  /// @param track   The track to play
+  /// @param restart Whether to restart if the specified track is already playing, determined by
+  /// [Object#equals(Object)]
+  /// @return The playback of the music
   public MusicPlayback playMusic(Track track, boolean restart) {
     return playMusic(track, null, restart, true);
   }
 
-  /**
-   * Plays the specified track.
-   *
-   * @param track   The track to play
-   * @param restart Whether to restart if the specified track is already playing, determined by
-   *                {@link Object#equals(Object)}
-   * @param stop    Whether to stop an existing track if present
-   * @return The playback of the music
-   */
+  /// Plays the specified track.
+  ///
+  /// @param track   The track to play
+  /// @param restart Whether to restart if the specified track is already playing, determined by
+  /// [Object#equals(Object)]
+  /// @param stop    Whether to stop an existing track if present
+  /// @return The playback of the music
   public MusicPlayback playMusic(Track track, boolean restart, boolean stop) {
     return playMusic(track, null, restart, stop);
   }
 
-  /**
-   * Plays the specified track, optionally configuring it before starting.
-   *
-   * @param track   The track to play
-   * @param config  A call to configure the playback prior to starting, which can be {@code null}
-   * @param restart Whether to restart if the specified track is already playing, determined by
-   *                {@link Object#equals(Object)}
-   * @param stop    Whether to stop an existing track if present
-   * @return The playback of the music
-   */
+  /// Plays the specified track, optionally configuring it before starting.
+  ///
+  /// @param track   The track to play
+  /// @param config  A call to configure the playback prior to starting, which can be `null`
+  /// @param restart Whether to restart if the specified track is already playing, determined by
+  /// [Object#equals(Object)]
+  /// @param stop    Whether to stop an existing track if present
+  /// @return The playback of the music
   public synchronized MusicPlayback playMusic(
     Track track, Consumer<? super MusicPlayback> config, boolean restart, boolean stop) {
     if (!restart && music != null && music.isPlaying() && music.getTrack().equals(track)) {
@@ -168,390 +149,331 @@ public final class SoundEngine implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Fades out all music volume to 0 over the specified time.
-   *
-   * @param duration The fade duration in milliseconds
-   */
+  /// Fades out all music volume to 0 over the specified time.
+  ///
+  /// @param duration The fade duration in milliseconds
   public void fadeMusic(int duration) {
     this.allMusic.forEach(m -> m.fade(duration));
   }
 
-  /**
-   * Fades all music volume to a given value over the specified time.
-   *
-   * @param duration The fade duration in milliseconds
-   * @param target   The target volume.
-   * @param easeType The easing Function used for Tweening the volume
-   */
+  /// Fades all music volume to a given value over the specified time.
+  ///
+  /// @param duration The fade duration in milliseconds
+  /// @param target   The target volume.
+  /// @param easeType The easing Function used for Tweening the volume
   public void fadeMusic(int duration, float target, TweenFunction easeType) {
     this.allMusic.forEach(m -> m.fade(duration, target, easeType));
   }
 
-  /**
-   * Gets the "main" music that is playing. This usually means the last call to {@code playMusic},
-   * though if the music has been stopped it will be {@code null}.
-   *
-   * @return The main music, which could be {@code null}.
-   */
+  /// Gets the "main" music that is playing. This usually means the last call to `playMusic`,
+  /// though if the music has been stopped it will be `null`.
+  ///
+  /// @return The main music, which could be `null`.
   public synchronized MusicPlayback getMusic() {
     return music;
   }
 
-  /**
-   * Gets a list of all music playbacks.
-   *
-   * @return A list of all music playbacks.
-   */
+  /// Gets a list of all music playbacks.
+  ///
+  /// @return A list of all music playbacks.
   public synchronized Collection<MusicPlayback> getAllMusic() {
     return Collections.unmodifiableCollection(allMusic);
   }
 
-  /**
-   * Plays the specified sound and updates its volume and pan by the current entity location in
-   * relation to the listener location.
-   *
-   * @param entity The entity at which location the sound should be played.
-   * @param sound  The sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound and updates its volume and pan by the current entity location in
+  /// relation to the listener location.
+  ///
+  /// @param entity The entity at which location the sound should be played.
+  /// @param sound  The sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final IEntity entity) {
     return playSound(sound, entity, false);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name and updates its volume and pan by the current
-   * entity location in relation to the listener location.
-   *
-   * @param entity    The entity at which location the sound should be played.
-   * @param soundName The name of the sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name and updates its volume and pan by the current
+  /// entity location in relation to the listener location.
+  ///
+  /// @param entity    The entity at which location the sound should be played.
+  /// @param soundName The name of the sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName, final IEntity entity) {
     return playSound(Resources.sounds().get(soundName), entity, false);
   }
 
-  /**
-   * Plays the specified sound and updates its volume and pan by the current entity location in
-   * relation to the listener location.
-   *
-   * @param entity The entity at which location the sound should be played.
-   * @param sound  The sound to play.
-   * @param loop   Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound and updates its volume and pan by the current entity location in
+  /// relation to the listener location.
+  ///
+  /// @param entity The entity at which location the sound should be played.
+  /// @param sound  The sound to play.
+  /// @param loop   Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final IEntity entity, boolean loop) {
     return playSound(sound, entity, loop, getMaxDistance(), 1f);
   }
 
-  /**
-   * Plays the specified sound and updates its volume and pan by the current entity location in
-   * relation to the listener location.
-   *
-   * @param entity The entity at which location the sound should be played.
-   * @param sound  The sound to play.
-   * @param loop   Determines whether this playback should be looped or not.
-   * @param range  the range in pixels for which this sound can be heard
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound and updates its volume and pan by the current entity location in
+  /// relation to the listener location.
+  ///
+  /// @param entity The entity at which location the sound should be played.
+  /// @param sound  The sound to play.
+  /// @param loop   Determines whether this playback should be looped or not.
+  /// @param range  the range in pixels for which this sound can be heard
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final IEntity entity, boolean loop, int range) {
     return playSound(sound, entity::getCenter, loop, range, 1f);
   }
 
-  /**
-   * Plays the specified sound and updates its volume and pan by the current entity location in
-   * relation to the listener location.
-   *
-   * @param entity The entity at which location the sound should be played.
-   * @param sound  The sound to play.
-   * @param loop   Determines whether this playback should be looped or not.
-   * @param range  the range in pixels for which this sound can be heard
-   * @param volume The volume modifier for the sound playback instance.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound and updates its volume and pan by the current entity location in
+  /// relation to the listener location.
+  ///
+  /// @param entity The entity at which location the sound should be played.
+  /// @param sound  The sound to play.
+  /// @param loop   Determines whether this playback should be looped or not.
+  /// @param range  the range in pixels for which this sound can be heard
+  /// @param volume The volume modifier for the sound playback instance.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(
     final Sound sound, final IEntity entity, boolean loop, int range, float volume) {
     return playSound(sound, entity::getCenter, loop, range, volume);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name and updates its volume and pan by the current
-   * entity location in relation to the listener location.
-   *
-   * @param entity    The entity at which location the sound should be played.
-   * @param soundName The name of the sound to play.
-   * @param loop      Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name and updates its volume and pan by the current
+  /// entity location in relation to the listener location.
+  ///
+  /// @param entity    The entity at which location the sound should be played.
+  /// @param soundName The name of the sound to play.
+  /// @param loop      Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName, final IEntity entity, boolean loop) {
     return playSound(Resources.sounds().get(soundName), entity, loop);
   }
 
-  /**
-   * Plays the specified sound at the specified location and updates the volume and pan in relation
-   * to the listener location.
-   *
-   * @param location The location at which to play the sound.
-   * @param sound    The sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound at the specified location and updates the volume and pan in relation
+  /// to the listener location.
+  ///
+  /// @param location The location at which to play the sound.
+  /// @param sound    The sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final Point2D location) {
     return playSound(sound, location, false);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name at the specified location and updates the volume
-   * and pan in relation to the listener location.
-   *
-   * @param location  The location at which to play the sound.
-   * @param soundName The name of the sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name at the specified location and updates the volume
+  /// and pan in relation to the listener location.
+  ///
+  /// @param location  The location at which to play the sound.
+  /// @param soundName The name of the sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName, final Point2D location) {
     return playSound(Resources.sounds().get(soundName), location, false);
   }
 
-  /**
-   * Plays the specified sound at the specified location and updates the volume and pan in relation
-   * to the listener location.
-   *
-   * @param x     The x-coordinate of the location at which to play the sound.
-   * @param y     The y-coordinate of the location at which to play the sound.
-   * @param sound The sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound at the specified location and updates the volume and pan in relation
+  /// to the listener location.
+  ///
+  /// @param x     The x-coordinate of the location at which to play the sound.
+  /// @param y     The y-coordinate of the location at which to play the sound.
+  /// @param sound The sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, double x, double y) {
     return playSound(sound, new Point2D.Double(x, y), false);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name at the specified location and updates the volume
-   * and pan in relation to the listener location.
-   *
-   * @param x         The x-coordinate of the location at which to play the sound.
-   * @param y         The y-coordinate of the location at which to play the sound.
-   * @param soundName The name of the sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name at the specified location and updates the volume
+  /// and pan in relation to the listener location.
+  ///
+  /// @param x         The x-coordinate of the location at which to play the sound.
+  /// @param y         The y-coordinate of the location at which to play the sound.
+  /// @param soundName The name of the sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName, double x, double y) {
     return playSound(Resources.sounds().get(soundName), new Point2D.Double(x, y), false);
   }
 
-  /**
-   * Plays the specified sound at the specified location and updates the volume and pan in relation
-   * to the listener location.
-   *
-   * @param location The location at which to play the sound.
-   * @param sound    The sound to play.
-   * @param loop     Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound at the specified location and updates the volume and pan in relation
+  /// to the listener location.
+  ///
+  /// @param location The location at which to play the sound.
+  /// @param sound    The sound to play.
+  /// @param loop     Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final Point2D location, boolean loop) {
     return playSound(sound, () -> location, loop, getMaxDistance(), 1f);
   }
 
-  /**
-   * Plays the specified sound at the specified location and updates the volume and pan in relation
-   * to the listener location.
-   *
-   * @param location The location at which to play the sound.
-   * @param sound    The sound to play.
-   * @param loop     Determines whether this playback should be looped or not.
-   * @param range    the range in pixels for which this sound can be heard
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound at the specified location and updates the volume and pan in relation
+  /// to the listener location.
+  ///
+  /// @param location The location at which to play the sound.
+  /// @param sound    The sound to play.
+  /// @param loop     Determines whether this playback should be looped or not.
+  /// @param range    the range in pixels for which this sound can be heard
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final Point2D location, boolean loop, int range) {
     return playSound(sound, () -> location, loop, range, 1f);
   }
 
-  /**
-   * Plays the specified sound at the specified location and updates the volume and pan in relation
-   * to the listener location.
-   *
-   * @param location The location at which to play the sound.
-   * @param sound    The sound to play.
-   * @param loop     Determines whether this playback should be looped or not.
-   * @param range    the range in pixels for which this sound can be heard
-   * @param volume   The volume modifier for the sound playback instance.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound at the specified location and updates the volume and pan in relation
+  /// to the listener location.
+  ///
+  /// @param location The location at which to play the sound.
+  /// @param sound    The sound to play.
+  /// @param loop     Determines whether this playback should be looped or not.
+  /// @param range    the range in pixels for which this sound can be heard
+  /// @param volume   The volume modifier for the sound playback instance.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(
     final Sound sound, final Point2D location, boolean loop, int range, float volume) {
     return playSound(sound, () -> location, loop, range, volume);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name at the specified location and updates the volume
-   * and pan in relation to the listener location.
-   *
-   * @param location  The location at which to play the sound.
-   * @param soundName The name of the sound to play.
-   * @param loop      Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name at the specified location and updates the volume
+  /// and pan in relation to the listener location.
+  ///
+  /// @param location  The location at which to play the sound.
+  /// @param soundName The name of the sound to play.
+  /// @param loop      Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName, final Point2D location, boolean loop) {
     return playSound(Resources.sounds().get(soundName), location, loop);
   }
 
-  /**
-   * Plays the specified sound at the specified location and updates the volume and pan in relation
-   * to the listener location.
-   *
-   * @param x     The x-coordinate of the location at which to play the sound.
-   * @param y     The y-coordinate of the location at which to play the sound.
-   * @param sound The sound to play.
-   * @param loop  Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound at the specified location and updates the volume and pan in relation
+  /// to the listener location.
+  ///
+  /// @param x     The x-coordinate of the location at which to play the sound.
+  /// @param y     The y-coordinate of the location at which to play the sound.
+  /// @param sound The sound to play.
+  /// @param loop  Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, final double x, final double y, boolean loop) {
     return playSound(sound, new Point2D.Double(x, y), loop);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name at the specified location and updates the volume
-   * and pan in relation to the listener location.
-   *
-   * @param x         The x-coordinate of the location at which to play the sound.
-   * @param y         The y-coordinate of the location at which to play the sound.
-   * @param soundName The name of the sound to play.
-   * @param loop      Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name at the specified location and updates the volume
+  /// and pan in relation to the listener location.
+  ///
+  /// @param x         The x-coordinate of the location at which to play the sound.
+  /// @param y         The y-coordinate of the location at which to play the sound.
+  /// @param soundName The name of the sound to play.
+  /// @param loop      Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(
     final String soundName, final double x, final double y, boolean loop) {
     return playSound(Resources.sounds().get(soundName), new Point2D.Double(x, y), loop);
   }
 
-  /**
-   * Plays the specified sound with the volume configured in the SOUND config with a center pan.
-   *
-   * @param sound The sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound with the volume configured in the SOUND config with a center pan.
+  ///
+  /// @param sound The sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound) {
     return playSound(sound, false);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name with the volume configured in the SOUND config
-   * with a center pan.
-   *
-   * @param soundName The name of the sound to play.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name with the volume configured in the SOUND config
+  /// with a center pan.
+  ///
+  /// @param soundName The name of the sound to play.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName) {
     return playSound(Resources.sounds().get(soundName), false);
   }
 
-  /**
-   * Plays the specified sound with the volume configured in the SOUND config with a center pan.
-   *
-   * @param sound The sound to play.
-   * @param loop  Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound with the volume configured in the SOUND config with a center pan.
+  ///
+  /// @param sound The sound to play.
+  /// @param loop  Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, boolean loop) {
     return playSound(sound, () -> null, loop, getMaxDistance(), 1f);
   }
 
-  /**
-   * Plays the specified sound with the volume configured in the SOUND config with a center pan.
-   *
-   * @param sound The sound to play.
-   * @param loop  Determines whether this playback should be looped or not.
-   * @param range the range in pixels for which this sound can be heard
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound with the volume configured in the SOUND config with a center pan.
+  ///
+  /// @param sound The sound to play.
+  /// @param loop  Determines whether this playback should be looped or not.
+  /// @param range the range in pixels for which this sound can be heard
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, boolean loop, int range) {
     return playSound(sound, () -> null, loop, range, 1f);
   }
 
-  /**
-   * Plays the specified sound with the volume configured in the SOUND config with a center pan.
-   *
-   * @param sound  The sound to play.
-   * @param loop   Determines whether this playback should be looped or not.
-   * @param range  the range in pixels for which this sound can be heard
-   * @param volume The volume modifier for the sound playback instance.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays the specified sound with the volume configured in the SOUND config with a center pan.
+  ///
+  /// @param sound  The sound to play.
+  /// @param loop   Determines whether this playback should be looped or not.
+  /// @param range  the range in pixels for which this sound can be heard
+  /// @param volume The volume modifier for the sound playback instance.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final Sound sound, boolean loop, int range, float volume) {
     return playSound(sound, () -> null, loop, range, volume);
   }
 
-  /**
-   * Plays a {@code Sound} with the specified name with the volume configured in the SOUND config
-   * with a center pan.
-   *
-   * @param soundName The name of the sound to play.
-   * @param loop      Determines whether this playback should be looped or not.
-   * @return An {@link SFXPlayback} instance that allows to further process and control the played
-   * sound.
-   */
+  /// Plays a `Sound` with the specified name with the volume configured in the SOUND config
+  /// with a center pan.
+  ///
+  /// @param soundName The name of the sound to play.
+  /// @param loop      Determines whether this playback should be looped or not.
+  /// @return An [SFXPlayback] instance that allows to further process and control the played
+  /// sound.
   public SFXPlayback playSound(final String soundName, boolean loop) {
     return playSound(Resources.sounds().get(soundName), loop);
   }
 
-  /**
-   * Sets the default maximum distance from the listener at which a sound source can still be heard.
-   * If the distance between the sound source and the listener is greater than the specified value,
-   * the volume is set to 0.
-   *
-   * @param radius The maximum distance at which sounds can still be heard.
-   */
+  /// Sets the default maximum distance from the listener at which a sound source can still be heard.
+  /// If the distance between the sound source and the listener is greater than the specified value,
+  /// the volume is set to 0.
+  ///
+  /// @param radius The maximum distance at which sounds can still be heard.
   public void setMaxDistance(final int radius) {
     maxDist = radius;
   }
 
-  /**
-   * Stops the playback of the current background music.
-   */
+  /// Stops the playback of the current background music.
   public synchronized void stopMusic() {
     for (MusicPlayback track : allMusic) {
       track.cancel();
     }
   }
 
-  /**
-   * Creates an {@code SFXPlayback} object that can be configured prior to starting. Also allows for
-   * a custom source supplier.
-   *
-   * <p>
-   * Unlike the {@code playSound} methods, the {@code SFXPlayback} objects returned by this method
-   * must be started using the {@link SoundPlayback#start()} method. However, necessary resources
-   * are acquired <em>immediately</em> upon calling this method, and will remain in use until the
-   * playback is either cancelled or finalized.
-   *
-   * @param sound    The sound to play
-   * @param supplier A function to get the sound's current source location (the sound is statically
-   *                 positioned if the location is {@code null})
-   * @param loop     Whether to loop the sound
-   * @param range    the range in pixels for which this sound can be heard
-   * @param volume   The volume modifier for the sound playback instance.
-   * @return An {@code SFXPlayback} object that can be configured prior to starting, but will need
-   * to be manually started.
-   */
+  /// Creates an `SFXPlayback` object that can be configured prior to starting. Also allows for
+  /// a custom source supplier.
+  ///
+  /// Unlike the `playSound` methods, the `SFXPlayback` objects returned by this method
+  /// must be started using the [SoundPlayback#start()] method. However, necessary resources
+  /// are acquired *immediately* upon calling this method, and will remain in use until the
+  /// playback is either cancelled or finalized.
+  ///
+  /// @param sound    The sound to play
+  /// @param supplier A function to get the sound's current source location (the sound is statically
+  /// positioned if the location is `null`)
+  /// @param loop     Whether to loop the sound
+  /// @param range    the range in pixels for which this sound can be heard
+  /// @param volume   The volume modifier for the sound playback instance.
+  /// @return An `SFXPlayback` object that can be configured prior to starting, but will need
+  /// to be manually started.
   public SFXPlayback createSound(Sound sound, Supplier<Point2D> supplier, boolean loop, int range,
     float volume) {
     try {
@@ -562,16 +484,13 @@ public final class SoundEngine implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * This method allows to set the callback that is used by the SoundEngine to determine where the
-   * listener location is.
-   *
-   * <p>
-   * If not explicitly set, the SoundEngine uses the camera focus (center of the screen) as listener
-   * location.
-   *
-   * @param callback The callback that determines the location of the sound listener.
-   */
+  /// This method allows to set the callback that is used by the SoundEngine to determine where the
+  /// listener location is.
+  ///
+  /// If not explicitly set, the SoundEngine uses the camera focus (center of the screen) as listener
+  /// location.
+  ///
+  /// @param callback The callback that determines the location of the sound listener.
   public void setListenerLocationCallback(UnaryOperator<Point2D> callback) {
     listenerLocationCallback = callback;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundEvent.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundEvent.java
@@ -3,12 +3,10 @@ package de.gurkenlabs.litiengine.sound;
 import java.io.Serial;
 import java.util.EventObject;
 
-/**
- * This implementation is used for all events that need to pass a {@code Sound} object to their listeners.
- *
- * @see SoundPlayback#cancel()
- * @see SoundPlayback#finish()
- */
+/// This implementation is used for all events that need to pass a `Sound` object to their listeners.
+///
+/// @see SoundPlayback#cancel()
+/// @see SoundPlayback#finish()
 public class SoundEvent extends EventObject {
   @Serial private static final long serialVersionUID = -2070316328855430839L;
 
@@ -19,11 +17,9 @@ public class SoundEvent extends EventObject {
     this.sound = sound;
   }
 
-  /**
-   * Gets the related {@code Sound} instance.
-   *
-   * @return The sound object.
-   */
+  /// Gets the related `Sound` instance.
+  ///
+  /// @return The sound object.
   public Sound getSound() {
     return this.sound;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundPlayback.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundPlayback.java
@@ -17,12 +17,10 @@ import javax.sound.sampled.FloatControl;
 import javax.sound.sampled.LineUnavailableException;
 import javax.sound.sampled.SourceDataLine;
 
-/**
- * The {@code SoundPlayback} class is a wrapper {@code SourceDataLine} on which a {@code Sound}
- * playback can be carried out.
- *
- * @see #play(Sound)
- */
+/// The `SoundPlayback` class is a wrapper `SourceDataLine` on which a `Sound`
+/// playback can be carried out.
+///
+/// @see #play(Sound)
 public abstract class SoundPlayback implements Runnable {
 
   protected final SourceDataLine line;
@@ -49,11 +47,9 @@ public abstract class SoundPlayback implements Runnable {
     this.masterVolume = this.createVolumeControl();
   }
 
-  /**
-   * Starts playing the audio.
-   *
-   * @throws IllegalStateException if the audio has already been started
-   */
+  /// Starts playing the audio.
+  ///
+  /// @throws IllegalStateException if the audio has already been started
   public synchronized void start() {
     if (this.started) {
       throw new IllegalStateException("already started");
@@ -62,29 +58,23 @@ public abstract class SoundPlayback implements Runnable {
     this.started = true;
   }
 
-  /**
-   * Adds a {@code SoundPlaybackListener} to this instance.
-   *
-   * @param listener The {@code SoundPlaybackListener} to be added.
-   */
+  /// Adds a `SoundPlaybackListener` to this instance.
+  ///
+  /// @param listener The `SoundPlaybackListener` to be added.
   public void addSoundPlaybackListener(SoundPlaybackListener listener) {
     this.listeners.add(listener);
   }
 
-  /**
-   * Removes a {@code SoundPlaybackListener} from this instance.
-   *
-   * @param listener The {@code SoundPlaybackListener} to be removed.
-   */
+  /// Removes a `SoundPlaybackListener` from this instance.
+  ///
+  /// @param listener The `SoundPlaybackListener` to be removed.
   public void removeSoundPlaybackListener(SoundPlaybackListener listener) {
     this.listeners.remove(listener);
   }
 
-  /**
-   * Sets the paused state of this playback to the provided value.
-   *
-   * @param paused Whether to pause or resume this playback
-   */
+  /// Sets the paused state of this playback to the provided value.
+  ///
+  /// @param paused Whether to pause or resume this playback
   public void setPaused(boolean paused) {
     if (paused) {
       this.pausePlayback();
@@ -93,71 +83,57 @@ public abstract class SoundPlayback implements Runnable {
     }
   }
 
-  /**
-   * Pauses this playback. If this playback is already paused, this call has no effect.
-   */
+  /// Pauses this playback. If this playback is already paused, this call has no effect.
   public void pausePlayback() {
     if (this.line.isOpen()) {
       this.line.stop();
     }
   }
 
-  /**
-   * Resumes this playback. If this playback is already playing, this call has no effect.
-   */
+  /// Resumes this playback. If this playback is already playing, this call has no effect.
   public void resumePlayback() {
     if (this.line.isOpen()) {
       this.line.start();
     }
   }
 
-  /**
-   * Fades this playback's volume to 0 over the given duration.
-   *
-   * @param duration the fade duration in milliseconds.
-   */
+  /// Fades this playback's volume to 0 over the given duration.
+  ///
+  /// @param duration the fade duration in milliseconds.
   public void fade(int duration) {
     this.fade(duration, 0f, TweenFunction.LINEAR);
   }
 
-  /**
-   * Fades this playback's volume to the target value over the given duration using the given
-   * {@code TweenFunction}.
-   *
-   * @param duration   the fade duration in milliseconds.
-   * @param target     the target volume at the end of the fade
-   * @param easingType the TweenFunction determining the falloff curve of this fade.
-   */
+  /// Fades this playback's volume to the target value over the given duration using the given
+  /// `TweenFunction`.
+  ///
+  /// @param duration   the fade duration in milliseconds.
+  /// @param target     the target volume at the end of the fade
+  /// @param easingType the TweenFunction determining the falloff curve of this fade.
   public void fade(int duration, float target, TweenFunction easingType) {
     for (VolumeControl v : this.getVolumeControls()) {
       Game.tweens().start(v, TweenType.VOLUME, duration).target(target).ease(easingType);
     }
   }
 
-  /**
-   * Determines if this playback is paused.
-   *
-   * @return Whether this playback is paused
-   */
+  /// Determines if this playback is paused.
+  ///
+  /// @return Whether this playback is paused
   public boolean isPaused() {
     return !this.line.isActive();
   }
 
-  /**
-   * Determines if this playback has sound to play. If it is paused but still in the middle of
-   * playback, it will return {@code true}, but it will return {@code false} if it has finished or
-   * it has been cancelled.
-   *
-   * @return Whether this playback has sound to play
-   */
+  /// Determines if this playback has sound to play. If it is paused but still in the middle of
+  /// playback, it will return `true`, but it will return `false` if it has finished or
+  /// it has been cancelled.
+  ///
+  /// @return Whether this playback has sound to play
   public boolean isPlaying() {
     return this.line.isOpen();
   }
 
-  /**
-   * Attempts to cancel the playback of this audio. If the playback was successfully cancelled, it
-   * will notify listeners.
-   */
+  /// Attempts to cancel the playback of this audio. If the playback was successfully cancelled, it
+  /// will notify listeners.
   public synchronized void cancel() {
     if (!this.started) {
       throw new IllegalStateException("not started");
@@ -173,12 +149,10 @@ public abstract class SoundPlayback implements Runnable {
     }
   }
 
-  /**
-   * Gets the current volume of this playback, considering all {@code VolumeControl} objects created
-   * for it.
-   *
-   * @return The current volume.
-   */
+  /// Gets the current volume of this playback, considering all `VolumeControl` objects created
+  /// for it.
+  ///
+  /// @return The current volume.
   public float getMasterVolume() {
     if (this.muteControl.getValue()) {
       return 0f;
@@ -186,21 +160,17 @@ public abstract class SoundPlayback implements Runnable {
     return (float) Math.pow(10.0, this.gainControl.getValue() / 20.0);
   }
 
-  /**
-   * Gets the current master volume of this playback. This will be approximately equal to the value
-   * set by a previous call to {@code setVolume}, though rounding errors may occur.
-   *
-   * @return The settable volume.
-   */
+  /// Gets the current master volume of this playback. This will be approximately equal to the value
+  /// set by a previous call to `setVolume`, though rounding errors may occur.
+  ///
+  /// @return The settable volume.
   public float getVolume() {
     return this.masterVolume.get();
   }
 
-  /**
-   * Sets the master volume of this playback.
-   *
-   * @param volume The new volume.
-   */
+  /// Sets the master volume of this playback.
+  ///
+  /// @param volume The new volume.
   public void setVolume(float volume) {
     this.masterVolume.set(volume);
   }
@@ -219,12 +189,10 @@ public abstract class SoundPlayback implements Runnable {
     SoundEngine.EXECUTOR.submit(this);
   }
 
-  /**
-   * Plays a sound to this object's data line.
-   *
-   * @param sound The sound to play
-   * @return Whether the sound was cancelled while playing
-   */
+  /// Plays a sound to this object's data line.
+  ///
+  /// @param sound The sound to play
+  /// @return Whether the sound was cancelled while playing
   boolean play(Sound sound) throws LineUnavailableException {
     this.line.open();
     this.line.start();
@@ -242,10 +210,8 @@ public abstract class SoundPlayback implements Runnable {
     return this.cancelled;
   }
 
-  /**
-   * Finishes the playback. If this playback was not cancelled in the process, it will notify
-   * listeners.
-   */
+  /// Finishes the playback. If this playback was not cancelled in the process, it will notify
+  /// listeners.
   void finish() {
     this.line.drain();
     synchronized (this) {
@@ -276,12 +242,10 @@ public abstract class SoundPlayback implements Runnable {
   }
 
 
-  /**
-   * An object for controlling the volume of a {@code SoundPlayback}. Each distinct instance
-   * represents an independent factor contributing to its volume.
-   *
-   * @see SoundPlayback#createVolumeControl()
-   */
+  /// An object for controlling the volume of a `SoundPlayback`. Each distinct instance
+  /// represents an independent factor contributing to its volume.
+  ///
+  /// @see SoundPlayback#createVolumeControl()
   public class VolumeControl implements Tweenable, AutoCloseable {
 
     private volatile float value = 1f;
@@ -289,20 +253,16 @@ public abstract class SoundPlayback implements Runnable {
     private VolumeControl() {
     }
 
-    /**
-     * Gets the value of this volume control.
-     *
-     * @return The value of this control.
-     */
+    /// Gets the value of this volume control.
+    ///
+    /// @return The value of this control.
     public float get() {
       return this.value;
     }
 
-    /**
-     * Sets the value of this volume control.
-     *
-     * @param value The value to be set.
-     */
+    /// Sets the value of this volume control.
+    ///
+    /// @param value The value to be set.
     public void set(float value) {
       if (value < 0f) {
         throw new IllegalArgumentException("negative volume");

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundPlaybackListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/SoundPlaybackListener.java
@@ -2,25 +2,19 @@ package de.gurkenlabs.litiengine.sound;
 
 import java.util.EventListener;
 
-/**
- * This event listener implementation provides callbacks for when a {@link SoundPlayback} instance gets cancelled or
- * finished.
- */
+/// This event listener implementation provides callbacks for when a [SoundPlayback] instance gets cancelled or
+/// finished.
 public interface SoundPlaybackListener extends EventListener {
 
-  /**
-   * This method gets called when a {@code SoundPlayback} is cancelled.
-   *
-   * @param event
-   *          a {@link SoundEvent} object describing the event source and the related {@link Sound}.
-   */
+  /// This method gets called when a `SoundPlayback` is cancelled.
+  ///
+  /// @param event
+  /// a [SoundEvent] object describing the event source and the related [Sound].
   default void cancelled(SoundEvent event) {}
 
-  /**
-   * This method gets called when a {@code SoundPlayback} is finished.
-   *
-   * @param event
-   *          a {@link SoundEvent} object describing the event source and the related {@link Sound}.
-   */
+  /// This method gets called when a `SoundPlayback` is finished.
+  ///
+  /// @param event
+  /// a [SoundEvent] object describing the event source and the related [Sound].
   default void finished(SoundEvent event) {}
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/Track.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/Track.java
@@ -2,14 +2,11 @@ package de.gurkenlabs.litiengine.sound;
 
 import javax.sound.sampled.AudioFormat;
 
-/**
- * The {@code Track} class defines a sequence in which music {@code Sounds} should be played back by the engine.
- *
- * <p>
- * This is useful to further define how music is played in the engine.
- *
- * @see SoundEngine#playMusic(Track)
- */
+/// The `Track` class defines a sequence in which music `Sounds` should be played back by the engine.
+///
+/// This is useful to further define how music is played in the engine.
+///
+/// @see SoundEngine#playMusic(Track)
 public interface Track extends Iterable<Sound> {
   AudioFormat getFormat();
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/AudioFileReader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/AudioFileReader.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-/** Common stream and resource handling for LITIENGINE Java Sound file readers. */
+/// Common stream and resource handling for LITIENGINE Java Sound file readers.
 public abstract class AudioFileReader extends javax.sound.sampled.spi.AudioFileReader {
   private final int markLimit;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/BitReader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/BitReader.java
@@ -56,20 +56,16 @@ public class BitReader {
     return getNextBit() == 1;
   }
 
-  /**
-   * Returns the number of bits read since the start position.
-   *
-   * @return bits consumed since construction (or last reset)
-   */
+  /// Returns the number of bits read since the start position.
+  ///
+  /// @return bits consumed since construction (or last reset)
   public int getPosition() {
     return this.current - this.startByteIndex * BITS_PER_BYTE;
   }
 
-  /**
-   * Skips the specified number of bits without returning them.
-   *
-   * @param bits number of bits to skip
-   */
+  /// Skips the specified number of bits without returning them.
+  ///
+  /// @param bits number of bits to skip
   public void skip(int bits) {
     setPosition(getPosition() + bits);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/HuffmanCode.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/HuffmanCode.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** MPEG-1 Layer III Huffman codebooks from ISO/IEC 11172-3, Annex B. */
+/// MPEG-1 Layer III Huffman codebooks from ISO/IEC 11172-3, Annex B.
 final class HuffmanCode {
   private static final int MAX_DEPTH = 32;
   private static final int TREE_JUMP = 250;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Imdct.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Imdct.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.sound.spi.mp3;
 
-/** Hybrid synthesis transform used by MPEG-1 Layer III. */
+/// Hybrid synthesis transform used by MPEG-1 Layer III.
 final class Imdct {
   private Imdct() {}
 
@@ -48,7 +48,7 @@ final class Imdct {
     return output;
   }
 
-  /** Kept for source compatibility; transforms are already windowed. */
+  /// Kept for source compatibility; transforms are already windowed.
   static float[] applyWindow(float[] data, int blockType) {
     return data.clone();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Mp3FileReader.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Mp3FileReader.java
@@ -11,15 +11,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-/** Reads MPEG-1 Layer III stream metadata for the Java Sound service provider. */
+/// Reads MPEG-1 Layer III stream metadata for the Java Sound service provider.
 public final class Mp3FileReader extends AudioFileReader {
-  /** The Java Sound file type for MP3 resources. */
+  /// The Java Sound file type for MP3 resources.
   public static final AudioFileFormat.Type MP3 = new AudioFileFormat.Type("MP3", "mp3");
 
   private static final int HEADER_LENGTH = 10;
   private static final int MAX_FRAME_SEARCH = 64 * 1024;
 
-  /** Creates an MP3 file reader. */
+  /// Creates an MP3 file reader.
   public Mp3FileReader() {
     super(16 * 1024 * 1024);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Mp3FormatConversionProvider.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Mp3FormatConversionProvider.java
@@ -7,7 +7,7 @@ import javax.sound.sampled.spi.FormatConversionProvider;
 
 import static javax.sound.sampled.AudioFormat.Encoding.PCM_SIGNED;
 
-/** Converts LITIENGINE MPEG-1 Layer III streams to signed 16-bit PCM. */
+/// Converts LITIENGINE MPEG-1 Layer III streams to signed 16-bit PCM.
 public final class Mp3FormatConversionProvider extends FormatConversionProvider {
 
   @Override

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Mpeg.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/Mpeg.java
@@ -132,15 +132,13 @@ final class Mpeg {
     return 10 + dataLength + (hasFooter ? 10 : 0);
   }
 
-  /**
-   * <p/>
-   * Mono   : 136 bits (= 17 bytes)<br>
-   * Stereo : 256 bits (= 32 bytes)
-   * <p/>
-   *
-   * @param channels The number of channels
-   * @return The length of the side information
-   */
+  /// Mono   : 136 bits (= 17 bytes)
+  ///
+  /// Stereo : 256 bits (= 32 bytes)
+  ///
+  ///
+  /// @param channels The number of channels
+  /// @return The length of the side information
   static int getSideInfoLength(int channels) {
     return channels == 1 ? 17 : 32;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/MpegFrame.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/MpegFrame.java
@@ -6,15 +6,13 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.UnsupportedAudioFileException;
 import java.nio.ByteBuffer;
 
-/**
- * An MPEG frame is organized like this:
- *
- * <pre>
- * +--------+------------------+-----------+----------------+
- * | HEADER | SIDE INFORMATION | MAIN DATA | ANCILLARY DATA |
- * +--------+------------------+-----------+----------------+
- * </pre>
- */
+/// An MPEG frame is organized like this:
+///
+/// ```
+/// +--------+------------------+-----------+----------------+
+/// | HEADER | SIDE INFORMATION | MAIN DATA | ANCILLARY DATA |
+/// +--------+------------------+-----------+----------------+
+/// ```
 class MpegFrame {
 
   private static final int HEADER_SIZE_IN_BYTES = 4;
@@ -44,9 +42,7 @@ class MpegFrame {
     this.mainData = new MainData(byteBuffer, frameOffset, this);
   }
 
-  /**
-   * Constructor that accepts header+side info and main data separately.
-   */
+  /// Constructor that accepts header+side info and main data separately.
   public MpegFrame(ByteBuffer headerAndSideInfo, int frameOffset, byte[] mainData) throws UnsupportedAudioFileException {
     this.header = new Header(headerAndSideInfo, frameOffset);
     if (this.isProtected() && !checkCrc(headerAndSideInfo, frameOffset, this.getChannels())) {
@@ -164,23 +160,21 @@ class MpegFrame {
     return crc;
   }
 
-  /**
-   * The frame header is organized like this:
-   *
-   * <pre>
-   * |     1st byte   |     2nd byte         |      3rd byte         |       4th byte          |
-   * +----------------+----------------------+-----------------------+-------------------------+
-   * | 1 1 1 1 1 1 1 1 1 1 1 | 0 0 | 0 0 | 0 | 0 0 0 0 | 0 0 | 0 | 0 | 0 0 | 0 0 | 0 | 0 | 0 0 |
-   * +-----------------------+-----+-----+---+---------+-----+---+---+-----+-----+---+---+-----+
-   *  \__________ __________/ \_ _/ \_ _/ \ / \___ ___/ \_ _/ \ / \ / \_ _/ \_ _/ \ / \ / \_ _/
-   *             V              V     V    V      V       V    V   V    V     V    V   V    V
-   *         syncword          ID   layer  | bitrate_index|    | private|     |    | org/cop|
-   *                                error_protection      | padding   mode    | copyright emphasis
-   *                                             sampling_frequency     mode_extension
-   * </pre>
-   * <p>
-   * If the protection bit is zero, the header is followed by a two byte CRC.
-   */
+  /// The frame header is organized like this:
+  ///
+  /// ```
+  /// |     1st byte   |     2nd byte         |      3rd byte         |       4th byte          |
+  /// +----------------+----------------------+-----------------------+-------------------------+
+  /// | 1 1 1 1 1 1 1 1 1 1 1 | 0 0 | 0 0 | 0 | 0 0 0 0 | 0 0 | 0 | 0 | 0 0 | 0 0 | 0 | 0 | 0 0 |
+  /// +-----------------------+-----+-----+---+---------+-----+---+---+-----+-----+---+---+-----+
+  ///  \__________ __________/ \_ _/ \_ _/ \ / \___ ___/ \_ _/ \ / \ / \_ _/ \_ _/ \ / \ / \_ _/
+  ///             V              V     V    V      V       V    V   V    V     V    V   V    V
+  ///         syncword          ID   layer  | bitrate_index|    | private|     |    | org/cop|
+  ///                                error_protection      | padding   mode    | copyright emphasis
+  ///                                             sampling_frequency     mode_extension
+  /// ```
+  ///
+  /// If the protection bit is zero, the header is followed by a two byte CRC.
   static class Header {
     private static final int FRAME_SYNC = 0b11111111111;
 
@@ -225,39 +219,33 @@ class MpegFrame {
     }
   }
 
-  /**
-   * The side information is organized like this:
-   * <pre>
-   *   +-----------------+--------------+-------+-------------------------+-------------------------+
-   *   | MAIN_DATA_BEGIN | PRIVATE_BITS | SCFSI | SIDE_INFO_FOR_GRANULE_1 | SIDE_INFO_FOR_GRANULE_2 |
-   *   +-----------------+--------------+-------+-------------------------+-------------------------+
-   * </pre>
-   */
+  /// The side information is organized like this:
+  /// ```
+  ///   +-----------------+--------------+-------+-------------------------+-------------------------+
+  ///   | MAIN_DATA_BEGIN | PRIVATE_BITS | SCFSI | SIDE_INFO_FOR_GRANULE_1 | SIDE_INFO_FOR_GRANULE_2 |
+  ///   +-----------------+--------------+-------+-------------------------+-------------------------+
+  /// ```
   static class SideInfo {
-    /**
-     * A pointer that points to the beginning of the main data. The variable has
-     * nine bits and specifies the location of the main data as a negative offset
-     * (jumping backwards) in bytes from the first byte of the audio sync word.
-     * The number of bytes of the header and side information are not taken into
-     * account while calculating the location of the main data. This is called bit
-     * reservoir technique and it allows the encoder to use some extra bits while
-     * encoding a difficult frame. Since it is nine bits long, it can point upto
-     * 29 −1 = 511 bytes in front of the header. If the value of main_data_begin is
-     * zero, then the main data follows immediately the side information.
-     */
+    /// A pointer that points to the beginning of the main data. The variable has
+    /// nine bits and specifies the location of the main data as a negative offset
+    /// (jumping backwards) in bytes from the first byte of the audio sync word.
+    /// The number of bytes of the header and side information are not taken into
+    /// account while calculating the location of the main data. This is called bit
+    /// reservoir technique and it allows the encoder to use some extra bits while
+    /// encoding a difficult frame. Since it is nine bits long, it can point upto
+    /// 29 −1 = 511 bytes in front of the header. If the value of main_data_begin is
+    /// zero, then the main data follows immediately the side information.
     final int mainDataBegin;
 
     final int privateBits;
 
     final Channel[] channels;
 
-    /**
-     * Reads the side info from the bytebuffer.
-     * @param byteBuffer The buffer to read the info from.
-     * @param frameOffset The offset of the frame within the buffer.
-     * @param isProtected A flag indicating whether the MPEG frame is protected.
-     * @param channels The number of channels of the MPEG frame.
-     */
+    /// Reads the side info from the bytebuffer.
+    /// @param byteBuffer The buffer to read the info from.
+    /// @param frameOffset The offset of the frame within the buffer.
+    /// @param isProtected A flag indicating whether the MPEG frame is protected.
+    /// @param channels The number of channels of the MPEG frame.
     SideInfo(ByteBuffer byteBuffer, int frameOffset, boolean isProtected, int channels)
       throws UnsupportedAudioFileException {
       var payloadOffset = HEADER_SIZE_IN_BYTES + (isProtected ? CRC_SIZE_IN_BYTES : 0);
@@ -357,16 +345,14 @@ class MpegFrame {
 
     static class Channel {
 
-      /**
-       * Scale factor select information.
-       * <p/>
-       * Layer III contains two granules and the encoder can specify separately for
-       * each group of scale factor bands whether the second granule will reuse the
-       * scale factor information of the first granule or not. If the value of scfsi is
-       * true, then sharing of scale factors is allowed between the granules.
-       * <p/>
-       * Irrelevant for MPEG-2 which only has one granule per frame.
-       */
+      /// Scale factor select information.
+      ///
+      /// Layer III contains two granules and the encoder can specify separately for
+      /// each group of scale factor bands whether the second granule will reuse the
+      /// scale factor information of the first granule or not. If the value of scfsi is
+      /// true, then sharing of scale factors is allowed between the granules.
+      ///
+      /// Irrelevant for MPEG-2 which only has one granule per frame.
       final boolean[] scfsi;
 
       final Granule[] granules;
@@ -414,21 +400,19 @@ class MpegFrame {
     }
   }
 
-  /**
-   * The main data does not follow the side information in the bitstream.
-   * The main data ends at a location in the bitstream preceding the frame header of the frame at an offset
-   * given by the value of main_data_start.
-   * <p/>
-   * <p>
-   * The main data is organized like this:
-   * <pre>
-   *   +---------------+---------------------------+----------------+
-   *   | SCALE FACTORS | HUFFMAN CODED RAW SAMPLES | ANCILLARY INFO |
-   *   +---------------+---------------------------+----------------+
-   * </pre>
-   *
-   * @return The decoded samples.
-   */
+  /// The main data does not follow the side information in the bitstream.
+  /// The main data ends at a location in the bitstream preceding the frame header of the frame at an offset
+  /// given by the value of main_data_start.
+  ///
+  ///
+  /// The main data is organized like this:
+  /// ```
+  ///   +---------------+---------------------------+----------------+
+  ///   | SCALE FACTORS | HUFFMAN CODED RAW SAMPLES | ANCILLARY INFO |
+  ///   +---------------+---------------------------+----------------+
+  /// ```
+  ///
+  /// @return The decoded samples.
   static class MainData {
     private final float[][][] samples; // [channel][granule][576]
     private final MpegFrame frame;
@@ -536,9 +520,7 @@ class MpegFrame {
     StereoProcessing.process(this.frame, this.scaleFactors, this.samples);
   }
 
-  /**
-   * Constructor that accepts main data directly (for bit reservoir support).
-   */
+  /// Constructor that accepts main data directly (for bit reservoir support).
   MainData(byte[] mainData, MpegFrame frame) {
     this.frame = frame;
     this.samples = new float[frame.getChannels()][2][576];
@@ -693,10 +675,8 @@ class MpegFrame {
       return this.samples;
     }
 
-    /**
-     * Dequantize the Huffman-decoded samples using scale factors and global gain.
-     * Formula: xr[i] = sign(is[i]) * |is[i]|^(4/3) * 2^(0.25 * (global_gain - 210)) * 2^(-scalefactor/4)
-     */
+    /// Dequantize the Huffman-decoded samples using scale factors and global gain.
+    /// Formula: xr[i] = sign(is[i]) * |is[i]|^(4/3) * 2^(0.25 * (global_gain - 210)) * 2^(-scalefactor/4)
     private void dequantize(int gr, int ch) {
       var sideInfo = this.frame.getSideInfo();
       var granule = sideInfo.channels[ch].granules[gr];

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/StereoProcessing.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/StereoProcessing.java
@@ -1,6 +1,6 @@
 package de.gurkenlabs.litiengine.sound.spi.mp3;
 
-/** Reconstructs MPEG-1 Layer III joint-stereo channels before spectral reordering. */
+/// Reconstructs MPEG-1 Layer III joint-stereo channels before spectral reordering.
 final class StereoProcessing {
   private static final float SQRT_HALF = 0.707106781f;
   private static final float[] INTENSITY_RATIOS = {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/SynthesisFilter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/sound/spi/mp3/SynthesisFilter.java
@@ -1,10 +1,8 @@
 package de.gurkenlabs.litiengine.sound.spi.mp3;
 
-/**
- * A class for the synthesis filter bank.
- * This class performs the polyphase synthesis filter required for MP3 decoding.
- * It converts 32 subband samples into 32 PCM samples.
- */
+/// A class for the synthesis filter bank.
+/// This class performs the polyphase synthesis filter required for MP3 decoding.
+/// It converts 32 subband samples into 32 PCM samples.
 final class SynthesisFilter {
     private final float[] v1;
     private final float[] v2;
@@ -54,9 +52,7 @@ final class SynthesisFilter {
         System.arraycopy(s, 0, samples, 0, 32);
     }
 
-    /**
-     * Compute new values via a fast cosine transform.
-     */
+    /// Compute new values via a fast cosine transform.
     private void computeNewV() {
         float newV0, newV1, newV2, newV3, newV4, newV5, newV6, newV7, newV8, newV9;
         float newV10, newV11, newV12, newV13, newV14, newV15, newV16, newV17, newV18, newV19;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/Tween.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/Tween.java
@@ -5,10 +5,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * A Tween is an interpolation between start values and target values over a given time period. It modifies the start values by applying an easing
- * function ({@code TweenEquation}) each tick.
- */
+/// A Tween is an interpolation between start values and target values over a given time period. It modifies the start values by applying an easing
+/// function (`TweenEquation`) each tick.
 public class Tween {
   private int duration;
   private TweenEquation equation;
@@ -22,13 +20,11 @@ public class Tween {
   private boolean reversed;
   private final Collection<TweenListener> listeners = ConcurrentHashMap.newKeySet();
 
-  /**
-   * Instantiates a new tween.
-   *
-   * @param target   the {@code Tweenable} target object
-   * @param type     the {@code TweenType} determining which values of the target object will be modified.
-   * @param duration the duration of the Tween in ticks.
-   */
+  /// Instantiates a new tween.
+  ///
+  /// @param target   the `Tweenable` target object
+  /// @param type     the `TweenType` determining which values of the target object will be modified.
+  /// @param duration the duration of the Tween in ticks.
   public Tween(final Tweenable target, final TweenType type, final int duration) {
     this.target = target;
     this.type = type;
@@ -37,11 +33,9 @@ public class Tween {
     this.targetValues = new float[this.startValues.length];
   }
 
-  /**
-   * Starts the Tween by setting its start time to the current game time in ticks.
-   *
-   * @return the Tween instance
-   */
+  /// Starts the Tween by setting its start time to the current game time in ticks.
+  ///
+  /// @return the Tween instance
   public Tween start() {
     this.started = Game.time().now();
     this.stopped = false;
@@ -51,143 +45,113 @@ public class Tween {
     return this;
   }
 
-  /**
-   * Checks if the Tween is currently running.
-   *
-   * @return true if the Tween is running, false otherwise.
-   */
+  /// Checks if the Tween is currently running.
+  ///
+  /// @return true if the Tween is running, false otherwise.
   public boolean isRunning() {
     return !stopped && Game.time().since(started) < duration;
   }
 
-  /**
-   * Sets a custom easing function for this Tween.
-   *
-   * @param easeEquation the {@code TweenEquation} applied to the tween values.
-   * @return the Tween instance.
-   */
+  /// Sets a custom easing function for this Tween.
+  ///
+  /// @param easeEquation the `TweenEquation` applied to the tween values.
+  /// @return the Tween instance.
   public Tween ease(final TweenEquation easeEquation) {
     this.equation = easeEquation;
     return this;
   }
 
-  /**
-   * Sets a predefined easing function for this Tween.
-   *
-   * @param easingFunction the {@code TweenFunction} applied to the tween values.
-   * @return the Tween instance.
-   */
+  /// Sets a predefined easing function for this Tween.
+  ///
+  /// @param easingFunction the `TweenFunction` applied to the tween values.
+  /// @return the Tween instance.
   public Tween ease(final TweenFunction easingFunction) {
     this.equation = easingFunction.getEquation();
     return this;
   }
 
-  /**
-   * Gets the duration of the Tween.
-   *
-   * @return the duration of the Tween in ticks
-   */
+  /// Gets the duration of the Tween.
+  ///
+  /// @return the duration of the Tween in ticks
   public int getDuration() {
     return this.duration;
   }
 
-  /**
-   * Gets the tween equation that modifies the start values each tick.
-   *
-   * @return the TweenEquation
-   */
+  /// Gets the tween equation that modifies the start values each tick.
+  ///
+  /// @return the TweenEquation
   public TweenEquation getEquation() {
     return this.equation;
   }
 
-  /**
-   * Gets the start tick of the Tween.
-   *
-   * @return the start time in ticks
-   */
+  /// Gets the start tick of the Tween.
+  ///
+  /// @return the start time in ticks
   public long getStartTime() {
     return this.started;
   }
 
-  /**
-   * Gets the start values.
-   *
-   * @return the start values
-   */
+  /// Gets the start values.
+  ///
+  /// @return the start values
   public float[] getStartValues() {
     return this.startValues;
   }
 
-  /**
-   * Gets the {@code Tweenable} target object.
-   *
-   * @return the target
-   */
+  /// Gets the `Tweenable` target object.
+  ///
+  /// @return the target
   public Tweenable getTarget() {
     return this.target;
   }
 
-  /**
-   * Gets the target values.
-   *
-   * @return the target values
-   */
+  /// Gets the target values.
+  ///
+  /// @return the target values
   public float[] getTargetValues() {
     return this.targetValues;
   }
 
-  /**
-   * Gets the tween type determining which values of the {@code Tweenable} object will be modified.
-   *
-   * @return the {@code TweenType} of this Tween
-   */
+  /// Gets the tween type determining which values of the `Tweenable` object will be modified.
+  ///
+  /// @return the `TweenType` of this Tween
   public TweenType getType() {
     return this.type;
   }
 
-  /**
-   * Checks if the Tween has stopped.
-   *
-   * @return true, if successful
-   */
+  /// Checks if the Tween has stopped.
+  ///
+  /// @return true, if successful
   public boolean hasStopped() {
     return this.stopped;
   }
 
-  /**
-   * Resets the Tween values to the start values.
-   *
-   * @return the Tween instance
-   */
+  /// Resets the Tween values to the start values.
+  ///
+  /// @return the Tween instance
   public Tween reset() {
     this.getTarget().setTweenValues(this.getType(), this.startValues);
     return this;
   }
 
-  /**
-   * Resumes the stopped Tween.
-   *
-   * @return the Tween instance
-   */
+  /// Resumes the stopped Tween.
+  ///
+  /// @return the Tween instance
   public Tween resume() {
     this.stopped = false;
     return this;
   }
 
-  /**
-   * Sets the Tween duration.
-   *
-   * @param duration the new duration in ticks
-   */
+  /// Sets the Tween duration.
+  ///
+  /// @param duration the new duration in ticks
   public void setDuration(final int duration) {
     this.duration = duration;
   }
 
-  /**
-   * Stops the Tween.
-   *
-   * @return the Tween instance
-   */
+  /// Stops the Tween.
+  ///
+  /// @return the Tween instance
   public Tween stop() {
     if (this.stopped) {
       return this;
@@ -199,53 +163,43 @@ public class Tween {
     return this;
   }
 
-  /**
-   * Gets the configured loop mode for this Tween.
-   *
-   * @return the {@code TweenLoop} mode.
-   */
+  /// Gets the configured loop mode for this Tween.
+  ///
+  /// @return the `TweenLoop` mode.
   public TweenLoop getLoop() {
     return this.loop;
   }
 
-  /**
-   * Sets the loop mode for this Tween. When the Tween completes its duration, it will either stop, restart from the beginning,
-   * or reverse direction depending on the configured loop mode.
-   *
-   * @param loop the desired {@code TweenLoop} mode.
-   * @return the Tween instance.
-   */
+  /// Sets the loop mode for this Tween. When the Tween completes its duration, it will either stop, restart from the beginning,
+  /// or reverse direction depending on the configured loop mode.
+  ///
+  /// @param loop the desired `TweenLoop` mode.
+  /// @return the Tween instance.
   public Tween loop(final TweenLoop loop) {
     this.loop = loop == null ? TweenLoop.NONE : loop;
     return this;
   }
 
-  /**
-   * Checks whether the Tween is currently running in its reversed direction. This is only relevant for {@link TweenLoop#PINGPONG}
-   * tweens.
-   *
-   * @return {@code true} if the Tween currently interpolates from its target values back to its start values.
-   */
+  /// Checks whether the Tween is currently running in its reversed direction. This is only relevant for [TweenLoop#PINGPONG]
+  /// tweens.
+  ///
+  /// @return `true` if the Tween currently interpolates from its target values back to its start values.
   public boolean isReversed() {
     return this.reversed;
   }
 
-  /**
-   * Toggles the playback direction of the Tween. The next interpolation cycle will swap the role of start and target values.
-   *
-   * @return the Tween instance.
-   */
+  /// Toggles the playback direction of the Tween. The next interpolation cycle will swap the role of start and target values.
+  ///
+  /// @return the Tween instance.
   Tween toggleReversed() {
     this.reversed = !this.reversed;
     return this;
   }
 
-  /**
-   * Registers a {@link TweenListener} that gets notified about the Tween's lifecycle events.
-   *
-   * @param listener the listener to add.
-   * @return the Tween instance.
-   */
+  /// Registers a [TweenListener] that gets notified about the Tween's lifecycle events.
+  ///
+  /// @param listener the listener to add.
+  /// @return the Tween instance.
   public Tween addListener(final TweenListener listener) {
     if (listener != null) {
       this.listeners.add(listener);
@@ -253,33 +207,27 @@ public class Tween {
     return this;
   }
 
-  /**
-   * Removes a previously registered {@link TweenListener}.
-   *
-   * @param listener the listener to remove.
-   * @return the Tween instance.
-   */
+  /// Removes a previously registered [TweenListener].
+  ///
+  /// @param listener the listener to remove.
+  /// @return the Tween instance.
   public Tween removeListener(final TweenListener listener) {
     this.listeners.remove(listener);
     return this;
   }
 
-  /**
-   * Notifies registered listeners that the Tween completed a duration cycle. This is invoked by the {@link TweenEngine} after each
-   * cycle, before deciding whether to stop or continue the Tween.
-   */
+  /// Notifies registered listeners that the Tween completed a duration cycle. This is invoked by the [TweenEngine] after each
+  /// cycle, before deciding whether to stop or continue the Tween.
   void notifyCompleted() {
     for (final TweenListener listener : this.listeners) {
       listener.completed(this);
     }
   }
 
-  /**
-   * Sets the target values absolutely.
-   *
-   * @param targetValues the absolute target values
-   * @return the Tween instance
-   */
+  /// Sets the target values absolutely.
+  ///
+  /// @param targetValues the absolute target values
+  /// @return the Tween instance
   public Tween target(final float... targetValues) {
     if (this.getStartValues().length == 0 || targetValues.length == 0) {
       return this;
@@ -288,12 +236,10 @@ public class Tween {
     return this;
   }
 
-  /**
-   * Sets the target values relatively to the start values.
-   *
-   * @param targetValues the relative target values with respect to the start values
-   * @return the Tween instance
-   */
+  /// Sets the target values relatively to the start values.
+  ///
+  /// @param targetValues the relative target values with respect to the start values
+  /// @return the Tween instance
   public Tween targetRelative(final float... targetValues) {
     if (this.getStartValues().length == 0 || targetValues.length == 0) {
       return this;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenEngine.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenEngine.java
@@ -6,29 +6,23 @@ import de.gurkenlabs.litiengine.IUpdateable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * The TweenEngine is the central manager for Tweens. It tracks all current Tween instances and applies their {@code TweenEquation} with every
- * {@code GameLoop} update.
- */
+/// The TweenEngine is the central manager for Tweens. It tracks all current Tween instances and applies their `TweenEquation` with every
+/// `GameLoop` update.
 public class TweenEngine implements IUpdateable, ILaunchable {
   private final Map<Tweenable, Map<TweenType, Tween>> tweens;
 
-  /**
-   * Instantiates a new {@code TweenEngine}.
-   */
+  /// Instantiates a new `TweenEngine`.
   public TweenEngine() {
     this.tweens = new ConcurrentHashMap<>();
   }
 
-  /**
-   * Starts a new Tween. If a Tween is already registered for the {@code Tweenable} with the given {@code TweenType}, it is restarted with the given
-   * duration.
-   *
-   * @param target   the {@code Tweenable} target object
-   * @param type     the {@code TweenType} determining which values of the target object will be modified.
-   * @param duration the duration of the Tween in ticks.
-   * @return the Tween instance
-   */
+  /// Starts a new Tween. If a Tween is already registered for the `Tweenable` with the given `TweenType`, it is restarted with the given
+  /// duration.
+  ///
+  /// @param target   the `Tweenable` target object
+  /// @param type     the `TweenType` determining which values of the target object will be modified.
+  /// @param duration the duration of the Tween in ticks.
+  /// @return the Tween instance
   public Tween start(final Tweenable target, final TweenType type, final int duration) {
     Tween tween = this.getTween(target, type);
     if (tween == null) {
@@ -41,13 +35,11 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     return tween;
   }
 
-  /**
-   * Attempts to get a previously registered {@code Tween} or registers a new one.
-   *
-   * @param target the {@code Tweenable} target object
-   * @param type   the {@code TweenType} determining which values of the target object will be modified.
-   * @return the Tween instance
-   */
+  /// Attempts to get a previously registered `Tween` or registers a new one.
+  ///
+  /// @param target the `Tweenable` target object
+  /// @param type   the `TweenType` determining which values of the target object will be modified.
+  /// @return the Tween instance
   public Tween getTween(final Tweenable target, final TweenType type) {
     if (this.getTweens().get(target) == null) {
       this.getTweens().put(target, new ConcurrentHashMap<>());
@@ -56,23 +48,19 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     return this.getTweens().get(target).get(type);
   }
 
-  /**
-   * Gets the map of registered {@code Tweens}.
-   *
-   * @return the map of registered {@code Tweens}.
-   */
+  /// Gets the map of registered `Tweens`.
+  ///
+  /// @return the map of registered `Tweens`.
   public Map<Tweenable, Map<TweenType, Tween>> getTweens() {
     return this.tweens;
   }
 
-  /**
-   * Looks for a registered Tween instance with the given target and type. Attempts to stop the Tween and reset the {@code Tweenable} values to the
-   * start values.
-   *
-   * @param target the {@code Tweenable} target object
-   * @param type   the {@code TweenType} determining which values of the target object will be modified.
-   * @return the Tween instance
-   */
+  /// Looks for a registered Tween instance with the given target and type. Attempts to stop the Tween and reset the `Tweenable` values to the
+  /// start values.
+  ///
+  /// @param target the `Tweenable` target object
+  /// @param type   the `TweenType` determining which values of the target object will be modified.
+  /// @return the Tween instance
   public Tween reset(final Tweenable target, final TweenType type) {
     final Tween tween = this.getTween(target, type);
     if (tween != null) {
@@ -82,13 +70,11 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     return tween;
   }
 
-  /**
-   * Looks for a registered Tween instance with the given target and type. Attempts to resume the Tween if it was stopped.
-   *
-   * @param target the {@code Tweenable} target object
-   * @param type   the {@code TweenType} determining which values of the target object will be modified.
-   * @return the Tween instance
-   */
+  /// Looks for a registered Tween instance with the given target and type. Attempts to resume the Tween if it was stopped.
+  ///
+  /// @param target the `Tweenable` target object
+  /// @param type   the `TweenType` determining which values of the target object will be modified.
+  /// @return the Tween instance
   public Tween resume(final Tweenable target, final TweenType type) {
     final Tween tween = this.getTween(target, type);
     if (tween != null) {
@@ -97,20 +83,16 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     return tween;
   }
 
-  /**
-   * Start.
-   */
+  /// Start.
   @Override
   public void start() {
     Game.loop().attach(this);
   }
 
-  /**
-   * Looks for a registered Tween instance with the given target and type. Attempts to remove the Tween from the TweenEngine.
-   *
-   * @param target the {@code Tweenable} target object
-   * @param type   the {@code TweenType} determining which values of the target object will be modified.
-   */
+  /// Looks for a registered Tween instance with the given target and type. Attempts to remove the Tween from the TweenEngine.
+  ///
+  /// @param target the `Tweenable` target object
+  /// @param type   the `TweenType` determining which values of the target object will be modified.
   public void remove(final Tweenable target, final TweenType type) {
     final Tween tween = this.getTween(target, type);
     if (tween != null) {
@@ -118,11 +100,9 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Removes all Tweens associated with the given {@code Tweenable} target.
-   *
-   * @param target the {@code Tweenable} target object whose Tweens are to be removed.
-   */
+  /// Removes all Tweens associated with the given `Tweenable` target.
+  ///
+  /// @param target the `Tweenable` target object whose Tweens are to be removed.
   public void remove(final Tweenable target) {
     if (getTweens().containsKey(target)) {
       getTweens().get(target).clear();
@@ -130,13 +110,11 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     }
   }
 
-  /**
-   * Looks for a registered Tween instance with the given target and type. Attempts to stop the Tween.
-   *
-   * @param target the {@code Tweenable} target object
-   * @param type   the {@code TweenType} determining which values of the target object will be modified.
-   * @return the Tween instance
-   */
+  /// Looks for a registered Tween instance with the given target and type. Attempts to stop the Tween.
+  ///
+  /// @param target the `Tweenable` target object
+  /// @param type   the `TweenType` determining which values of the target object will be modified.
+  /// @return the Tween instance
   public Tween stop(final Tweenable target, final TweenType type) {
     final Tween tween = this.getTween(target, type);
     if (tween != null) {
@@ -145,17 +123,13 @@ public class TweenEngine implements IUpdateable, ILaunchable {
     return tween;
   }
 
-  /**
-   * Terminate.
-   */
+  /// Terminate.
   @Override
   public void terminate() {
     Game.loop().detach(this);
   }
 
-  /**
-   * Updates all registered Tweens by applying the {@code TweenEquation}.
-   */
+  /// Updates all registered Tweens by applying the `TweenEquation`.
   @Override
   public void update() {
     for (final Tweenable target : this.getTweens().keySet()) {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenEquation.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenEquation.java
@@ -1,14 +1,12 @@
 package de.gurkenlabs.litiengine.tweening;
 
-/** An interface to generally apply a function to a value. */
+/// An interface to generally apply a function to a value.
 public interface TweenEquation {
 
-  /**
-   * Applies the function to the value and returns the result.
-   *
-   * @param progress
-   *          the current value
-   * @return a {@code float} representing the result of applying the {@code TweenEquation} to the value.
-   */
+  /// Applies the function to the value and returns the result.
+  ///
+  /// @param progress
+  /// the current value
+  /// @return a `float` representing the result of applying the `TweenEquation` to the value.
   float compute(final float progress);
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenFunction.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenFunction.java
@@ -1,63 +1,59 @@
 package de.gurkenlabs.litiengine.tweening;
 
-/** Easing equations based on Robert Penner's work: <a href="http://robertpenner.com/easing/">...</a> */
+/// Easing equations based on Robert Penner's work: [...](http://robertpenner.com/easing/)
 public enum TweenFunction {
-  /**
-   * Linear interpolation: {@code f(t) = t}.
-   */
+  /// Linear interpolation: `f(t) = t`.
   LINEAR(time -> time),
 
   // Quad based (x^2)
-  /**
-   * Quadratic ease-in.
-   */
+  /// Quadratic ease-in.
   QUAD_IN(time -> (float) Math.pow(time, 2)),
-  /** Quadratic ease-out. */
+  /// Quadratic ease-out.
   QUAD_OUT(time -> (float) (1f - Math.pow((time - 1f), 2))),
-  /** Quadratic ease-in / ease-out. */
+  /// Quadratic ease-in / ease-out.
   QUAD_INOUT(
     time -> (float) (time * 2f < 1f ? Math.pow(time, 2) * 2f : 1f - Math.pow(time - 1f, 2) * 2f)),
 
   // Circle
-  /** Circular ease-in. */
+  /// Circular ease-in.
   CIRCLE_IN(time -> (float) (1.0F - Math.sqrt(1.0F - Math.pow(time, 2)))),
-  /** Circular ease-out. */
+  /// Circular ease-out.
   CIRCLE_OUT(time -> (float) Math.sqrt(1.0F - Math.pow(time - 1f, 2))),
-  /** Circular ease-in / ease-out. */
+  /// Circular ease-in / ease-out.
   CIRCLE_INOUT(
     time -> (float) (time * 2f < 1f
         ? (1f - Math.sqrt(1.0F - Math.pow(time * 2f, 2))) * 0.5
         : (Math.sqrt(1f - 4 * Math.pow((time - 1f), 2)) + 1.0f) * 0.5f)),
 
   // Sine
-  /** Sinusoidal ease-in. */
+  /// Sinusoidal ease-in.
   SINE_IN(time -> (float) (1.0f - Math.cos(time * Math.PI / 2f))),
-  /** Sinusoidal ease-out. */
+  /// Sinusoidal ease-out.
   SINE_OUT(time -> (float) (1.0f - Math.sin(time * Math.PI / 2f))),
-  /** Sinusoidal ease-in / ease-out. */
+  /// Sinusoidal ease-in / ease-out.
   SINE_INOUT(time -> (float) (.5f * (1f - Math.cos(time * Math.PI / 2f)))),
 
   // Exponential
-  /** Exponential ease-in. */
+  /// Exponential ease-in.
   EXPO_IN(time -> (float) Math.pow(2, 10f * (time - 1f))),
-  /** Exponential ease-out. */
+  /// Exponential ease-out.
   EXPO_OUT(time -> (float) (1f - Math.pow(2, -10f * time))),
-  /** Exponential ease-in / ease-out. */
+  /// Exponential ease-in / ease-out.
   EXPO_INOUT(
     time -> (float) (time < .5f
         ? Math.pow(2, 10f * (2f * time - 1f) - 1f)
         : 1f - Math.pow(2, -10f * (2f * time - 1f) - 1f))),
 
   // Back
-  /** Back ease-in (overshoots origin slightly before easing in). */
+  /// Back ease-in (overshoots origin slightly before easing in).
   BACK_IN(time -> (float) Math.pow(time, 2) * (time * (1.70158f + 1f) - 1.70158f)),
-  /** Back ease-out (overshoots target slightly before settling). */
+  /// Back ease-out (overshoots target slightly before settling).
   BACK_OUT(
     time -> {
       final float k = 1.70158F;
       return (float) (1f + Math.pow(time - 1f, 2) * ((time - 1f) * (k + 1f) + k));
     }),
-  /** Back ease-in / ease-out (overshoots on both ends). */
+  /// Back ease-in / ease-out (overshoots on both ends).
   BACK_INOUT(
     time -> {
       final float k2 = 1.70158F * 1.525F;
@@ -67,7 +63,7 @@ public enum TweenFunction {
     }),
 
   // Bounce
-  /** Bounce ease-out (bouncing settle to target). */
+  /// Bounce ease-out (bouncing settle to target).
   BOUNCE_OUT(
     time -> {
       final float BOUNCE_R = 1.0F / 2.75F; // reciprocal
@@ -96,23 +92,23 @@ public enum TweenFunction {
       }
     }),
 
-  /** Bounce ease-in (mirror of {@link #BOUNCE_OUT}). */
+  /// Bounce ease-in (mirror of [#BOUNCE_OUT]).
   BOUNCE_IN(time -> 1f - BOUNCE_OUT.equation.compute(1f - time)),
-  /** Bounce ease-in / ease-out. */
+  /// Bounce ease-in / ease-out.
   BOUNCE_INOUT(
     time -> time * 2f < 1f
         ? 0.5F - 0.5F * BOUNCE_OUT.equation.compute(1.0F - time * 2)
         : 0.5F + 0.5F * BOUNCE_OUT.equation.compute(time * 2 - 1.0F)),
 
   // Elastic
-  /** Elastic ease-in. */
+  /// Elastic ease-in.
   ELASTIC_IN(
     time -> (float) (-Math.pow(2, 10f * (time - 1f))
         * Math.sin(((time - 1f) * 40f - 3f) * Math.PI / 6f))),
-  /** Elastic ease-out. */
+  /// Elastic ease-out.
   ELASTIC_OUT(
     time -> (float) (1f + (Math.pow(2, 10f * -time) * Math.sin((-time * 40f - 3f) * Math.PI / 6f)))),
-  /** Elastic ease-in / ease-out. */
+  /// Elastic ease-in / ease-out.
   ELASTIC_INOUT(
     time -> {
       time *= 2.0F; // remap: [0,0.5] -> [-1,0]
@@ -128,32 +124,26 @@ public enum TweenFunction {
 
   private final transient TweenEquation equation;
 
-  /**
-   * Instantiates a new tween function with a given mathematical equation.
-   *
-   * @param equation
-   *          the equation
-   */
+  /// Instantiates a new tween function with a given mathematical equation.
+  ///
+  /// @param equation
+  /// the equation
   TweenFunction(final TweenEquation equation) {
     this.equation = equation;
   }
 
-  /**
-   * Gets the mathematical equation.
-   *
-   * @return the equation
-   */
+  /// Gets the mathematical equation.
+  ///
+  /// @return the equation
   public TweenEquation getEquation() {
     return equation;
   }
 
-  /**
-   * Computes the next value of the interpolation.
-   *
-   * @param time
-   *          The current progress of the tween duration, between 0 and 1.
-   * @return The next interpolated value.
-   */
+  /// Computes the next value of the interpolation.
+  ///
+  /// @param time
+  /// The current progress of the tween duration, between 0 and 1.
+  /// @return The next interpolated value.
   public float compute(float time) {
     return equation.compute(time);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenListener.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenListener.java
@@ -2,35 +2,27 @@ package de.gurkenlabs.litiengine.tweening;
 
 import java.util.EventListener;
 
-/**
- * This listener interface receives lifecycle events from a {@code Tween}.
- *
- * @see Tween#addListener(TweenListener)
- */
+/// This listener interface receives lifecycle events from a `Tween`.
+///
+/// @see Tween#addListener(TweenListener)
 public interface TweenListener extends EventListener {
-  /**
-   * Invoked when a Tween is started (or restarted).
-   *
-   * @param tween the Tween that has been started.
-   */
+  /// Invoked when a Tween is started (or restarted).
+  ///
+  /// @param tween the Tween that has been started.
   default void started(Tween tween) {
   }
 
-  /**
-   * Invoked when a Tween is stopped, either manually via {@link Tween#stop()} or by completing its duration when no looping
-   * is configured.
-   *
-   * @param tween the Tween that has been stopped.
-   */
+  /// Invoked when a Tween is stopped, either manually via [Tween#stop()] or by completing its duration when no looping
+  /// is configured.
+  ///
+  /// @param tween the Tween that has been stopped.
   default void stopped(Tween tween) {
   }
 
-  /**
-   * Invoked when a Tween completes a full duration cycle. For non-looping Tweens, this is fired right before the
-   * {@link #stopped(Tween)} event. For looping Tweens, this is fired on every cycle completion.
-   *
-   * @param tween the Tween that has completed.
-   */
+  /// Invoked when a Tween completes a full duration cycle. For non-looping Tweens, this is fired right before the
+  /// [#stopped(Tween)] event. For looping Tweens, this is fired on every cycle completion.
+  ///
+  /// @param tween the Tween that has completed.
   default void completed(Tween tween) {
   }
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenLoop.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenLoop.java
@@ -1,21 +1,13 @@
 package de.gurkenlabs.litiengine.tweening;
 
-/**
- * Determines how a {@code Tween} behaves once its duration has elapsed.
- */
+/// Determines how a `Tween` behaves once its duration has elapsed.
 public enum TweenLoop {
-  /**
-   * The Tween stops after completing once.
-   */
+  /// The Tween stops after completing once.
   NONE,
 
-  /**
-   * The Tween restarts from the beginning after completing.
-   */
+  /// The Tween restarts from the beginning after completing.
   LOOP,
 
-  /**
-   * The Tween reverses its direction on each completion, swapping start and target values back and forth.
-   */
+  /// The Tween reverses its direction on each completion, swapping start and target values back and forth.
   PINGPONG
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenType.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/TweenType.java
@@ -1,91 +1,55 @@
 package de.gurkenlabs.litiengine.tweening;
 
-/**
- * The TweenType determines which values of a {@code Tweenable} will be modified by a {@code Tween}.
- */
+/// The TweenType determines which values of a `Tweenable` will be modified by a `Tween`.
 public enum TweenType {
-  /**
-   * The angle of the entity.
-   */
+  /// The angle of the entity.
   ANGLE,
 
-  /**
-   * Both the width and height of the collision box.
-   */
+  /// Both the width and height of the collision box.
   COLLISION_BOTH,
 
-  /**
-   * The height of the collision box.
-   */
+  /// The height of the collision box.
   COLLISION_HEIGHT,
 
-  /**
-   * The width of the collision box.
-   */
+  /// The width of the collision box.
   COLLISION_WIDTH,
 
-  /**
-   * The hitpoints of the entity.
-   */
+  /// The hitpoints of the entity.
   HITPOINTS,
 
-  /**
-   * The X coordinate of the location.
-   */
+  /// The X coordinate of the location.
   LOCATION_X,
 
-  /**
-   * Both the X and Y coordinates of the location.
-   */
+  /// Both the X and Y coordinates of the location.
   LOCATION_XY,
 
-  /**
-   * The Y coordinate of the location.
-   */
+  /// The Y coordinate of the location.
   LOCATION_Y,
 
-  /**
-   * Both the width and height of the size.
-   */
+  /// Both the width and height of the size.
   SIZE_BOTH,
 
-  /**
-   * The height of the size.
-   */
+  /// The height of the size.
   SIZE_HEIGHT,
 
-  /**
-   * The width of the size.
-   */
+  /// The width of the size.
   SIZE_WIDTH,
 
-  /**
-   * Undefined type.
-   */
+  /// Undefined type.
   UNDEFINED,
 
-  /**
-   * The velocity of the entity.
-   */
+  /// The velocity of the entity.
   VELOCITY,
 
-  /**
-   * The volume of the entity.
-   */
+  /// The volume of the entity.
   VOLUME,
 
-  /**
-   * The font size.
-   */
+  /// The font size.
   FONTSIZE,
 
-  /**
-   * The opacity of the entity.
-   */
+  /// The opacity of the entity.
   OPACITY,
 
-  /**
-   * The zoom level (e.g. of the {@code Camera}).
-   */
+  /// The zoom level (e.g. of the `Camera`).
   ZOOM
 }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/Tweenable.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/tweening/Tweenable.java
@@ -3,20 +3,15 @@ package de.gurkenlabs.litiengine.tweening;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * The Tweenable interface allows modifying an object's attributes smoothly over time using {@code
- * Tween} instances managed by the {@code TweenEngine}.
- */
+/// The Tweenable interface allows modifying an object's attributes smoothly over time using `Tween` instances managed by the `TweenEngine`.
 public interface Tweenable {
 
-  /**
-   * Gets one or many values from the target object associated to the given tween type. It is used by the Tween Engine to
-   * determine starting values.
-   *
-   * @param tweenType
-   *          The tween type of this interpolation, determining which values are modified.
-   * @return The array of current tween values.
-   */
+  /// Gets one or many values from the target object associated to the given tween type. It is used by the Tween Engine to
+  /// determine starting values.
+  ///
+  /// @param tweenType
+  /// The tween type of this interpolation, determining which values are modified.
+  /// @return The array of current tween values.
   default float[] getTweenValues(final TweenType tweenType) {
     Logger.getLogger(this.getClass().getName())
         .log(
@@ -27,14 +22,12 @@ public interface Tweenable {
     return new float[0];
   }
 
-  /**
-   * This method is called in a Tween's update() method to set the new interpolated values.
-   *
-   * @param tweenType
-   *          The tween type of this interpolation, determining which values are modified.
-   * @param newValues
-   *          The new values determined by the tween equation.
-   */
+  /// This method is called in a Tween's update() method to set the new interpolated values.
+  ///
+  /// @param tweenType
+  /// The tween type of this interpolation, determining which values are modified.
+  /// @param newValues
+  /// The new values determined by the tween equation.
   default void setTweenValues(final TweenType tweenType, final float[] newValues) {
     Logger.getLogger(this.getClass().getName())
         .log(

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/AlphanumComparator.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/AlphanumComparator.java
@@ -31,12 +31,9 @@ package de.gurkenlabs.litiengine.util;
 
 import java.util.Comparator;
 
-/**
- * This is an updated version with enhancements made by Daniel Migowski, Andre Bogus, and David Koelle. Updated by David Koelle in 2017.
- *
- * <p>
- * To use this class: Use the static "sort" method from the java.util.Collections class: Collections.sort(your list, new AlphanumComparator());
- */
+/// This is an updated version with enhancements made by Daniel Migowski, Andre Bogus, and David Koelle. Updated by David Koelle in 2017.
+///
+/// To use this class: Use the static "sort" method from the java.util.Collections class: Collections.sort(your list, new AlphanumComparator());
 public class AlphanumComparator implements Comparator<String> {
   private AlphanumComparator() {
     // Default constructor
@@ -46,9 +43,7 @@ public class AlphanumComparator implements Comparator<String> {
     return ((ch >= 48) && (ch <= 57));
   }
 
-  /**
-   * Length of string is passed in for improved efficiency (only need to calculate it once) *
-   */
+  /// Length of string is passed in for improved efficiency (only need to calculate it once) *
   private static String getChunk(String s, int slength, int marker) {
     StringBuilder chunk = new StringBuilder();
     char c = s.charAt(marker);
@@ -76,27 +71,23 @@ public class AlphanumComparator implements Comparator<String> {
     return chunk.toString();
   }
 
-  /**
-   * Compares two strings using the Alphanum algorithm. This method compares two strings by breaking them into chunks of numeric and non-numeric
-   * characters and comparing these chunks numerically and lexicographically.
-   *
-   * @param s1 the first string to compare
-   * @param s2 the second string to compare
-   * @return a negative integer, zero, or a positive integer as the first string is less than, equal to, or greater than the second string
-   */
+  /// Compares two strings using the Alphanum algorithm. This method compares two strings by breaking them into chunks of numeric and non-numeric
+  /// characters and comparing these chunks numerically and lexicographically.
+  ///
+  /// @param s1 the first string to compare
+  /// @param s2 the second string to compare
+  /// @return a negative integer, zero, or a positive integer as the first string is less than, equal to, or greater than the second string
   @Override
   public int compare(String s1, String s2) {
     return compareTo(s1, s2);
   }
 
-  /**
-   * Compares two strings using the Alphanum algorithm. This method compares two strings by breaking them into chunks of numeric and non-numeric
-   * characters and comparing these chunks numerically and lexicographically.
-   *
-   * @param s1 the first string to compare
-   * @param s2 the second string to compare
-   * @return a negative integer, zero, or a positive integer as the first string is less than, equal to, or greater than the second string
-   */
+  /// Compares two strings using the Alphanum algorithm. This method compares two strings by breaking them into chunks of numeric and non-numeric
+  /// characters and comparing these chunks numerically and lexicographically.
+  ///
+  /// @param s1 the first string to compare
+  /// @param s2 the second string to compare
+  /// @return a negative integer, zero, or a positive integer as the first string is less than, equal to, or greater than the second string
   public static int compareTo(String s1, String s2) {
     if ((s1 == null) || (s2 == null)) {
       return 0;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ArrayUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ArrayUtilities.java
@@ -6,13 +6,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.*;
 
-/**
- * Utility class for array operations.
- *
- * <p>This class provides various static methods for manipulating arrays, such as concatenation, splitting, joining, and more.</p>
- *
- * <p>Note: This class cannot be instantiated.</p>
- */
+/// Utility class for array operations.
+///
+/// This class provides various static methods for manipulating arrays, such as concatenation, splitting, joining, and more.
+///
+/// Note: This class cannot be instantiated.
 public final class ArrayUtilities {
   public static final String DEFAULT_STRING_DELIMITER = ",";
   private static final Logger log = Logger.getLogger(ArrayUtilities.class.getName());
@@ -21,81 +19,67 @@ public final class ArrayUtilities {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Concatenates the two specified byte arrays to a new array.
-   *
-   * @param first  The first array.
-   * @param second The second array.
-   * @return A new array with both specified arrays in sequence.
-   */
+  /// Concatenates the two specified byte arrays to a new array.
+  ///
+  /// @param first  The first array.
+  /// @param second The second array.
+  /// @return A new array with both specified arrays in sequence.
   public static byte[] concat(byte[] first, byte[] second) {
     byte[] result = Arrays.copyOf(first, first.length + second.length);
     System.arraycopy(second, 0, result, first.length, second.length);
     return result;
   }
 
-  /**
-   * Concatenates the two specified int arrays to a new array.
-   *
-   * @param first  The first array.
-   * @param second The second array.
-   * @return A new array with both specified arrays in sequence.
-   */
+  /// Concatenates the two specified int arrays to a new array.
+  ///
+  /// @param first  The first array.
+  /// @param second The second array.
+  /// @return A new array with both specified arrays in sequence.
   public static int[] concat(int[] first, int[] second) {
     return IntStream.concat(Arrays.stream(first), Arrays.stream(second)).toArray();
   }
 
-  /**
-   * Concatenates the two specified long arrays to a new array.
-   *
-   * @param first  The first array.
-   * @param second The second array.
-   * @return A new array with both specified arrays in sequence.
-   */
+  /// Concatenates the two specified long arrays to a new array.
+  ///
+  /// @param first  The first array.
+  /// @param second The second array.
+  /// @return A new array with both specified arrays in sequence.
   public static long[] concat(long[] first, long[] second) {
     return LongStream.concat(Arrays.stream(first), Arrays.stream(second)).toArray();
   }
 
-  /**
-   * Concatenates the two specified double arrays to a new array.
-   *
-   * @param first  The first array.
-   * @param second The second array.
-   * @return A new array with both specified arrays in sequence.
-   */
+  /// Concatenates the two specified double arrays to a new array.
+  ///
+  /// @param first  The first array.
+  /// @param second The second array.
+  /// @return A new array with both specified arrays in sequence.
   public static double[] concat(double[] first, double[] second) {
     return DoubleStream.concat(Arrays.stream(first), Arrays.stream(second)).toArray();
   }
 
-  /**
-   * Concatenates the two specified double arrays to a new array.
-   *
-   * @param <T>    The type of the array elements.
-   * @param first  The first array.
-   * @param second The second array.
-   * @return A new array with both specified arrays in sequence.
-   */
+  /// Concatenates the two specified double arrays to a new array.
+  ///
+  /// @param <T>    The type of the array elements.
+  /// @param first  The first array.
+  /// @param second The second array.
+  /// @return A new array with both specified arrays in sequence.
   public static <T> T[] concat(T[] first, T[] second) {
     return Stream.concat(Arrays.stream(first), Arrays.stream(second)).toArray(size -> (T[]) Array.newInstance(first.getClass().getComponentType(), size));
   }
 
-  /**
-   * Splits the specified string by the {@link #DEFAULT_STRING_DELIMITER} into an int array.
-   *
-   * @param delimiterSeparatedString The string to split.
-   * @return An int array with all separated elements of the specified string.
-   */
+  /// Splits the specified string by the [#DEFAULT_STRING_DELIMITER] into an int array.
+  ///
+  /// @param delimiterSeparatedString The string to split.
+  /// @return An int array with all separated elements of the specified string.
   public static int[] splitInt(String delimiterSeparatedString) {
     return splitInt(delimiterSeparatedString, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Splits the specified string by the defined delimiter into an int array.
-   *
-   * @param delimiterSeparatedString The string to split.
-   * @param delimiter                The delimiter by which to split the elements.
-   * @return An int array with all separated elements of the specified string.
-   */
+  /// Splits the specified string by the defined delimiter into an int array.
+  ///
+  /// @param delimiterSeparatedString The string to split.
+  /// @param delimiter                The delimiter by which to split the elements.
+  /// @return An int array with all separated elements of the specified string.
   public static int[] splitInt(String delimiterSeparatedString, String delimiter) {
     if (delimiterSeparatedString == null || delimiterSeparatedString.isEmpty()) {
       return new int[0];
@@ -122,23 +106,19 @@ public final class ArrayUtilities {
     return integers;
   }
 
-  /**
-   * Splits the specified string by the {@link #DEFAULT_STRING_DELIMITER} into a double array.
-   *
-   * @param delimiterSeparatedString The string to split.
-   * @return An double array with all separated elements of the specified string.
-   */
+  /// Splits the specified string by the [#DEFAULT_STRING_DELIMITER] into a double array.
+  ///
+  /// @param delimiterSeparatedString The string to split.
+  /// @return An double array with all separated elements of the specified string.
   public static double[] splitDouble(String delimiterSeparatedString) {
     return splitDouble(delimiterSeparatedString, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Splits the specified string by the defined delimiter into a double array.
-   *
-   * @param delimiterSeparatedString The string to split.
-   * @param delimiter                The delimiter by which to split the elements.
-   * @return An double array with all separated elements of the specified string.
-   */
+  /// Splits the specified string by the defined delimiter into a double array.
+  ///
+  /// @param delimiterSeparatedString The string to split.
+  /// @param delimiter                The delimiter by which to split the elements.
+  /// @return An double array with all separated elements of the specified string.
   public static double[] splitDouble(String delimiterSeparatedString, String delimiter) {
     if (delimiterSeparatedString == null || delimiterSeparatedString.isEmpty()) {
       return new double[0];
@@ -165,96 +145,78 @@ public final class ArrayUtilities {
     return doubles;
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(boolean[] arr) {
     return joinArray(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(boolean[] arr, String delimiter) {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(int[] arr) {
     return joinArray(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(int[] arr, String delimiter) {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(double[] arr) {
     return joinArray(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(double[] arr, String delimiter) {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(float[] arr) {
     return joinArray(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(float[] arr, String delimiter) {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(short[] arr) {
     return joinArray(arr, DEFAULT_STRING_DELIMITER);
   }
@@ -263,86 +225,70 @@ public final class ArrayUtilities {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(long[] arr) {
     return join(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(long[] arr, String delimiter) {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(byte[] arr) {
     return join(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(byte[] arr, String delimiter) {
     return joinArray(arr, delimiter);
   }
 
-  /**
-   * Joins the specified collection with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param collection The collection that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified collection with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param collection The collection that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(Collection<?> collection) {
     return join(collection, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified collection with the defined delimiter.
-   *
-   * @param collection The list that provides the elements to be joined.
-   * @param delimiter  The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified collection with the defined delimiter.
+  ///
+  /// @param collection The list that provides the elements to be joined.
+  /// @param delimiter  The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(Collection<?> collection, String delimiter) {
     return collection.stream().map(String::valueOf).collect(Collectors.joining(delimiter));
   }
 
-  /**
-   * Joins the specified array with the {@link #DEFAULT_STRING_DELIMITER}.
-   *
-   * @param arr The array that provides the elements to be joined.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the [#DEFAULT_STRING_DELIMITER].
+  ///
+  /// @param arr The array that provides the elements to be joined.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(Object[] arr) {
     return join(arr, DEFAULT_STRING_DELIMITER);
   }
 
-  /**
-   * Joins the specified array with the defined delimiter.
-   *
-   * @param arr       The array that provides the elements to be joined.
-   * @param delimiter The delimiter used to separate the elements with.
-   * @return A string with all joined elements, separated by the delimiter.
-   */
+  /// Joins the specified array with the defined delimiter.
+  ///
+  /// @param arr       The array that provides the elements to be joined.
+  /// @param delimiter The delimiter used to separate the elements with.
+  /// @return A string with all joined elements, separated by the delimiter.
   public static String join(Object[] arr, String delimiter) {
     return Arrays.stream(arr).map(String::valueOf).collect(Collectors.joining(delimiter));
   }
@@ -356,13 +302,11 @@ public final class ArrayUtilities {
     return list;
   }
 
-  /**
-   * Return true if the array contains the specified value.
-   *
-   * @param arr   The array that is tested for the existence of the element.
-   * @param value The element to check for in the array.
-   * @return True if the specified element is in the array; otherwise false.
-   */
+  /// Return true if the array contains the specified value.
+  ///
+  /// @param arr   The array that is tested for the existence of the element.
+  /// @param value The element to check for in the array.
+  /// @return True if the specified element is in the array; otherwise false.
   public static boolean contains(Object[] arr, Object value) {
     for (Object v : arr) {
       if (Objects.equals(v, value)) {
@@ -373,14 +317,12 @@ public final class ArrayUtilities {
   }
 
 
-  /**
-   * Return true if the array contains the specified string argument.
-   *
-   * @param arr        The array that is tested for the existence of the argument.
-   * @param argument   The argument to check for in the array.
-   * @param ignoreCase A flag indicating whether the case should be ignored when checking for equality.
-   * @return True if the specified argument is in the array; otherwise false.
-   */
+  /// Return true if the array contains the specified string argument.
+  ///
+  /// @param arr        The array that is tested for the existence of the argument.
+  /// @param argument   The argument to check for in the array.
+  /// @param ignoreCase A flag indicating whether the case should be ignored when checking for equality.
+  /// @return True if the specified argument is in the array; otherwise false.
   public static boolean contains(String[] arr, String argument, boolean ignoreCase) {
     if (arr == null) {
       return false;
@@ -395,15 +337,13 @@ public final class ArrayUtilities {
     return false;
   }
 
-  /**
-   * Removes the specified deleteItem from the input array and returns a trimmed new array instance without null entries. The resulting array will
-   * have a length -1;
-   *
-   * @param <T>        The element type of the array.
-   * @param input      The original array
-   * @param deleteItem The item to delete
-   * @return A new array with the length input.length - 1.
-   */
+  /// Removes the specified deleteItem from the input array and returns a trimmed new array instance without null entries. The resulting array will
+  /// have a length -1;
+  ///
+  /// @param <T>        The element type of the array.
+  /// @param input      The original array
+  /// @param deleteItem The item to delete
+  /// @return A new array with the length input.length - 1.
   @SuppressWarnings("unchecked")
   public static <T> T[] remove(T[] input, T deleteItem) {
     List<T> result = new ArrayList<>();
@@ -419,14 +359,12 @@ public final class ArrayUtilities {
       (T[]) Array.newInstance(input.getClass().getComponentType(), result.size()));
   }
 
-  /**
-   * Adds the specified item to the input array and returns a new array instance with the length of the input array +1.
-   *
-   * @param <T>     The element type of the array.
-   * @param input   The original array.
-   * @param addItem The item to add.
-   * @return A new array with the item to add appended at the end.
-   */
+  /// Adds the specified item to the input array and returns a new array instance with the length of the input array +1.
+  ///
+  /// @param <T>     The element type of the array.
+  /// @param input   The original array.
+  /// @param addItem The item to add.
+  /// @return A new array with the item to add appended at the end.
   @SuppressWarnings("unchecked")
   public static <T> T[] append(T[] input, T addItem) {
     List<T> result = new ArrayList<>(Arrays.asList(input));
@@ -436,14 +374,12 @@ public final class ArrayUtilities {
       (T[]) Array.newInstance(input.getClass().getComponentType(), result.size()));
   }
 
-  /**
-   * Combines the two specified arrays by only keeping distinct values.
-   *
-   * @param <T>    The element type of the array.
-   * @param first  The first array.
-   * @param second The second array.
-   * @return A new array with every distinct value of the specified arrays.
-   */
+  /// Combines the two specified arrays by only keeping distinct values.
+  ///
+  /// @param <T>    The element type of the array.
+  /// @param first  The first array.
+  /// @param second The second array.
+  /// @return A new array with every distinct value of the specified arrays.
   @SuppressWarnings("unchecked")
   public static <T> T[] distinct(T[] first, T[] second) {
     List<T> firstList = Arrays.asList(first);
@@ -455,24 +391,20 @@ public final class ArrayUtilities {
     return hash.toArray((T[]) Array.newInstance(first.getClass().getComponentType(), hash.size()));
   }
 
-  /**
-   * Creates a copy of the specified array.
-   *
-   * @param <T>      the type of the array elements
-   * @param original the array to copy
-   * @return a new array that is a copy of the original array
-   */
+  /// Creates a copy of the specified array.
+  ///
+  /// @param <T>      the type of the array elements
+  /// @param original the array to copy
+  /// @return a new array that is a copy of the original array
   public static <T> T[] arrayCopy(T[] original) {
     return original.clone();
   }
 
-  /**
-   * General method for joining an array. Encapsulated for type safety.
-   *
-   * @param arr       The array to join.
-   * @param separator The separator to use between elements.
-   * @return A string with all joined elements, separated by the specified separator.
-   */
+  /// General method for joining an array. Encapsulated for type safety.
+  ///
+  /// @param arr       The array to join.
+  /// @param separator The separator to use between elements.
+  /// @return A string with all joined elements, separated by the specified separator.
   private static String joinArray(Object arr, String separator) {
     if (arr == null) {
       return null;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ColorHelper.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ColorHelper.java
@@ -4,9 +4,7 @@ import java.awt.Color;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Utility class for color-related helper methods. This class cannot be instantiated.
- */
+/// Utility class for color-related helper methods. This class cannot be instantiated.
 public final class ColorHelper {
 
   private static final Logger log = Logger.getLogger(ColorHelper.class.getName());
@@ -18,26 +16,24 @@ public final class ColorHelper {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Encodes the specified color to a hexadecimal string representation. The output format is:
-   *
-   * <ul>
-   * <li>#RRGGBB - For colors without alpha
-   * <li>#AARRGGBB - For colors with alpha
-   * <li>#RRGGBB|A - Legacy format with decimal alpha
-   * </ul>
-   * <p>
-   * Examples: <br>
-   * {@code Color.RED} = "#ff0000"<br>
-   * {@code new Color(255, 0, 0, 200)} = "#c8ff0000"
-   *
-   * @param color The color that is encoded.
-   * @return An hexadecimal string representation of the specified color.
-   * @see ColorHelper#decode(String)
-   * @see Color
-   * @see Color#getRGB()
-   * @see Integer#toHexString(int)
-   */
+  /// Encodes the specified color to a hexadecimal string representation. The output format is:
+  ///
+  /// - #RRGGBB - For colors without alpha
+  /// - #AARRGGBB - For colors with alpha
+  /// - #RRGGBB|A - Legacy format with decimal alpha
+  ///
+  /// Examples:
+  ///
+  /// `Color.RED` = "#ff0000"
+  ///
+  /// `new Color(255, 0, 0, 200)` = "#c8ff0000"
+  ///
+  /// @param color The color that is encoded.
+  /// @return An hexadecimal string representation of the specified color.
+  /// @see ColorHelper#decode(String)
+  /// @see Color
+  /// @see Color#getRGB()
+  /// @see Integer#toHexString(int)
   public static String encode(Color color) {
     if (color == null) {
       return null;
@@ -51,56 +47,50 @@ public final class ColorHelper {
     }
   }
 
-  /**
-   * Decodes the specified color string to an actual {@code Color} instance. The accepted format is:
-   * <p>
-   * <i>Note: This returns null if the format of the provided color string is invalid.</i>
-   * </p>
-   *
-   * <ul>
-   * <li>#RRGGBB - For colors without alpha
-   * <li>#AARRGGBB - For colors with alpha
-   * </ul>
-   * <p>
-   * Examples: <br>
-   * "#ff0000" = {@code Color.RED}<br>
-   * "#c8ff0000" = {@code new Color(255, 0, 0, 200)}
-   *
-   * @param colorHexString The hexadecimal encodes color string representation.
-   * @return The decoded color.
-   * @see ColorHelper#encode(Color)
-   * @see Color
-   * @see Color#decode(String)
-   * @see Integer#decode(String)
-   */
+  /// Decodes the specified color string to an actual `Color` instance. The accepted format is:
+  ///
+  /// *Note: This returns null if the format of the provided color string is invalid.*
+  ///
+  /// - #RRGGBB - For colors without alpha
+  /// - #AARRGGBB - For colors with alpha
+  ///
+  /// Examples:
+  ///
+  /// "#ff0000" = `Color.RED`
+  ///
+  /// "#c8ff0000" = `new Color(255, 0, 0, 200)`
+  ///
+  /// @param colorHexString The hexadecimal encodes color string representation.
+  /// @return The decoded color.
+  /// @see ColorHelper#encode(Color)
+  /// @see Color
+  /// @see Color#decode(String)
+  /// @see Integer#decode(String)
   public static Color decode(String colorHexString) {
     return decode(colorHexString, false);
   }
 
-  /**
-   * Decodes the specified color string to an actual {@code Color} instance, with an option to create a darker version of the base color. The accepted
-   * format is:
-   * <ul>
-   * <li>#RRGGBB - For colors without alpha
-   * <li>#AARRGGBB - For colors with alpha
-   * </ul>
-   * <p>
-   * If the `solid` parameter is true, the color alpha will create a darker version of the base color.
-   * </p>
-   * <p>
-   * Examples: <br>
-   * "#ff0000" = {@code Color.RED}<br>
-   * "#c8ff0000" = {@code new Color(255, 0, 0, 200)}
-   * </p>
-   *
-   * @param colorHexString The hexadecimal encoded color string representation.
-   * @param solid          If true, the color alpha will create a darker version of the base color.
-   * @return The decoded {@code Color} object, or {@code null} if the input string is invalid.
-   * @see ColorHelper#encode(Color)
-   * @see Color
-   * @see Color#decode(String)
-   * @see Integer#decode(String)
-   */
+  /// Decodes the specified color string to an actual `Color` instance, with an option to create a darker version of the base color. The accepted
+  /// format is:
+  ///
+  /// - #RRGGBB - For colors without alpha
+  /// - #AARRGGBB - For colors with alpha
+  ///
+  /// If the `solid` parameter is true, the color alpha will create a darker version of the base color.
+  ///
+  /// Examples:
+  ///
+  /// "#ff0000" = `Color.RED`
+  ///
+  /// "#c8ff0000" = `new Color(255, 0, 0, 200)`
+  ///
+  /// @param colorHexString The hexadecimal encoded color string representation.
+  /// @param solid          If true, the color alpha will create a darker version of the base color.
+  /// @return The decoded `Color` object, or `null` if the input string is invalid.
+  /// @see ColorHelper#encode(Color)
+  /// @see Color
+  /// @see Color#decode(String)
+  /// @see Integer#decode(String)
   public static Color decode(String colorHexString, boolean solid) {
     if (colorHexString == null || colorHexString.isEmpty()) {
       return null;
@@ -157,34 +147,28 @@ public final class ColorHelper {
     }
   }
 
-  /**
-   * Ensures that the specified value lies within the accepted range for Color values (0-255). Smaller values will be forced to be 0 and larger values
-   * will result in 255.
-   *
-   * @param value The value to check for.
-   * @return An integer value that fits the color value restrictions.
-   */
+  /// Ensures that the specified value lies within the accepted range for Color values (0-255). Smaller values will be forced to be 0 and larger values
+  /// will result in 255.
+  ///
+  /// @param value The value to check for.
+  /// @return An integer value that fits the color value restrictions.
   public static int ensureColorValueRange(float value) {
     return ensureColorValueRange(Math.round(value));
   }
 
-  /**
-   * Ensures that the specified value lies within the accepted range for Color values (0-255). Smaller values will be forced to be 0 and larger values
-   * will result in 255.
-   *
-   * @param value The value to check for.
-   * @return An integer value that fits the color value restrictions.
-   */
+  /// Ensures that the specified value lies within the accepted range for Color values (0-255). Smaller values will be forced to be 0 and larger values
+  /// will result in 255.
+  ///
+  /// @param value The value to check for.
+  /// @return An integer value that fits the color value restrictions.
   public static int ensureColorValueRange(int value) {
     return Math.clamp(value, 0, MAX_RGB_VALUE);
   }
 
-  /**
-   * Premultiplies the alpha on the given color.
-   *
-   * @param color The color to premultiply
-   * @return The color given, with alpha replaced with a black background.
-   */
+  /// Premultiplies the alpha on the given color.
+  ///
+  /// @param color The color to premultiply
+  /// @return The color given, with alpha replaced with a black background.
   public static Color premultiply(Color color) {
     if (color.getAlpha() == 255) {
       return color;
@@ -193,15 +177,13 @@ public final class ColorHelper {
       premultiply(color.getBlue(), color.getAlpha()));
   }
 
-  /**
-   * Interpolates between two colors based on the given factor. The factor determines the weight of each color in the interpolation. A factor of 0.0
-   * will return the first color, and a factor of 1.0 will return the second color. Intermediate values will return a blend of the two colors.
-   *
-   * @param color1 The first color.
-   * @param color2 The second color.
-   * @param factor The interpolation factor, ranging from 0.0 to 1.0.
-   * @return A new {@code Color} object that is the result of interpolating between the two colors.
-   */
+  /// Interpolates between two colors based on the given factor. The factor determines the weight of each color in the interpolation. A factor of 0.0
+  /// will return the first color, and a factor of 1.0 will return the second color. Intermediate values will return a blend of the two colors.
+  ///
+  /// @param color1 The first color.
+  /// @param color2 The second color.
+  /// @param factor The interpolation factor, ranging from 0.0 to 1.0.
+  /// @return A new `Color` object that is the result of interpolating between the two colors.
   public static Color interpolate(Color color1, Color color2, double factor) {
     factor = Math.clamp(factor, 0, 1);
 
@@ -213,30 +195,24 @@ public final class ColorHelper {
     return new Color(r, g, b, a);
   }
 
-  /**
-   * Returns a transparent variant of the specified color with the given alpha value. The red, green, and blue components of the color remain
-   * unchanged.
-   *
-   * @param color    The original color.
-   * @param newAlpha The new alpha value to be applied to the color.
-   * @return A new {@code Color} object with the specified alpha value.
-   */
+  /// Returns a transparent variant of the specified color with the given alpha value. The red, green, and blue components of the color remain
+  /// unchanged.
+  ///
+  /// @param color    The original color.
+  /// @param newAlpha The new alpha value to be applied to the color.
+  /// @return A new `Color` object with the specified alpha value.
   public static Color getTransparentVariant(Color color, int newAlpha) {
     return new Color(color.getRed(), color.getGreen(), color.getBlue(), ensureColorValueRange(newAlpha));
   }
 
-  /**
-   * Decodes a well-formed hexadecimal color string to a {@code Color} object. This method expects the input string to be in the format:
-   * <ul>
-   * <li>#RRGGBB - For colors without alpha
-   * </ul>
-   * <p>
-   * If the input string is not well-formed, this method logs a {@code SEVERE} level message and returns {@code null}.
-   * </p>
-   *
-   * @param hexString The well-formed hexadecimal color string representation.
-   * @return The decoded {@code Color} object, or {@code null} if the input string is invalid.
-   */
+  /// Decodes a well-formed hexadecimal color string to a `Color` object. This method expects the input string to be in the format:
+  ///
+  /// - #RRGGBB - For colors without alpha
+  ///
+  /// If the input string is not well-formed, this method logs a `SEVERE` level message and returns `null`.
+  ///
+  /// @param hexString The well-formed hexadecimal color string representation.
+  /// @return The decoded `Color` object, or `null` if the input string is invalid.
   private static Color decodeWellformedHexString(String hexString) {
     try {
       return Color.decode(hexString);
@@ -246,35 +222,29 @@ public final class ColorHelper {
     return null;
   }
 
-  /**
-   * Premultiplies the given color value with the specified alpha value. This method accounts for gamma correction.
-   *
-   * @param value The color value to be premultiplied.
-   * @param alpha The alpha value to premultiply with.
-   * @return The premultiplied color value.
-   */
+  /// Premultiplies the given color value with the specified alpha value. This method accounts for gamma correction.
+  ///
+  /// @param value The color value to be premultiplied.
+  /// @param alpha The alpha value to premultiply with.
+  /// @return The premultiplied color value.
   private static int premultiply(int value, int alpha) {
     // account for gamma
     return (int) Math.round(value * Math.pow(alpha / 255.0, 1 / 2.2));
   }
 
-  /**
-   * Decodes a hexadecimal color string with an alpha component to a {@code Color} object. The accepted format is:
-   * <ul>
-   * <li>#AARRGGBB - For colors with alpha
-   * </ul>
-   * <p>
-   * If the `solid` parameter is true, the color alpha will create a darker version of the base color.
-   * </p>
-   * <p>
-   * Examples: <br>
-   * "#c8ff0000" = {@code new Color(255, 0, 0, 200)}
-   * </p>
-   *
-   * @param hexString The hexadecimal encoded color string representation with alpha.
-   * @param solid     If true, the color alpha will create a darker version of the base color.
-   * @return The decoded {@code Color} object, or null if the input string is invalid.
-   */
+  /// Decodes a hexadecimal color string with an alpha component to a `Color` object. The accepted format is:
+  ///
+  /// - #AARRGGBB - For colors with alpha
+  ///
+  /// If the `solid` parameter is true, the color alpha will create a darker version of the base color.
+  ///
+  /// Examples:
+  ///
+  /// "#c8ff0000" = `new Color(255, 0, 0, 200)`
+  ///
+  /// @param hexString The hexadecimal encoded color string representation with alpha.
+  /// @param solid     If true, the color alpha will create a darker version of the base color.
+  /// @return The decoded `Color` object, or null if the input string is invalid.
   private static Color decodeHexStringWithAlpha(String hexString, boolean solid) {
     String alpha = hexString.substring(1, 3);
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/CommandManager.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/CommandManager.java
@@ -10,29 +10,23 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Manages the binding and execution of commands. Implements the ILaunchable interface to provide start and terminate functionality.
- */
+/// Manages the binding and execution of commands. Implements the ILaunchable interface to provide start and terminate functionality.
 public class CommandManager implements ILaunchable {
   private static final Logger log = Logger.getLogger(CommandManager.class.getName());
   private final Map<String, Predicate<String[]>> commandConsumers;
   private final ConsoleCommandProcessor commandListener;
 
-  /**
-   * Constructs a new CommandManager. Initializes the commandConsumers map and the commandListener.
-   */
+  /// Constructs a new CommandManager. Initializes the commandConsumers map and the commandListener.
   public CommandManager() {
     this.commandConsumers = new ConcurrentHashMap<>();
     this.commandListener = new ConsoleCommandProcessor();
   }
 
-  /**
-   * Binds a command to a specific consumer. If the command is already bound, an IllegalArgumentException is thrown.
-   *
-   * @param command         the command to bind
-   * @param commandConsumer the consumer to bind to the command
-   * @throws IllegalArgumentException if the command is already bound
-   */
+  /// Binds a command to a specific consumer. If the command is already bound, an IllegalArgumentException is thrown.
+  ///
+  /// @param command         the command to bind
+  /// @param commandConsumer the consumer to bind to the command
+  /// @throws IllegalArgumentException if the command is already bound
   public void bind(final String command, final Predicate<String[]> commandConsumer) {
     if (this.commandConsumers.containsKey(command)) {
       throw new IllegalArgumentException(
@@ -42,13 +36,11 @@ public class CommandManager implements ILaunchable {
     this.commandConsumers.put(command, commandConsumer);
   }
 
-  /**
-   * Executes a command by finding the corresponding consumer and passing the command arguments to it. If the command is null, empty, or not bound to
-   * any consumer, it returns false.
-   *
-   * @param command the command to execute
-   * @return true if the command was successfully executed, false otherwise
-   */
+  /// Executes a command by finding the corresponding consumer and passing the command arguments to it. If the command is null, empty, or not bound to
+  /// any consumer, it returns false.
+  ///
+  /// @param command the command to execute
+  /// @return true if the command was successfully executed, false otherwise
   public boolean executeCommand(final String command) {
     if (command == null || command.isEmpty()) {
       return false;
@@ -78,9 +70,7 @@ public class CommandManager implements ILaunchable {
     this.commandListener.terminate();
   }
 
-  /**
-   * A processor for handling console commands. Runs in a virtual thread and listens for commands from the console input.
-   */
+  /// A processor for handling console commands. Runs in a virtual thread and listens for commands from the console input.
   private class ConsoleCommandProcessor {
     private Thread virtualThread;
 
@@ -88,16 +78,12 @@ public class CommandManager implements ILaunchable {
 
     }
 
-    /**
-     * Starts the CommandManager by initiating the command listener.
-     */
+    /// Starts the CommandManager by initiating the command listener.
     public void start() {
       virtualThread = Thread.ofVirtual().start(this::run);
     }
 
-    /**
-     * Listens for commands from the console input and executes them. Runs in a loop until the thread is interrupted.
-     */
+    /// Listens for commands from the console input and executes them. Runs in a loop until the thread is interrupted.
     public void run() {
       final Scanner scanner = new Scanner(System.in);
       while (!Thread.currentThread().isInterrupted()) {
@@ -116,9 +102,7 @@ public class CommandManager implements ILaunchable {
       scanner.close();
     }
 
-    /**
-     * Terminates the CommandManager by interrupting the command listener thread.
-     */
+    /// Terminates the CommandManager by interrupting the command listener thread.
     public void terminate() {
       if (virtualThread != null) {
         virtualThread.interrupt();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/FontUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/FontUtilities.java
@@ -2,27 +2,21 @@ package de.gurkenlabs.litiengine.util;
 
 import java.awt.Font;
 
-/**
- * Utility class for font-related operations.
- */
+/// Utility class for font-related operations.
 public class FontUtilities {
 
-  /**
-   * Private constructor to prevent instantiation. Throws UnsupportedOperationException if called.
-   */
+  /// Private constructor to prevent instantiation. Throws UnsupportedOperationException if called.
   private FontUtilities() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Returns a fallback font if the primary font cannot display the specified string.
-   *
-   * @param stringToWrite the string to be displayed
-   * @param textSize      the size of the text
-   * @param primaryFont   the primary font to be used
-   * @param fallbackFont  the fallback font to be used if the primary font cannot display the string
-   * @return the primary font if it can display the string, otherwise the fallback font
-   */
+  /// Returns a fallback font if the primary font cannot display the specified string.
+  ///
+  /// @param stringToWrite the string to be displayed
+  /// @param textSize      the size of the text
+  /// @param primaryFont   the primary font to be used
+  /// @param fallbackFont  the fallback font to be used if the primary font cannot display the string
+  /// @return the primary font if it can display the string, otherwise the fallback font
   public static Font getFallbackFontIfNecessary(
     final String stringToWrite,
     final float textSize,

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/Imaging.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/Imaging.java
@@ -30,9 +30,7 @@ import java.util.Objects;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 
-/**
- * Utility class for various image processing operations. This class only provides static helper methods and cannot be instantiated.
- */
+/// Utility class for various image processing operations. This class only provides static helper methods and cannot be instantiated.
 public final class Imaging {
 
   public static final int CROP_ALIGN_CENTER = 0;
@@ -50,15 +48,13 @@ public final class Imaging {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Adds a shadow effect by executing the following steps: 1. Transform visible pixels to a semi-transparent black 2. Flip the image vertically 3.
-   * Scale it down 4. Render original image and shadow on a buffered image
-   *
-   * @param image   the image
-   * @param xOffset the x offset
-   * @param yOffset the y offset
-   * @return the buffered image
-   */
+  /// Adds a shadow effect by executing the following steps: 1. Transform visible pixels to a semi-transparent black 2. Flip the image vertically 3.
+  /// Scale it down 4. Render original image and shadow on a buffered image
+  ///
+  /// @param image   the image
+  /// @param xOffset the x offset
+  /// @param yOffset the y offset
+  /// @return the buffered image
   public static BufferedImage addShadow(final BufferedImage image, final int xOffset, final int yOffset) {
     if (image == null) {
       return null;
@@ -97,13 +93,11 @@ public final class Imaging {
     return shadow;
   }
 
-  /**
-   * All pixels that have the specified color are rendered transparent.
-   *
-   * @param img   the img
-   * @param color the color
-   * @return the image
-   */
+  /// All pixels that have the specified color are rendered transparent.
+  ///
+  /// @param img   the img
+  /// @param color the color
+  /// @return the image
   public static BufferedImage applyAlphaChannel(final BufferedImage img, final Color color) {
     if (color == null || img == null) {
       return img;
@@ -130,14 +124,12 @@ public final class Imaging {
     return toBufferedImage(Toolkit.getDefaultToolkit().createImage(ip));
   }
 
-  /**
-   * Draw a stroke around an image in the given color.
-   *
-   * @param image       the input image
-   * @param strokeColor the stroke color
-   * @param borderOnly  decide whether only the border of the given image will be drawn
-   * @return the buffered image with a border drawn around it
-   */
+  /// Draw a stroke around an image in the given color.
+  ///
+  /// @param image       the input image
+  /// @param strokeColor the stroke color
+  /// @param borderOnly  decide whether only the border of the given image will be drawn
+  /// @return the buffered image with a border drawn around it
   public static BufferedImage borderAlpha(final BufferedImage image, final Color strokeColor, boolean borderOnly) {
     final BufferedImage bimage = getCompatibleImage(image.getWidth(null) + 2, image.getHeight(null) + 2);
     if (bimage == null) {
@@ -173,12 +165,10 @@ public final class Imaging {
     return bimage;
   }
 
-  /**
-   * Checks whether a given BufferedImage only has transparent pixels.
-   *
-   * @param image the image
-   * @return true if there are no coloured pixels in the image.
-   */
+  /// Checks whether a given BufferedImage only has transparent pixels.
+  ///
+  /// @param image the image
+  /// @return true if there are no coloured pixels in the image.
   public static boolean isEmpty(final BufferedImage image) {
     for (int y = 0; y < image.getHeight(); y++) {
       for (int x = 0; x < image.getWidth(); x++) {
@@ -192,13 +182,11 @@ public final class Imaging {
     return true;
   }
 
-  /**
-   * Checks whether two BufferedImages are equal.
-   *
-   * @param image1 the image 1
-   * @param image2 the image 2
-   * @return true if the images are equal
-   */
+  /// Checks whether two BufferedImages are equal.
+  ///
+  /// @param image1 the image 1
+  /// @param image2 the image 2
+  /// @return true if the images are equal
   public static boolean areEqual(final BufferedImage image1, final BufferedImage image2) {
     if (image1.getWidth() != image2.getWidth() || image1.getHeight() != image2.getHeight()) {
       return false;
@@ -215,27 +203,25 @@ public final class Imaging {
     return true;
   }
 
-  /**
-   * Crops a sub image from the specified image.
-   *
-   * @param image                 The image to crop the sub-image from.
-   * @param cropAlignment         use the following consts: <br>
-   *                              <ul>
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_CENTER CROP_ALIGN_CENTER}
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_LEFT CROP_ALIGN_LEFT}
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_RIGHT CROP_ALIGN_RIGHT}
-   *                              </ul>
-   * @param cropVerticlaAlignment use the following consts: <br>
-   *                              <ul>
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_CENTER CROP_VALIGN_CENTER}
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_TOP CROP_VALIGN_TOP}
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_TOPCENTER CROP_VALIGN_TOPCENTER}
-   *                              <li>{@link de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_BOTTOM CROP_VALIGN_BOTTOM}
-   *                              </ul>
-   * @param width                 The width to crop.
-   * @param height                The height to crop.
-   * @return The cropped image or the original image if it is smaller than the specified dimensions.
-   */
+  /// Crops a sub image from the specified image.
+  ///
+  /// @param image                 The image to crop the sub-image from.
+  /// @param cropAlignment         use the following consts:
+  ///
+  /// - [CROP_ALIGN_CENTER][de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_CENTER]
+  /// - [CROP_ALIGN_LEFT][de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_LEFT]
+  /// - [CROP_ALIGN_RIGHT][de.gurkenlabs.litiengine.util.Imaging#CROP_ALIGN_RIGHT]
+  ///
+  /// @param cropVerticlaAlignment use the following consts:
+  ///
+  /// - [CROP_VALIGN_CENTER][de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_CENTER]
+  /// - [CROP_VALIGN_TOP][de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_TOP]
+  /// - [CROP_VALIGN_TOPCENTER][de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_TOPCENTER]
+  /// - [CROP_VALIGN_BOTTOM][de.gurkenlabs.litiengine.util.Imaging#CROP_VALIGN_BOTTOM]
+  ///
+  /// @param width                 The width to crop.
+  /// @param height                The height to crop.
+  /// @return The cropped image or the original image if it is smaller than the specified dimensions.
   public static BufferedImage crop(final BufferedImage image, final int cropAlignment, final int cropVerticlaAlignment, final int width,
     final int height) {
     if (width > image.getWidth() || height > image.getHeight()) {
@@ -258,13 +244,11 @@ public final class Imaging {
     return image.getSubimage(x, y, width, height);
   }
 
-  /**
-   * All pixels that are not transparent are replaced by a pixel of the specified flashColor.
-   *
-   * @param image      the image
-   * @param flashColor the flash color
-   * @return the buffered image
-   */
+  /// All pixels that are not transparent are replaced by a pixel of the specified flashColor.
+  ///
+  /// @param image      the image
+  /// @param flashColor the flash color
+  /// @return the buffered image
   public static BufferedImage flashVisiblePixels(final Image image, final Color flashColor) {
     final BufferedImage bimage = getCompatibleImage(image.getWidth(null), image.getHeight(null));
     if (bimage == null) {
@@ -288,38 +272,31 @@ public final class Imaging {
     return bimage;
   }
 
-  /**
-   * Flip the individual sprites in a {@link Spritesheet} horizontally and return an image from which a new {@link Spritesheet} can be created.
-   *
-   * @param sprite the spritesheet
-   * @return a {@link BufferedImage} containing the horizontally flipped sprites
-   */
+  /// Flip the individual sprites in a [Spritesheet] horizontally and return an image from which a new [Spritesheet] can be created.
+  ///
+  /// @param sprite the spritesheet
+  /// @return a [BufferedImage] containing the horizontally flipped sprites
   public static BufferedImage flipSpritesHorizontally(final Spritesheet sprite) {
     return flipSprites(sprite, Imaging::horizontalFlip);
   }
 
-  /**
-   * Flip the individual sprites in a {@link Spritesheet} vertically and return an image from which a new {@link Spritesheet} can be created.
-   *
-   * @param sprite the spritesheet
-   * @return a {@link BufferedImage} containing the vertically flipped sprites
-   */
+  /// Flip the individual sprites in a [Spritesheet] vertically and return an image from which a new [Spritesheet] can be created.
+  ///
+  /// @param sprite the spritesheet
+  /// @return a [BufferedImage] containing the vertically flipped sprites
   public static BufferedImage flipSpritesVertically(final Spritesheet sprite) {
     return flipSprites(sprite, Imaging::verticalFlip);
   }
 
-  /**
-   * Generates a 9-slice scaled image from a given image in the given dimensions.
-   *
-   * @param image        the input image used for slicing. Will be sliced into 3 rows and 3 columns (@see <a
-   *                     href="https://en.wikipedia.org/wiki/9-slice_scaling">9-slice scaling</a>).
-   * @param sliceWidth   the slice width of the input image
-   * @param sliceHeight  the slice width of the input image
-   * @param targetWidth  the target width of the output image
-   * @param targetHeight the target height of the output image
-   * @param scaleFactor  the factor by which the individual slices will be resized
-   * @return a new BufferedImage with the scaled slices put together
-   */
+  /// Generates a 9-slice scaled image from a given image in the given dimensions.
+  ///
+  /// @param image        the input image used for slicing. Will be sliced into 3 rows and 3 columns (@see [9-slice scaling](https://en.wikipedia.org/wiki/9-slice_scaling)).
+  /// @param sliceWidth   the slice width of the input image
+  /// @param sliceHeight  the slice width of the input image
+  /// @param targetWidth  the target width of the output image
+  /// @param targetHeight the target height of the output image
+  /// @param scaleFactor  the factor by which the individual slices will be resized
+  /// @return a new BufferedImage with the scaled slices put together
   public static BufferedImage nineSlice(final BufferedImage image, int sliceWidth, int sliceHeight, int targetWidth, int targetHeight,
     float scaleFactor) {
     int targetSliceWidth = (int) (sliceWidth * scaleFactor);
@@ -352,26 +329,21 @@ public final class Imaging {
     return img;
   }
 
-  /**
-   * Generates a 9-slice scaled image from a given spritesheet in the given dimensions.
-   *
-   * @param spritesheet  the spritesheet used for slicing. Will be sliced into 3 rows and 3 columns (@see <a
-   *                     href="https://en.wikipedia.org/wiki/9-slice_scaling">9-slice scaling</a>).
-   * @param targetWidth  the target width of the output image
-   * @param targetHeight the target height of the output image
-   * @param scaleFactor  the factor by which the individual slices will be resized
-   * @return a new BufferedImage with the scaled slices put together
-   */
+  /// Generates a 9-slice scaled image from a given spritesheet in the given dimensions.
+  ///
+  /// @param spritesheet  the spritesheet used for slicing. Will be sliced into 3 rows and 3 columns (@see [9-slice scaling](https://en.wikipedia.org/wiki/9-slice_scaling)).
+  /// @param targetWidth  the target width of the output image
+  /// @param targetHeight the target height of the output image
+  /// @param scaleFactor  the factor by which the individual slices will be resized
+  /// @return a new BufferedImage with the scaled slices put together
   public static BufferedImage nineSlice(final Spritesheet spritesheet, int targetWidth, int targetHeight, float scaleFactor) {
     return nineSlice(spritesheet.getImage(), spritesheet.getSpriteWidth(), spritesheet.getSpriteHeight(), targetWidth, targetHeight, scaleFactor);
   }
 
-  /**
-   * Creates a new {@code BufferedImage} instance from the specified image.
-   *
-   * @param image The image to be copied.
-   * @return A {@link BufferedImage} that is a copy of the input image.
-   */
+  /// Creates a new `BufferedImage` instance from the specified image.
+  ///
+  /// @param image The image to be copied.
+  /// @return A [BufferedImage] that is a copy of the input image.
   public static BufferedImage copy(BufferedImage image) {
     ColorModel cm = image.getColorModel();
     boolean isAlphaPremultiplied = cm.isAlphaPremultiplied();
@@ -379,13 +351,11 @@ public final class Imaging {
     return new BufferedImage(cm, raster, isAlphaPremultiplied, null);
   }
 
-  /**
-   * Gets an empty {@link BufferedImage} with the given size.
-   *
-   * @param width  the width
-   * @param height the height
-   * @return an empty {@link BufferedImage} with the given size
-   */
+  /// Gets an empty [BufferedImage] with the given size.
+  ///
+  /// @param width  the width
+  /// @param height the height
+  /// @return an empty [BufferedImage] with the given size
   public static BufferedImage getCompatibleImage(final int width, final int height) {
     if (width == 0 || height == 0) {
       return null;
@@ -404,15 +374,13 @@ public final class Imaging {
     return graphicsConfig.createCompatibleImage(width, height, Transparency.TRANSLUCENT);
   }
 
-  /**
-   * Gets a two dimensional grid that contains parts of the specified image. Splits up the specified image into a grid with the defined number of rows
-   * and columns.
-   *
-   * @param image the image
-   * @param rows  the rows
-   * @param columns the columns
-   * @return the two dimensional array containing the sub-images
-   */
+  /// Gets a two dimensional grid that contains parts of the specified image. Splits up the specified image into a grid with the defined number of rows
+  /// and columns.
+  ///
+  /// @param image the image
+  /// @param rows  the rows
+  /// @param columns the columns
+  /// @return the two dimensional array containing the sub-images
   public static BufferedImage[][] getSubImages(final BufferedImage image, final int rows, final int columns) {
     if (image == null || rows <= 0 || columns <= 0) {
       return new BufferedImage[0][0];
@@ -433,12 +401,10 @@ public final class Imaging {
     return smallImages;
   }
 
-  /**
-   * Flips the specified image horizontally.
-   *
-   * @param img The image to be flipped.
-   * @return The horizontally flipped image.
-   */
+  /// Flips the specified image horizontally.
+  ///
+  /// @param img The image to be flipped.
+  /// @return The horizontally flipped image.
   public static BufferedImage horizontalFlip(final BufferedImage img) {
     if (img == null) {
       return null;
@@ -456,12 +422,10 @@ public final class Imaging {
     return dimg;
   }
 
-  /**
-   * Flips the specified image vertically.
-   *
-   * @param img The image to be flipped.
-   * @return The vertically flipped image.
-   */
+  /// Flips the specified image vertically.
+  ///
+  /// @param img The image to be flipped.
+  /// @return The vertically flipped image.
   public static BufferedImage verticalFlip(final BufferedImage img) {
     if (img == null) {
       return null;
@@ -479,13 +443,11 @@ public final class Imaging {
     return dimg;
   }
 
-  /**
-   * Replace colors in an image according to a Map containing source colors and target colors, then return the result.
-   *
-   * @param bufferedImage the original image
-   * @param colorMappings a Map with source colors as keys and target colors as values
-   * @return a new version of the original image, where the source colors are replaced with the target colors.
-   */
+  /// Replace colors in an image according to a Map containing source colors and target colors, then return the result.
+  ///
+  /// @param bufferedImage the original image
+  /// @param colorMappings a Map with source colors as keys and target colors as values
+  /// @return a new version of the original image, where the source colors are replaced with the target colors.
   public static BufferedImage replaceColors(final BufferedImage bufferedImage, Map<Color, Color> colorMappings) {
     BufferedImage recoloredImage = copy(bufferedImage);
     for (Entry<Color, Color> c : colorMappings.entrySet()) {
@@ -501,24 +463,20 @@ public final class Imaging {
     return recoloredImage;
   }
 
-  /**
-   * Rotate a given {@link BufferedImage} by a given {@link Rotation}.
-   *
-   * @param bufferedImage the input image
-   * @param rotation      the amount of {@link Rotation}
-   * @return the rotated {@link BufferedImage}
-   */
+  /// Rotate a given [BufferedImage] by a given [Rotation].
+  ///
+  /// @param bufferedImage the input image
+  /// @param rotation      the amount of [Rotation]
+  /// @return the rotated [BufferedImage]
   public static BufferedImage rotate(final BufferedImage bufferedImage, final Rotation rotation) {
     return rotate(bufferedImage, rotation.getRadians());
   }
 
-  /**
-   * Rotate a {@link BufferedImage} by a given rotation.
-   *
-   * @param bufferedImage the input image
-   * @param radians       the amount of rotation in radians.
-   * @return the rotated {@link BufferedImage}
-   */
+  /// Rotate a [BufferedImage] by a given rotation.
+  ///
+  /// @param bufferedImage the input image
+  /// @param radians       the amount of rotation in radians.
+  /// @return the rotated [BufferedImage]
   public static BufferedImage rotate(final BufferedImage bufferedImage, final double radians) {
     double sin = Math.abs(Math.sin(radians));
     double cos = Math.abs(Math.cos(radians));
@@ -544,151 +502,133 @@ public final class Imaging {
     return bimg;
   }
 
-  /**
-   * Scale buffered image so that the longer edge of the image will be set to a given maximum.
-   *
-   * @param image the input {@link BufferedImage} to be scaled
-   * @param max   the maximum length of the longer image edge
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image so that the longer edge of the image will be set to a given maximum.
+  ///
+  /// @param image the input [BufferedImage] to be scaled
+  /// @param max   the maximum length of the longer image edge
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int max) {
     Dimension2D newDimension = GeometricUtilities.scaleWithRatio(image.getWidth(), image.getHeight(), max);
     return scale(image, (int) Objects.requireNonNull(newDimension).getWidth(), (int) Objects.requireNonNull(newDimension).getHeight());
   }
 
-  /**
-   * Scale buffered image by multiplying its width and height with a given factor. By default, {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used
-   * for scaling. If you want smooth interpolation, use one of the method overloads with a custom interpolation parameter.
-   *
-   * @param image  the input {@link BufferedImage} to be scaled
-   * @param factor the factor by which the image width and height will be multiplied
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image by multiplying its width and height with a given factor. By default, [AffineTransformOp#TYPE_NEAREST_NEIGHBOR] is used
+  /// for scaling. If you want smooth interpolation, use one of the method overloads with a custom interpolation parameter.
+  ///
+  /// @param image  the input [BufferedImage] to be scaled
+  /// @param factor the factor by which the image width and height will be multiplied
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final double factor) {
     return scale(image, factor, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
   }
 
-  /**
-   * Scale buffered image by multiplying its width and height with a given factor. This default overload will not generate white space around the
-   * scaled image to match the full target dimensions.
-   *
-   * @param image         the input {@link BufferedImage} to be scaled
-   * @param factor        the factor by which the image width and height will be multiplied
-   * @param interpolation the interpolation mode used for scaling. Choose one of the following:
-   *                      <ul>
-   *                      <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
-   *                      <li>{@link AffineTransformOp#TYPE_BILINEAR}
-   *                      <li>{@link AffineTransformOp#TYPE_BICUBIC}
-   *                      </ul>
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image by multiplying its width and height with a given factor. This default overload will not generate white space around the
+  /// scaled image to match the full target dimensions.
+  ///
+  /// @param image         the input [BufferedImage] to be scaled
+  /// @param factor        the factor by which the image width and height will be multiplied
+  /// @param interpolation the interpolation mode used for scaling. Choose one of the following:
+  ///
+  /// - [AffineTransformOp#TYPE_NEAREST_NEIGHBOR]
+  /// - [AffineTransformOp#TYPE_BILINEAR]
+  /// - [AffineTransformOp#TYPE_BICUBIC]
+  ///
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final double factor, final int interpolation) {
     return image == null
       ? null
       : scale(image, (int) Math.ceil(image.getWidth() * factor), (int) Math.ceil(image.getHeight() * factor), interpolation);
   }
 
-  /**
-   * Scale buffered image. The original image ratio will be kept. By default, {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If
-   * you want smooth interpolation, use one of the method overloads with a custom interpolation parameter. This default overload will not generate
-   * white space around the scaled image to match the full target dimensions.
-   *
-   * @param image  the input {@link BufferedImage} to be scaled
-   * @param width  the width of the scaled image in pixels
-   * @param height the height of the scaled image in pixels
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image. The original image ratio will be kept. By default, [AffineTransformOp#TYPE_NEAREST_NEIGHBOR] is used for scaling. If
+  /// you want smooth interpolation, use one of the method overloads with a custom interpolation parameter. This default overload will not generate
+  /// white space around the scaled image to match the full target dimensions.
+  ///
+  /// @param image  the input [BufferedImage] to be scaled
+  /// @param width  the width of the scaled image in pixels
+  /// @param height the height of the scaled image in pixels
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int width, final int height) {
     return scale(image, width, height, AffineTransformOp.TYPE_NEAREST_NEIGHBOR, false, false);
   }
 
 
-  /**
-   * Scale buffered image. By default, {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If you want smooth interpolation, use one
-   * of the method overloads with a custom interpolation parameter. This default overload will not generate white space around the scaled image to
-   * match the full target dimensions.
-   *
-   * @param image     the input {@link BufferedImage} to be scaled
-   * @param width     the width of the scaled image in pixels
-   * @param height    the height of the scaled image in pixels
-   * @param keepRatio determines whether the original image ratio should be kept while scaling.
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image. By default, [AffineTransformOp#TYPE_NEAREST_NEIGHBOR] is used for scaling. If you want smooth interpolation, use one
+  /// of the method overloads with a custom interpolation parameter. This default overload will not generate white space around the scaled image to
+  /// match the full target dimensions.
+  ///
+  /// @param image     the input [BufferedImage] to be scaled
+  /// @param width     the width of the scaled image in pixels
+  /// @param height    the height of the scaled image in pixels
+  /// @param keepRatio determines whether the original image ratio should be kept while scaling.
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int width, final int height, final boolean keepRatio) {
     return scale(image, width, height, AffineTransformOp.TYPE_NEAREST_NEIGHBOR, keepRatio, false);
   }
 
-  /**
-   * Scale buffered image. By default, {@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR} is used for scaling. If you want smooth interpolation, use one
-   * of the method overloads with a custom interpolation parameter.
-   *
-   * @param image     the input {@link BufferedImage} to be scaled
-   * @param width     the width of the scaled image in pixels
-   * @param height    the height of the scaled image in pixels
-   * @param keepRatio determines whether the original image ratio should be kept while scaling.
-   * @param fill      determines whether the target image should contain the transparent space around the scaled image to fill the full target
-   *                  dimensions.
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image. By default, [AffineTransformOp#TYPE_NEAREST_NEIGHBOR] is used for scaling. If you want smooth interpolation, use one
+  /// of the method overloads with a custom interpolation parameter.
+  ///
+  /// @param image     the input [BufferedImage] to be scaled
+  /// @param width     the width of the scaled image in pixels
+  /// @param height    the height of the scaled image in pixels
+  /// @param keepRatio determines whether the original image ratio should be kept while scaling.
+  /// @param fill      determines whether the target image should contain the transparent space around the scaled image to fill the full target
+  /// dimensions.
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int width, final int height, final boolean keepRatio, final boolean fill) {
     return scale(image, width, height, AffineTransformOp.TYPE_NEAREST_NEIGHBOR, keepRatio, fill);
   }
 
-  /**
-   * Scale buffered image. This default overload will not generate white space around the scaled image to match the full target dimensions.
-   *
-   * @param image         the input {@link BufferedImage} to be scaled
-   * @param width         the width of the scaled image in pixels
-   * @param height        the height of the scaled image in pixels
-   * @param interpolation the interpolation mode used for scaling. Choose one of the following:
-   *                      <ul>
-   *                      <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
-   *                      <li>{@link AffineTransformOp#TYPE_BILINEAR}
-   *                      <li>{@link AffineTransformOp#TYPE_BICUBIC}
-   *                      </ul>
-   * @param keepRatio     determines whether the original image ratio should be kept while scaling.
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image. This default overload will not generate white space around the scaled image to match the full target dimensions.
+  ///
+  /// @param image         the input [BufferedImage] to be scaled
+  /// @param width         the width of the scaled image in pixels
+  /// @param height        the height of the scaled image in pixels
+  /// @param interpolation the interpolation mode used for scaling. Choose one of the following:
+  ///
+  /// - [AffineTransformOp#TYPE_NEAREST_NEIGHBOR]
+  /// - [AffineTransformOp#TYPE_BILINEAR]
+  /// - [AffineTransformOp#TYPE_BICUBIC]
+  ///
+  /// @param keepRatio     determines whether the original image ratio should be kept while scaling.
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int width, final int height, final int interpolation, final boolean keepRatio) {
     return scale(image, width, height, interpolation, keepRatio, false);
   }
 
-  /**
-   * Scale buffered image. This default overload will keep the original image ratio and not generate white space around the scaled image to match the
-   * full target dimensions.
-   *
-   * @param image         the input {@link BufferedImage} to be scaled
-   * @param width         the width of the scaled image in pixels
-   * @param height        the height of the scaled image in pixels
-   * @param interpolation the interpolation mode used for scaling. Choose one of the following:
-   *                      <ul>
-   *                      <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
-   *                      <li>{@link AffineTransformOp#TYPE_BILINEAR}
-   *                      <li>{@link AffineTransformOp#TYPE_BICUBIC}
-   *                      </ul>
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image. This default overload will keep the original image ratio and not generate white space around the scaled image to match the
+  /// full target dimensions.
+  ///
+  /// @param image         the input [BufferedImage] to be scaled
+  /// @param width         the width of the scaled image in pixels
+  /// @param height        the height of the scaled image in pixels
+  /// @param interpolation the interpolation mode used for scaling. Choose one of the following:
+  ///
+  /// - [AffineTransformOp#TYPE_NEAREST_NEIGHBOR]
+  /// - [AffineTransformOp#TYPE_BILINEAR]
+  /// - [AffineTransformOp#TYPE_BICUBIC]
+  ///
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int width, final int height, final int interpolation) {
     return scale(image, width, height, interpolation, true, false);
   }
 
-  /**
-   * Scale buffered image.
-   *
-   * @param image         the input {@link BufferedImage} to be scaled
-   * @param width         the width of the scaled image in pixels
-   * @param height        the height of the scaled image in pixels
-   * @param interpolation the interpolation mode used for scaling. Choose one of the following:
-   *                      <ul>
-   *                      <li>{@link AffineTransformOp#TYPE_NEAREST_NEIGHBOR}
-   *                      <li>{@link AffineTransformOp#TYPE_BILINEAR}
-   *                      <li>{@link AffineTransformOp#TYPE_BICUBIC}
-   *                      </ul>
-   * @param keepRatio     determines whether the original image ratio should be kept while scaling.
-   * @param fill          determines whether the target image should contain the transparent space around the scaled image to fill the full target
-   *                      dimensions.
-   * @return the scaled {@link BufferedImage}.
-   */
+  /// Scale buffered image.
+  ///
+  /// @param image         the input [BufferedImage] to be scaled
+  /// @param width         the width of the scaled image in pixels
+  /// @param height        the height of the scaled image in pixels
+  /// @param interpolation the interpolation mode used for scaling. Choose one of the following:
+  ///
+  /// - [AffineTransformOp#TYPE_NEAREST_NEIGHBOR]
+  /// - [AffineTransformOp#TYPE_BILINEAR]
+  /// - [AffineTransformOp#TYPE_BICUBIC]
+  ///
+  /// @param keepRatio     determines whether the original image ratio should be kept while scaling.
+  /// @param fill          determines whether the target image should contain the transparent space around the scaled image to fill the full target
+  /// dimensions.
+  /// @return the scaled [BufferedImage].
   public static BufferedImage scale(final BufferedImage image, final int width, final int height, final int interpolation, final boolean keepRatio,
     final boolean fill) {
     if (width == 0 || height == 0 || image == null) {
@@ -736,14 +676,12 @@ public final class Imaging {
     return newImg;
   }
 
-  /**
-   * Sets the opacity of a given image.
-   *
-   * @param img   the original {@link Image}
-   * @param alpha the constant alpha to be multiplied with the alpha of the source. alpha must be a floating point number in the inclusive range [0.0,
-   *              1.0].
-   * @return the {@link BufferedImage} produced by applying the given alpha on the source image
-   */
+  /// Sets the opacity of a given image.
+  ///
+  /// @param img   the original [Image]
+  /// @param alpha the constant alpha to be multiplied with the alpha of the source. alpha must be a floating point number in the inclusive range [0.0,
+  /// 1.0].
+  /// @return the [BufferedImage] produced by applying the given alpha on the source image
   public static BufferedImage setAlpha(final Image img, final float alpha) {
     if (img == null) {
       return null;
@@ -762,12 +700,10 @@ public final class Imaging {
     return bimage;
   }
 
-  /**
-   * Converts a given {@link Image} instance to a {@link BufferedImage}.
-   *
-   * @param img the original {@link Image}
-   * @return the {@link BufferedImage} produced from the original {@link Image}
-   */
+  /// Converts a given [Image] instance to a [BufferedImage].
+  ///
+  /// @param img the original [Image]
+  /// @return the [BufferedImage] produced from the original [Image]
   public static BufferedImage toBufferedImage(final Image img) {
     if (img == null) {
       return null;
@@ -789,12 +725,10 @@ public final class Imaging {
     return bimage;
   }
 
-  /**
-   * Creates a compatible buffered image that contains the source image.
-   *
-   * @param image the source image
-   * @return the compatible buffered image
-   */
+  /// Creates a compatible buffered image that contains the source image.
+  ///
+  /// @param image the source image
+  /// @return the compatible buffered image
   public static BufferedImage toCompatibleImage(final BufferedImage image) {
     if (image == null || image.getWidth() == 0 || image.getHeight() == 0) {
       return image;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ListUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ListUtilities.java
@@ -3,32 +3,26 @@ package de.gurkenlabs.litiengine.util;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Utility class for various list operations. This class cannot be instantiated.
- */
+/// Utility class for various list operations. This class cannot be instantiated.
 public class ListUtilities {
   private ListUtilities() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Checks if the list contains an instance of the specified class.
-   *
-   * @param <E>   the type of elements in the list
-   * @param list  the list to check
-   * @param clazz the class to check for instances of
-   * @return true if the list contains an instance of the specified class, false otherwise
-   */
+  /// Checks if the list contains an instance of the specified class.
+  ///
+  /// @param <E>   the type of elements in the list
+  /// @param list  the list to check
+  /// @param clazz the class to check for instances of
+  /// @return true if the list contains an instance of the specified class, false otherwise
   public static <E> boolean containsInstance(final List<E> list, final Class<? extends E> clazz) {
     return list.stream().anyMatch(clazz::isInstance);
   }
 
-  /**
-   * Converts an array of int values to a list of Integer objects.
-   *
-   * @param values the array of int values
-   * @return a list of Integer objects
-   */
+  /// Converts an array of int values to a list of Integer objects.
+  ///
+  /// @param values the array of int values
+  /// @return a list of Integer objects
   public static List<Integer> getIntList(int... values) {
     return Arrays.stream(values).boxed().toList();
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/MathUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/MathUtilities.java
@@ -4,49 +4,39 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Arrays;
 
-/**
- * Utility class for mathematical operations.
- */
+/// Utility class for mathematical operations.
 public class MathUtilities {
-  /**
-   * Private constructor to prevent instantiation.
-   * Throws UnsupportedOperationException if called.
-   */
+  /// Private constructor to prevent instantiation.
+  /// Throws UnsupportedOperationException if called.
   private MathUtilities() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Checks if two double values are equal within a given epsilon.
-   *
-   * @param d1 the first double value
-   * @param d2 the second double value
-   * @param epsilon the tolerance within which the two values are considered equal
-   * @return true if the absolute difference between d1 and d2 is less than or equal to epsilon, false otherwise
-   */
+  /// Checks if two double values are equal within a given epsilon.
+  ///
+  /// @param d1 the first double value
+  /// @param d2 the second double value
+  /// @param epsilon the tolerance within which the two values are considered equal
+  /// @return true if the absolute difference between d1 and d2 is less than or equal to epsilon, false otherwise
   public static boolean equals(double d1, double d2, double epsilon) {
     return Math.abs(d1 - d2) <= epsilon;
   }
 
-  /**
-   * Rounds a float value to the specified number of decimal places.
-   *
-   * @param value the float value to be rounded
-   * @param places the number of decimal places to round to
-   * @return the rounded float value
-   */
+  /// Rounds a float value to the specified number of decimal places.
+  ///
+  /// @param value the float value to be rounded
+  /// @param places the number of decimal places to round to
+  /// @return the rounded float value
   public static float round(float value, int places) {
     return (float) round((double) value, places);
   }
 
-  /**
-   * Rounds a double value to the specified number of decimal places.
-   *
-   * @param value the double value to be rounded
-   * @param places the number of decimal places to round to
-   * @return the rounded double value
-   * @throws IllegalArgumentException if the number of decimal places is negative
-   */
+  /// Rounds a double value to the specified number of decimal places.
+  ///
+  /// @param value the double value to be rounded
+  /// @param places the number of decimal places to round to
+  /// @return the rounded double value
+  /// @throws IllegalArgumentException if the number of decimal places is negative
   public static double round(double value, int places) {
     if (places < 0) {
       throw new IllegalArgumentException();
@@ -57,22 +47,18 @@ public class MathUtilities {
     return bd.doubleValue();
   }
 
-  /**
-   * Calculates the average of an array of double values.
-   *
-   * @param numbers the array of double values
-   * @return the average of the values in the array
-   */
+  /// Calculates the average of an array of double values.
+  ///
+  /// @param numbers the array of double values
+  /// @return the average of the values in the array
   public static double getAverage(final double[] numbers) {
     return Arrays.stream(numbers).average().orElse(0);
   }
 
-  /**
-   * Calculates the average of an array of float values.
-   *
-   * @param numbers the array of float values
-   * @return the average of the values in the array
-   */
+  /// Calculates the average of an array of float values.
+  ///
+  /// @param numbers the array of float values
+  /// @return the average of the values in the array
   public static float getAverage(final float[] numbers) {
     float sum = 0;
     for (final float number : numbers) {
@@ -84,53 +70,43 @@ public class MathUtilities {
     return sum / numbers.length;
   }
 
-  /**
-   * Calculates the average of an array of int values.
-   *
-   * @param numbers the array of int values
-   * @return the average of the values in the array
-   */
+  /// Calculates the average of an array of int values.
+  ///
+  /// @param numbers the array of int values
+  /// @return the average of the values in the array
   public static double getAverage(final int[] numbers) {
     return Arrays.stream(numbers).average().orElse(0);
   }
 
-  /**
-   * Finds the maximum value in an array of int values.
-   *
-   * @param numbers the array of int values
-   * @return the maximum value in the array
-   */
+  /// Finds the maximum value in an array of int values.
+  ///
+  /// @param numbers the array of int values
+  /// @return the maximum value in the array
   public static int getMax(final int... numbers) {
     return Arrays.stream(numbers).max().orElse(Integer.MIN_VALUE);
   }
 
-  /**
-   * Checks if a double value is an integer.
-   *
-   * @param value the double value to check
-   * @return true if the value is an integer, false otherwise
-   */
+  /// Checks if a double value is an integer.
+  ///
+  /// @param value the double value to check
+  /// @return true if the value is an integer, false otherwise
   public static boolean isInt(final double value) {
     return value == Math.floor(value) && !Double.isInfinite(value);
   }
 
-  /**
-   * Checks if an int value is an odd number.
-   *
-   * @param num the int value to check
-   * @return true if the value is odd, false otherwise
-   */
+  /// Checks if an int value is an odd number.
+  ///
+  /// @param num the int value to check
+  /// @return true if the value is odd, false otherwise
   public static boolean isOddNumber(int num) {
     return (num & 1) != 0;
   }
 
-  /**
-   * Calculates the percentage of a fraction relative to a value.
-   *
-   * @param value the total value
-   * @param fraction the fraction of the total value
-   * @return the percentage of the fraction relative to the total value
-   */
+  /// Calculates the percentage of a fraction relative to a value.
+  ///
+  /// @param value the total value
+  /// @param fraction the fraction of the total value
+  /// @return the percentage of the fraction relative to the total value
   public static int getFullPercent(double value, double fraction) {
     if (value == 0) {
       return 0;
@@ -139,13 +115,11 @@ public class MathUtilities {
     return (int) ((fraction * 100.0f) / value);
   }
 
-  /**
-   * Calculates the percentage of a fraction relative to a value.
-   *
-   * @param value the total value
-   * @param fraction the fraction of the total value
-   * @return the percentage of the fraction relative to the total value
-   */
+  /// Calculates the percentage of a fraction relative to a value.
+  ///
+  /// @param value the total value
+  /// @param fraction the fraction of the total value
+  /// @return the percentage of the fraction relative to the total value
   public static double getPercent(double value, double fraction) {
     if (value == 0) {
       return 0;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ReflectionUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/ReflectionUtilities.java
@@ -63,15 +63,13 @@ public final class ReflectionUtilities {
     }
   }
 
-  /**
-   * Recursively gets all fields of the specified type, respecting parent classes.
-   *
-   * @param fields
-   *          The list containing all fields.
-   * @param type
-   *          The type to retrieve the fields from.
-   * @return All fields of the specified type, including the fields of the parent classes.
-   */
+  /// Recursively gets all fields of the specified type, respecting parent classes.
+  ///
+  /// @param fields
+  /// The list containing all fields.
+  /// @param type
+  /// The type to retrieve the fields from.
+  /// @return All fields of the specified type, including the fields of the parent classes.
   public static List<Field> getAllFields(List<Field> fields, Class<?> type) {
     fields.addAll(Arrays.asList(type.getDeclaredFields()));
 
@@ -82,18 +80,16 @@ public final class ReflectionUtilities {
     return fields;
   }
 
-  /**
-   * Recursively gets a method by the specified name respecting the parent classes and the parameters of the
-   * declaration.
-   *
-   * @param name
-   *          The name of the method.
-   * @param type
-   *          The type on which to search for the method.
-   * @param parameterTypes
-   *          The types of the parameters defined by the method declaration.
-   * @return The found method or null if no such method exists.
-   */
+  /// Recursively gets a method by the specified name respecting the parent classes and the parameters of the
+  /// declaration.
+  ///
+  /// @param name
+  /// The name of the method.
+  /// @param type
+  /// The type on which to search for the method.
+  /// @param parameterTypes
+  /// The types of the parameters defined by the method declaration.
+  /// @return The found method or null if no such method exists.
   public static Method getMethod(String name, Class<?> type, Class<?>... parameterTypes) {
     Method method = null;
     try {
@@ -347,18 +343,15 @@ public final class ReflectionUtilities {
     return methods;
   }
 
-  /**
-   * Gets the events for the specified type.
-   *
-   * <p>
-   * This will search for all methods that have a parameter of type {@code EventListener} and match the LITIENGINE's
-   * naming conventions for event subscription (i.e. the method name starts with one of the prefixes "add" or "on".
-   *
-   * @param type
-   *          The type to inspect the events on.
-   * @return All methods on the specified type that are considered to be events.
-   * @see EventListener
-   */
+  /// Gets the events for the specified type.
+  ///
+  /// This will search for all methods that have a parameter of type `EventListener` and match the LITIENGINE's
+  /// naming conventions for event subscription (i.e. the method name starts with one of the prefixes "add" or "on".
+  ///
+  /// @param type
+  /// The type to inspect the events on.
+  /// @return All methods on the specified type that are considered to be events.
+  /// @see EventListener
   public static Collection<Method> getEvents(final Class<?> type) {
     final String eventAddPrefix = "add";
     final String eventOnPrefix = "on";

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/Stopwatch.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/Stopwatch.java
@@ -4,25 +4,19 @@ import java.util.function.LongConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Utility class for stopwatch-related operations.
- */
+/// Utility class for stopwatch-related operations.
 public final class Stopwatch {
   private static final Logger log = Logger.getLogger(Stopwatch.class.getName());
 
-  /**
-   * Private constructor to prevent instantiation. Throws UnsupportedOperationException if called.
-   */
+  /// Private constructor to prevent instantiation. Throws UnsupportedOperationException if called.
   private Stopwatch() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Tracks the execution time of a given operation and logs it to the console.
-   *
-   * @param name     the name of the operation being tracked
-   * @param consumer a LongConsumer that accepts the current time in nanoseconds
-   */
+  /// Tracks the execution time of a given operation and logs it to the console.
+  ///
+  /// @param name     the name of the operation being tracked
+  /// @param consumer a LongConsumer that accepts the current time in nanoseconds
   public static void trackInConsole(final String name, final LongConsumer consumer) {
     final long current = System.nanoTime();
     consumer.accept(current);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/TimeUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/TimeUtilities.java
@@ -2,72 +2,44 @@ package de.gurkenlabs.litiengine.util;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * Utility class for various time-related operations. This class cannot be instantiated.
- */
+/// Utility class for various time-related operations. This class cannot be instantiated.
 public final class TimeUtilities {
-  /**
-   * Enum representing various timer formats. Each format is associated with a specific format string.
-   */
+  /// Enum representing various timer formats. Each format is associated with a specific format string.
   public enum TimerFormat {
-    /**
-     * Undefined timer format.
-     */
+    /// Undefined timer format.
     UNDEFINED(null),
 
-    /**
-     * Timer format in hours, minutes, and seconds (HH:MM:SS).
-     */
+    /// Timer format in hours, minutes, and seconds (HH:MM:SS).
     HH_MM_SS("%02d:%02d:%02d"),
 
-    /**
-     * Timer format in minutes, seconds, and milliseconds (MM:SS.000).
-     */
+    /// Timer format in minutes, seconds, and milliseconds (MM:SS.000).
     MM_SS_000("%02d:%02d.%03d"),
 
-    /**
-     * Timer format in minutes, seconds, and tenths of a second (MM:SS.0).
-     */
+    /// Timer format in minutes, seconds, and tenths of a second (MM:SS.0).
     MM_SS_0("%02d:%02d.%01d"),
 
-    /**
-     * Timer format in seconds and milliseconds (SS.000).
-     */
+    /// Timer format in seconds and milliseconds (SS.000).
     SS_000("%02d.%03d"),
 
-    /**
-     * Timer format in seconds and hundredths of a second (SS.00).
-     */
+    /// Timer format in seconds and hundredths of a second (SS.00).
     SS_00("%02d.%02d"),
 
-    /**
-     * Timer format in seconds and tenths of a second (SS.0).
-     */
+    /// Timer format in seconds and tenths of a second (SS.0).
     SS_0("%02d.%01d"),
 
-    /**
-     * Timer format in seconds and milliseconds (S.000).
-     */
+    /// Timer format in seconds and milliseconds (S.000).
     S_000("%01d.%03d"),
 
-    /**
-     * Timer format in seconds and hundredths of a second (S.00).
-     */
+    /// Timer format in seconds and hundredths of a second (S.00).
     S_00("%01d.%02d"),
 
-    /**
-     * Timer format in seconds and tenths of a second (S.0).
-     */
+    /// Timer format in seconds and tenths of a second (S.0).
     S_0("%01d.%01d"),
 
-    /**
-     * Timer format in hours, minutes, seconds, and milliseconds (HH:MM:SS.000).
-     */
+    /// Timer format in hours, minutes, seconds, and milliseconds (HH:MM:SS.000).
     HH_MM_SS_000("%02d:%02d:%02d.%03d"),
 
-    /**
-     * Timer format in hours, minutes, seconds, and tenths of a second (HH:MM:SS.0).
-     */
+    /// Timer format in hours, minutes, seconds, and tenths of a second (HH:MM:SS.0).
     HH_MM_SS_0("%02d:%02d:%02d.%01d");
 
     private final String formatString;
@@ -85,113 +57,91 @@ public final class TimeUtilities {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Converts nanoseconds to milliseconds.
-   *
-   * @param nano the duration in nanoseconds
-   * @return the duration in milliseconds
-   */
+  /// Converts nanoseconds to milliseconds.
+  ///
+  /// @param nano the duration in nanoseconds
+  /// @return the duration in milliseconds
   public static double nanoToMs(final long nano) {
     return nano / 1000000.0;
   }
 
-  /**
-   * Converts milliseconds to days.
-   *
-   * @param ms the duration in milliseconds
-   * @return the duration in days
-   */
+  /// Converts milliseconds to days.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the duration in days
   public static long getDays(final long ms) {
     return TimeUnit.MILLISECONDS.toDays(ms);
   }
 
-  /**
-   * Converts milliseconds to hours.
-   *
-   * @param ms the duration in milliseconds
-   * @return the duration in hours
-   */
+  /// Converts milliseconds to hours.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the duration in hours
   public static long getHours(final long ms) {
     return TimeUnit.MILLISECONDS.toHours(ms);
   }
 
-  /**
-   * Converts milliseconds to minutes.
-   *
-   * @param ms the duration in milliseconds
-   * @return the duration in minutes
-   */
+  /// Converts milliseconds to minutes.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the duration in minutes
   public static long getMinutes(final long ms) {
     return TimeUnit.MILLISECONDS.toMinutes(ms);
   }
 
-  /**
-   * Converts milliseconds to seconds.
-   *
-   * @param ms the duration in milliseconds
-   * @return the duration in seconds
-   */
+  /// Converts milliseconds to seconds.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the duration in seconds
   public static long getSeconds(final long ms) {
     return TimeUnit.MILLISECONDS.toSeconds(ms);
   }
 
-  /**
-   * Gets the remaining days from the given milliseconds.
-   *
-   * @param ms the duration in milliseconds
-   * @return the remaining days
-   */
+  /// Gets the remaining days from the given milliseconds.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the remaining days
   public static long getRemainingDays(final long ms) {
     return ms / 1000 / 60 / 60 / 24 % 365;
   }
 
-  /**
-   * Gets the remaining hours from the given milliseconds.
-   *
-   * @param ms the duration in milliseconds
-   * @return the remaining hours
-   */
+  /// Gets the remaining hours from the given milliseconds.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the remaining hours
   public static long getRemainingHours(final long ms) {
     return ms / 1000 / 60 / 60 % 24;
   }
 
-  /**
-   * Gets the remaining minutes from the given milliseconds.
-   *
-   * @param ms the duration in milliseconds
-   * @return the remaining minutes
-   */
+  /// Gets the remaining minutes from the given milliseconds.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the remaining minutes
   public static long getRemainingMinutes(final long ms) {
     return ms / 1000 / 60 % 60;
   }
 
-  /**
-   * Gets the remaining seconds from the given milliseconds.
-   *
-   * @param ms the duration in milliseconds
-   * @return the remaining seconds
-   */
+  /// Gets the remaining seconds from the given milliseconds.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the remaining seconds
   public static long getRemainingSeconds(final long ms) {
     return ms / 1000 % 60;
   }
 
-  /**
-   * Gets the remaining milliseconds from the given milliseconds.
-   *
-   * @param ms the duration in milliseconds
-   * @return the remaining milliseconds
-   */
+  /// Gets the remaining milliseconds from the given milliseconds.
+  ///
+  /// @param ms the duration in milliseconds
+  /// @return the remaining milliseconds
   public static long getRemainingMilliSeconds(long ms) {
     return ms % 1000;
   }
 
-  /**
-   * Converts a duration to a formatted timer string based on the specified timer format.
-   *
-   * @param duration the duration in milliseconds
-   * @param format   the timer format to use
-   * @return the formatted timer string
-   */
+  /// Converts a duration to a formatted timer string based on the specified timer format.
+  ///
+  /// @param duration the duration in milliseconds
+  /// @param format   the timer format to use
+  /// @return the formatted timer string
   public static String toTimerFormat(long duration, TimerFormat format) {
     long h = getRemainingHours(duration);
     long m = getRemainingMinutes(duration);

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/UriUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/UriUtilities.java
@@ -7,26 +7,20 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Utility class for URI-related operations.
- */
+/// Utility class for URI-related operations.
 public final class UriUtilities {
   private static final Logger log = Logger.getLogger(UriUtilities.class.getName());
 
-  /**
-   * Private constructor to prevent instantiation.
-   * Throws UnsupportedOperationException if called.
-   */
+  /// Private constructor to prevent instantiation.
+  /// Throws UnsupportedOperationException if called.
   private UriUtilities() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Opens a webpage in the default browser.
-   *
-   * @param uri the URI of the webpage to open
-   * @return true if the webpage was successfully opened, false otherwise
-   */
+  /// Opens a webpage in the default browser.
+  ///
+  /// @param uri the URI of the webpage to open
+  /// @return true if the webpage was successfully opened, false otherwise
   public static boolean openWebpage(URI uri) {
     Desktop desktop = Desktop.isDesktopSupported() ? Desktop.getDesktop() : null;
     if (desktop != null && desktop.isSupported(Desktop.Action.BROWSE)) {
@@ -40,12 +34,10 @@ public final class UriUtilities {
     return false;
   }
 
-  /**
-   * Opens a webpage in the default browser.
-   *
-   * @param url the URL of the webpage to open
-   * @return true if the webpage was successfully opened, false otherwise
-   */
+  /// Opens a webpage in the default browser.
+  ///
+  /// @param url the URL of the webpage to open
+  /// @return true if the webpage was successfully opened, false otherwise
   public static boolean openWebpage(URL url) {
     try {
       return openWebpage(url.toURI());

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/GeometricUtilities.java
@@ -17,35 +17,29 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Static utility methods for 2D geometric calculations used throughout the engine, such as distance and angle computations, shape intersection
- * checks, scaling, and ray casting.
- */
+/// Static utility methods for 2D geometric calculations used throughout the engine, such as distance and angle computations, shape intersection
+/// checks, scaling, and ray casting.
 public class GeometricUtilities {
   private static final double RAYCAST_EPSILON = 0.01;
-  /**
-   * Tolerance used by {@link #intersects(Rectangle2D, Rectangle2D)} to ignore overlaps that
-   * are too small to be meaningful and most likely caused by floating-point imprecision (e.g.
-   * after sine/cosine based projections in the physics engine). Without this tolerance, two
-   * rectangles that are supposed to merely touch can be reported as intersecting because of
-   * a sub-femto-unit overlap, which leads to spurious collisions when sliding along walls.
-   */
+  /// Tolerance used by [Rectangle2D)][#intersects(Rectangle2D,] to ignore overlaps that
+  /// are too small to be meaningful and most likely caused by floating-point imprecision (e.g.
+  /// after sine/cosine based projections in the physics engine). Without this tolerance, two
+  /// rectangles that are supposed to merely touch can be reported as intersecting because of
+  /// a sub-femto-unit overlap, which leads to spurious collisions when sliding along walls.
   private static final double INTERSECTION_EPSILON = 1e-9;
 
   private GeometricUtilities() {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Calculates the clockwise rotation angle in degrees from a center point to a target point. The returned angle is in the range {@code [0, 360)} and
-   * uses the LITIengine coordinate system where {@code 0} degrees points NORTH.
-   *
-   * @param centerX the x coordinate of the center point
-   * @param centerY the y coordinate of the center point
-   * @param targetX the x coordinate of the target point
-   * @param targetY the y coordinate of the target point
-   * @return the clockwise rotation angle in degrees
-   */
+  /// Calculates the clockwise rotation angle in degrees from a center point to a target point. The returned angle is in the range `[0, 360)` and
+  /// uses the LITIengine coordinate system where `0` degrees points NORTH.
+  ///
+  /// @param centerX the x coordinate of the center point
+  /// @param centerY the y coordinate of the center point
+  /// @param targetX the x coordinate of the target point
+  /// @param targetY the y coordinate of the target point
+  /// @return the clockwise rotation angle in degrees
   public static double calcRotationAngleInDegrees(
       final double centerX, final double centerY, final double targetX, final double targetY) {
     // calculate the angle theta from the deltaY and deltaX values
@@ -73,34 +67,29 @@ public class GeometricUtilities {
     return (360 - angle) % 360;
   }
 
-  /**
-   * Calculates the angle from centerPt to targetPt in degrees. The return should range from [0,360), rotating CLOCKWISE,
-   * 0 and 360 degrees represents NORTH, 90 degrees represents EAST, etc...
-   *
-   * <p>
-   * Assumes all points are in the same coordinate space. If they are not, you will need to call
-   * SwingUtilities.convertPointToScreen or equivalent on all arguments before passing them to this function.
-   *
-   * @param centerPt
-   *          Point we are rotating around.
-   * @param targetPt
-   *          Point we want to calcuate the angle to.
-   * @return angle in degrees. This is the angle from centerPt to targetPt.
-   */
+  /// Calculates the angle from centerPt to targetPt in degrees. The return should range from [0,360), rotating CLOCKWISE,
+  /// 0 and 360 degrees represents NORTH, 90 degrees represents EAST, etc...
+  ///
+  /// Assumes all points are in the same coordinate space. If they are not, you will need to call
+  /// SwingUtilities.convertPointToScreen or equivalent on all arguments before passing them to this function.
+  ///
+  /// @param centerPt
+  /// Point we are rotating around.
+  /// @param targetPt
+  /// Point we want to calcuate the angle to.
+  /// @return angle in degrees. This is the angle from centerPt to targetPt.
   public static double calcRotationAngleInDegrees(final Point2D centerPt, final Point2D targetPt) {
     return calcRotationAngleInDegrees(
         centerPt.getX(), centerPt.getY(), targetPt.getX(), targetPt.getY());
   }
 
-  /**
-   * Contains.
-   *
-   * @param rectangle
-   *          the rectangle
-   * @param p
-   *          the p
-   * @return true, if successful
-   */
+  /// Contains.
+  ///
+  /// @param rectangle
+  /// the rectangle
+  /// @param p
+  /// the p
+  /// @return true, if successful
   public static boolean contains(final Rectangle2D rectangle, final Point2D p) {
     return rectangle.getX() <= p.getX()
         && rectangle.getY() <= p.getY()
@@ -108,55 +97,47 @@ public class GeometricUtilities {
         && rectangle.getY() + rectangle.getHeight() >= p.getY();
   }
 
-  /**
-   * Computes the Euclidean distance between two points.
-   *
-   * @param p1X the x coordinate of the first point
-   * @param p1Y the y coordinate of the first point
-   * @param p2X the x coordinate of the second point
-   * @param p2Y the y coordinate of the second point
-   * @return the Euclidean distance
-   */
+  /// Computes the Euclidean distance between two points.
+  ///
+  /// @param p1X the x coordinate of the first point
+  /// @param p1Y the y coordinate of the first point
+  /// @param p2X the x coordinate of the second point
+  /// @param p2Y the y coordinate of the second point
+  /// @return the Euclidean distance
   public static double distance(
       final double p1X, final double p1Y, final double p2X, final double p2Y) {
     return Math.sqrt((p1X - p2X) * (p1X - p2X) + (p1Y - p2Y) * (p1Y - p2Y));
   }
 
-  /**
-   * Computes the Euclidean distance between two points.
-   *
-   * @param p1 the first point
-   * @param p2 the second point
-   * @return the Euclidean distance
-   */
+  /// Computes the Euclidean distance between two points.
+  ///
+  /// @param p1 the first point
+  /// @param p2 the second point
+  /// @return the Euclidean distance
   public static double distance(final Point2D p1, final Point2D p2) {
     return Math.sqrt(
         (p1.getX() - p2.getX()) * (p1.getX() - p2.getX())
             + (p1.getY() - p2.getY()) * (p1.getY() - p2.getY()));
   }
 
-  /**
-   * Distance.
-   *
-   * @param rect
-   *          the rect
-   * @param p
-   *          the p
-   * @return the double
-   */
+  /// Distance.
+  ///
+  /// @param rect
+  /// the rect
+  /// @param p
+  /// the p
+  /// @return the double
   public static double distance(final Rectangle2D rect, final Point2D p) {
     final double dx = Math.max(rect.getMinX() - p.getX(), p.getX() - rect.getMaxX());
     final double dy = Math.max(rect.getMinY() - p.getY(), p.getY() - rect.getMaxY());
     return Math.sqrt(dx * dx + dy * dy);
   }
 
-  /**
-   * Returns a new rectangle with the given extension applied to all sides of the input rectangle.
-   *
-   * @param rect the input rectangle
-   * @param ext  the number of units to add to each side
-   * @return the extruded rectangle
-   */
+  /// Returns a new rectangle with the given extension applied to all sides of the input rectangle.
+  ///
+  /// @param rect the input rectangle
+  /// @param ext  the number of units to add to each side
+  /// @return the extruded rectangle
   public static Rectangle2D extrude(Rectangle2D rect, double ext) {
     return new Rectangle2D.Double(
         rect.getX() - ext,
@@ -165,25 +146,21 @@ public class GeometricUtilities {
         rect.getHeight() + ext * 2);
   }
 
-  /**
-   * Determines whether two points are within the given epsilon distance of each other.
-   *
-   * @param point1  the first point
-   * @param point2  the second point
-   * @param epsilon the maximum allowed distance for the points to be considered equal
-   * @return {@code true} if the distance between the points is less than {@code epsilon}
-   */
+  /// Determines whether two points are within the given epsilon distance of each other.
+  ///
+  /// @param point1  the first point
+  /// @param point2  the second point
+  /// @param epsilon the maximum allowed distance for the points to be considered equal
+  /// @return `true` if the distance between the points is less than `epsilon`
   public static boolean equals(final Point2D point1, final Point2D point2, final double epsilon) {
     return point1.distance(point2) < epsilon;
   }
 
-  /**
-   * Returns the line segments that connect the supplied point to each of the supplied rectangle corner points.
-   *
-   * @param point      the starting point
-   * @param rectPoints the corner points to connect to
-   * @return the connecting line segments, one per corner point
-   */
+  /// Returns the line segments that connect the supplied point to each of the supplied rectangle corner points.
+  ///
+  /// @param point      the starting point
+  /// @param rectPoints the corner points to connect to
+  /// @return the connecting line segments, one per corner point
   public static Line2D[] getConnectingLines(final Point2D point, final Point2D[] rectPoints) {
     final Line2D[] lines = new Line2D[rectPoints.length];
 
@@ -195,13 +172,11 @@ public class GeometricUtilities {
     return lines;
   }
 
-  /**
-   * Extracts the constraining line segments of the given {@link Area} by iterating over its path. The returned list contains every
-   * {@link PathIterator#SEG_LINETO} as well as the closing segments of every sub-path.
-   *
-   * @param area the area to inspect
-   * @return the list of line segments that form the area's boundary
-   */
+  /// Extracts the constraining line segments of the given [Area] by iterating over its path. The returned list contains every
+  /// [PathIterator#SEG_LINETO] as well as the closing segments of every sub-path.
+  ///
+  /// @param area the area to inspect
+  /// @return the list of line segments that form the area's boundary
   public static List<Line2D.Double> getConstrainingLines(final Area area) {
     final ArrayList<double[]> areaPoints = new ArrayList<>();
     final ArrayList<Line2D.Double> areaSegments = new ArrayList<>();
@@ -248,13 +223,11 @@ public class GeometricUtilities {
     return areaSegments;
   }
 
-  /**
-   * Computes the unit X displacement (cosine component) for the given angle in degrees, expressed in the LITIengine coordinate system where {@code 0}
-   * degrees points NORTH.
-   *
-   * @param angle the angle in degrees
-   * @return the unit X displacement
-   */
+  /// Computes the unit X displacement (cosine component) for the given angle in degrees, expressed in the LITIengine coordinate system where `0`
+  /// degrees points NORTH.
+  ///
+  /// @param angle the angle in degrees
+  /// @return the unit X displacement
   public static float getDeltaX(double angle) {
     double actualAngle = angle - 90;
 
@@ -266,13 +239,11 @@ public class GeometricUtilities {
     return Trigonometry.cosDeg((float) actualAngle);
   }
 
-  /**
-   * Computes the unit Y displacement (sine component) for the given angle in degrees, expressed in the LITIengine coordinate system where {@code 0}
-   * degrees points NORTH.
-   *
-   * @param angle the angle in degrees
-   * @return the unit Y displacement
-   */
+  /// Computes the unit Y displacement (sine component) for the given angle in degrees, expressed in the LITIengine coordinate system where `0`
+  /// degrees points NORTH.
+  ///
+  /// @param angle the angle in degrees
+  /// @return the unit Y displacement
   public static float getDeltaY(double angle) {
     double actualAngle = angle - 90;
 
@@ -284,37 +255,31 @@ public class GeometricUtilities {
     return Trigonometry.sinDeg((float) actualAngle);
   }
 
-  /**
-   * Computes the X displacement for the given angle and delta magnitude.
-   *
-   * @param angle the angle in degrees
-   * @param delta the magnitude
-   * @return the X displacement
-   */
+  /// Computes the X displacement for the given angle and delta magnitude.
+  ///
+  /// @param angle the angle in degrees
+  /// @param delta the magnitude
+  /// @return the X displacement
   public static double getDeltaX(final double angle, final double delta) {
     return Math.sin(Math.toRadians(angle)) * delta * 100 / 100.0;
   }
 
-  /**
-   * Computes the Y displacement for the given angle and delta magnitude.
-   *
-   * @param angle the angle in degrees
-   * @param delta the magnitude
-   * @return the Y displacement
-   */
+  /// Computes the Y displacement for the given angle and delta magnitude.
+  ///
+  /// @param angle the angle in degrees
+  /// @param delta the magnitude
+  /// @return the Y displacement
   public static double getDeltaY(final double angle, final double delta) {
     return Math.cos(Math.toRadians(angle)) * delta * 100 / 100.0;
   }
 
-  /**
-   * Gets the intersection point.
-   *
-   * @param lineA
-   *          the line a
-   * @param lineB
-   *          the line b
-   * @return the intersection point
-   */
+  /// Gets the intersection point.
+  ///
+  /// @param lineA
+  /// the line a
+  /// @param lineB
+  /// the line b
+  /// @return the intersection point
   public static Point2D getIntersectionPoint(final Line2D lineA, final Line2D lineB) {
 
     final double x1 = lineA.getX1();
@@ -345,15 +310,13 @@ public class GeometricUtilities {
     return p;
   }
 
-  /**
-   * Intersects.
-   *
-   * @param line
-   *          the line
-   * @param rectangle
-   *          the rectangle
-   * @return the point2 d
-   */
+  /// Intersects.
+  ///
+  /// @param line
+  /// the line
+  /// @param rectangle
+  /// the rectangle
+  /// @return the point2 d
   public static Point2D getIntersectionPoint(final Line2D line, final Rectangle2D rectangle) {
     final List<Point2D> intersectionPoints = getIntersectionPoints(line, rectangle);
     for (final Point2D p : intersectionPoints) {
@@ -364,15 +327,13 @@ public class GeometricUtilities {
     return null;
   }
 
-  /**
-   * Gets the intersection points.
-   *
-   * @param line
-   *          the line
-   * @param rectangle
-   *          the rectangle
-   * @return the intersection points
-   */
+  /// Gets the intersection points.
+  ///
+  /// @param line
+  /// the line
+  /// @param rectangle
+  /// the rectangle
+  /// @return the intersection points
   public static List<Point2D> getIntersectionPoints(
       final Line2D line, final Rectangle2D rectangle) {
     final ArrayList<Point2D> intersectionPoints = new ArrayList<>();
@@ -418,13 +379,11 @@ public class GeometricUtilities {
     return intersectionPoints;
   }
 
-  /**
-   * Gets the lines.
-   *
-   * @param rectangle
-   *          the rectangle
-   * @return the lines
-   */
+  /// Gets the lines.
+  ///
+  /// @param rectangle
+  /// the rectangle
+  /// @return the lines
   public static Line2D[] getLines(final Rectangle2D rectangle) {
     final Line2D[] lines = new Line2D[4];
     lines[0] =
@@ -442,12 +401,10 @@ public class GeometricUtilities {
     return lines;
   }
 
-  /**
-   * Computes the diagonal length of the given rectangle.
-   *
-   * @param rect the rectangle; may be {@code null}
-   * @return the diagonal length, or {@code 0} if {@code rect} is {@code null}
-   */
+  /// Computes the diagonal length of the given rectangle.
+  ///
+  /// @param rect the rectangle; may be `null`
+  /// @return the diagonal length, or `0` if `rect` is `null`
   public static double getDiagonal(Rectangle2D rect) {
     if (rect == null) {
       return 0;
@@ -456,90 +413,77 @@ public class GeometricUtilities {
     return Math.sqrt(Math.pow(rect.getWidth(), 2) + Math.pow(rect.getHeight(), 2));
   }
 
-  /**
-   * Returns the midpoint of the given line.
-   *
-   * @param line the line
-   * @return the midpoint
-   */
+  /// Returns the midpoint of the given line.
+  ///
+  /// @param line the line
+  /// @return the midpoint
   public static Point2D getCenter(final Line2D line) {
     return getCenter(line.getP1(), line.getP2());
   }
 
-  /**
-   * Returns the midpoint between two points.
-   *
-   * @param p1 the first point
-   * @param p2 the second point
-   * @return the midpoint
-   */
+  /// Returns the midpoint between two points.
+  ///
+  /// @param p1 the first point
+  /// @param p2 the second point
+  /// @return the midpoint
   public static Point2D getCenter(final Point2D p1, final Point2D p2) {
     return getCenter(p1.getX(), p2.getX(), p1.getY(), p2.getY());
   }
 
-  /**
-   * Returns the midpoint of the rectangle defined by the two given coordinate pairs.
-   *
-   * @param x1 the x coordinate of the first point
-   * @param y1 the y coordinate of the first point
-   * @param x2 the x coordinate of the second point
-   * @param y2 the y coordinate of the second point
-   * @return the midpoint
-   */
+  /// Returns the midpoint of the rectangle defined by the two given coordinate pairs.
+  ///
+  /// @param x1 the x coordinate of the first point
+  /// @param y1 the y coordinate of the first point
+  /// @param x2 the x coordinate of the second point
+  /// @param y2 the y coordinate of the second point
+  /// @return the midpoint
   public static Point2D getCenter(
       final double x1, final double y1, final double x2, final double y2) {
     return new Point2D.Double((x1 + x2) / 2, (y1 + y2) / 2);
   }
 
-  /**
-   * Returns the center of a shape whose geometry is defined by a rectangular frame.
-   *
-   * <p>
-   * Works for any subclass of RectuangularShape, including:<br>
-   * <br>
-   * Arc2D<br>
-   * Ellipse2D<br>
-   * Rectangle2D<br>
-   * RoundRectangle2D<br>
-   * <br>
-   *
-   * @param shape
-   *          the shape to retrieve the center of
-   * @return a Point2D representing the center of the shape
-   * @see java.awt.geom.RectangularShape
-   */
+  /// Returns the center of a shape whose geometry is defined by a rectangular frame.
+  ///
+  /// Works for any subclass of RectuangularShape, including:
+  ///
+  /// Arc2D
+  ///
+  /// Ellipse2D
+  ///
+  /// Rectangle2D
+  ///
+  /// RoundRectangle2D
+  ///
+  /// @param shape
+  /// the shape to retrieve the center of
+  /// @return a Point2D representing the center of the shape
+  /// @see java.awt.geom.RectangularShape
   public static Point2D getCenter(final RectangularShape shape) {
     return new Point2D.Double(shape.getCenterX(), shape.getCenterY());
   }
 
-  /**
-   * Creates a circle (as an {@link Ellipse2D}) with the given center and radius.
-   *
-   * @param center the center of the circle
-   * @param radius the radius of the circle
-   * @return the resulting ellipse
-   */
+  /// Creates a circle (as an [Ellipse2D]) with the given center and radius.
+  ///
+  /// @param center the center of the circle
+  /// @param radius the radius of the circle
+  /// @return the resulting ellipse
   public static Ellipse2D getCircle(Point2D center, double radius) {
     return new Ellipse2D.Double(
         center.getX() - radius, center.getY() - radius, radius * 2, radius * 2);
   }
 
-  /**
-   * Returns the average (centroid) location of the supplied collection of points.
-   *
-   * @param points the points
-   * @return the average location, or {@code null} if {@code points} is empty
-   */
+  /// Returns the average (centroid) location of the supplied collection of points.
+  ///
+  /// @param points the points
+  /// @return the average location, or `null` if `points` is empty
   public static Point2D getAverageLocation(Collection<Point2D> points) {
     return getAverageLocation(points.toArray(new Point2D[points.size()]));
   }
 
-  /**
-   * Returns the average (centroid) location of the supplied points.
-   *
-   * @param points the points
-   * @return the average location, or {@code null} if no points are supplied
-   */
+  /// Returns the average (centroid) location of the supplied points.
+  ///
+  /// @param points the points
+  /// @return the average location, or `null` if no points are supplied
   public static Point2D getAverageLocation(Point2D... points) {
     if (points.length == 0) {
       return null;
@@ -557,15 +501,13 @@ public class GeometricUtilities {
     return mid;
   }
 
-  /**
-   * Gets the perpendicular intersection.
-   *
-   * @param point
-   *          the point
-   * @param line
-   *          the line
-   * @return the perpendicular intersection
-   */
+  /// Gets the perpendicular intersection.
+  ///
+  /// @param point
+  /// the point
+  /// @param line
+  /// the line
+  /// @return the perpendicular intersection
   public static Point2D getPerpendicularIntersection(final Point2D point, final Line2D line) {
     final double x1 = line.getX1();
     final double y1 = line.getY1();
@@ -584,14 +526,12 @@ public class GeometricUtilities {
     return new Point2D.Double(x4, y4);
   }
 
-  /**
-   * Returns the point on the circle defined by {@code center} and {@code radius} at the given angle.
-   *
-   * @param center the center of the circle
-   * @param radius the radius of the circle
-   * @param angle  the angle in degrees (clockwise, {@code 0} pointing EAST)
-   * @return the point on the circle
-   */
+  /// Returns the point on the circle defined by `center` and `radius` at the given angle.
+  ///
+  /// @param center the center of the circle
+  /// @param radius the radius of the circle
+  /// @param angle  the angle in degrees (clockwise, `0` pointing EAST)
+  /// @return the point on the circle
   public static Point2D getPointOnCircle(
       final Point2D center, final double radius, final double angle) {
     final double x = center.getX() + radius * Math.cos(Math.toRadians(angle));
@@ -600,12 +540,10 @@ public class GeometricUtilities {
     return new Point2D.Double(x, y);
   }
 
-  /**
-   * Extracts the start points of all segments of the supplied path.
-   *
-   * @param path the path to iterate
-   * @return the list of segment start points
-   */
+  /// Extracts the start points of all segments of the supplied path.
+  ///
+  /// @param path the path to iterate
+  /// @return the list of segment start points
   public static List<Point2D> getPoints(final Path2D path) {
     final PathIterator pi = path.getPathIterator(null);
     final double[] coordinates = new double[22];
@@ -621,13 +559,11 @@ public class GeometricUtilities {
     return points;
   }
 
-  /**
-   * Gets the points.
-   *
-   * @param rectangle
-   *          the rectangle
-   * @return the points
-   */
+  /// Gets the points.
+  ///
+  /// @param rectangle
+  /// the rectangle
+  /// @return the points
   public static List<Point2D> getPoints(final Rectangle2D rectangle) {
 
     final ArrayList<Point2D> points = new ArrayList<>();
@@ -638,15 +574,13 @@ public class GeometricUtilities {
     return points;
   }
 
-  /**
-   * Gets the points between the specified points using the Bresenham algorithm.
-   *
-   * @param point1
-   *          the point1
-   * @param point2
-   *          the point2
-   * @return the points between points
-   */
+  /// Gets the points between the specified points using the Bresenham algorithm.
+  ///
+  /// @param point1
+  /// the point1
+  /// @param point2
+  /// the point2
+  /// @return the points between points
   public static List<Point2D> getPointsBetweenPoints(final Point2D point1, final Point2D point2) {
     double x0 = point1.getX();
     double y0 = point1.getY();
@@ -684,14 +618,12 @@ public class GeometricUtilities {
     return line;
   }
 
-  /**
-   * Tests whether two rectangles meaningfully intersect. Touching edges (zero-area overlap) and overlaps below an internal floating-point epsilon are
-   * treated as non-intersecting in order to avoid spurious collisions.
-   *
-   * @param a the first rectangle
-   * @param b the second rectangle
-   * @return {@code true} if the rectangles overlap by more than the internal epsilon
-   */
+  /// Tests whether two rectangles meaningfully intersect. Touching edges (zero-area overlap) and overlaps below an internal floating-point epsilon are
+  /// treated as non-intersecting in order to avoid spurious collisions.
+  ///
+  /// @param a the first rectangle
+  /// @param b the second rectangle
+  /// @return `true` if the rectangles overlap by more than the internal epsilon
   public static boolean intersects(final Rectangle2D a, final Rectangle2D b) {
     return a.getWidth() * 0.5 + b.getWidth() * 0.5 - Math.abs(a.getCenterX() - b.getCenterX())
             > INTERSECTION_EPSILON
@@ -699,14 +631,12 @@ public class GeometricUtilities {
             > INTERSECTION_EPSILON;
   }
 
-  /**
-   * Tests whether two ellipses intersect. Uses a circle/circle fast-path when both ellipses are circles; otherwise falls back to a generic shape
-   * intersection test.
-   *
-   * @param a the first ellipse
-   * @param b the second ellipse
-   * @return {@code true} if the ellipses overlap
-   */
+  /// Tests whether two ellipses intersect. Uses a circle/circle fast-path when both ellipses are circles; otherwise falls back to a generic shape
+  /// intersection test.
+  ///
+  /// @param a the first ellipse
+  /// @param b the second ellipse
+  /// @return `true` if the ellipses overlap
   public static boolean intersects(final Ellipse2D a, final Ellipse2D b) {
     if (a.getWidth() != a.getHeight() || b.getWidth() != b.getHeight()) {
       return shapeIntersects(a, b);
@@ -720,17 +650,15 @@ public class GeometricUtilities {
     return distSq <= radSumSq;
   }
 
-  /**
-   * Project a line from a point with a given length and angle, return the point where the line ends.
-   *
-   * @param start
-   *          The starting point of the projection.
-   * @param angle
-   *          The angle of the projection in degrees.
-   * @param delta
-   *          The distance between starting point and end point.
-   * @return The {@code Point2D} where the projection ends.
-   */
+  /// Project a line from a point with a given length and angle, return the point where the line ends.
+  ///
+  /// @param start
+  /// The starting point of the projection.
+  /// @param angle
+  /// The angle of the projection in degrees.
+  /// @param delta
+  /// The distance between starting point and end point.
+  /// @return The `Point2D` where the projection ends.
   public static Point2D project(final Point2D start, final double angle, final double delta) {
     double x = start.getX();
     double y = start.getY();
@@ -744,17 +672,15 @@ public class GeometricUtilities {
     return new Point2D.Double(x, y);
   }
 
-  /**
-   * Projects a point from end along the vector (end - start) by the given scalar amount.
-   *
-   * @param start
-   *          the start
-   * @param end
-   *          the end
-   * @param scalar
-   *          the scalar
-   * @return the point2 d. double
-   */
+  /// Projects a point from end along the vector (end - start) by the given scalar amount.
+  ///
+  /// @param start
+  /// the start
+  /// @param end
+  /// the end
+  /// @param scalar
+  /// the scalar
+  /// @return the point2 d. double
   public static Point2D project(final Point2D start, final Point2D end, final double scalar) {
     double dx = end.getX() - start.getX();
     double dy = end.getY() - start.getY();
@@ -765,14 +691,12 @@ public class GeometricUtilities {
     return new Point2D.Double(start.getX() + dx * scalar / len, start.getY() + dy * scalar / len);
   }
 
-  /**
-   * Performs a ray cast from the given point against the supplied rectangle and returns the visible corner points (i.e. corners that are not occluded
-   * by another corner along the ray).
-   *
-   * @param point     the origin of the ray cast
-   * @param rectangle the rectangle to test against
-   * @return the visible corner points of the rectangle
-   */
+  /// Performs a ray cast from the given point against the supplied rectangle and returns the visible corner points (i.e. corners that are not occluded
+  /// by another corner along the ray).
+  ///
+  /// @param point     the origin of the ray cast
+  /// @param rectangle the rectangle to test against
+  /// @return the visible corner points of the rectangle
   public static Point2D[] rayCastPoints(final Point2D point, final Rectangle2D rectangle) {
     // 1. get all rectangle points
     final List<Point2D> rectPoints = getPoints(rectangle);
@@ -804,13 +728,11 @@ public class GeometricUtilities {
     return resultPoints.toArray(new Point2D[resultPoints.size()]);
   }
 
-  /**
-   * Scales the given rectangle so that its longest side equals {@code max} pixels, preserving its aspect ratio.
-   *
-   * @param shape the rectangle to scale
-   * @param max   the maximum side length in pixels
-   * @return the scaled shape
-   */
+  /// Scales the given rectangle so that its longest side equals `max` pixels, preserving its aspect ratio.
+  ///
+  /// @param shape the rectangle to scale
+  /// @param max   the maximum side length in pixels
+  /// @return the scaled shape
   public static Shape scaleRect(final Rectangle2D shape, final int max) {
     Dimension2D newDimension = scaleWithRatio(shape.getWidth(), shape.getHeight(), max);
     if (newDimension == null) {
@@ -822,14 +744,12 @@ public class GeometricUtilities {
     return transform.createTransformedShape(shape);
   }
 
-  /**
-   * Computes a {@link Dimension2D} preserving the aspect ratio of {@code width:height} so that the longest side equals {@code max}.
-   *
-   * @param width  the original width
-   * @param height the original height
-   * @param max    the desired maximum side length
-   * @return the scaled dimension, or {@code null} if {@code width} or {@code height} is {@code 0}
-   */
+  /// Computes a [Dimension2D] preserving the aspect ratio of `width:height` so that the longest side equals `max`.
+  ///
+  /// @param width  the original width
+  /// @param height the original height
+  /// @param max    the desired maximum side length
+  /// @return the scaled dimension, or `null` if `width` or `height` is `0`
   public static Dimension2D scaleWithRatio(final double width, final double height, final int max) {
     if (width == 0 || height == 0) {
       return null;
@@ -856,27 +776,23 @@ public class GeometricUtilities {
     return dim;
   }
 
-  /**
-   * Applies a uniform scaling transformation to the given shape.
-   *
-   * @param shape the shape to scale
-   * @param scale the scaling factor applied to both axes
-   * @return the scaled shape
-   */
+  /// Applies a uniform scaling transformation to the given shape.
+  ///
+  /// @param shape the shape to scale
+  /// @param scale the scaling factor applied to both axes
+  /// @return the scaled shape
   public static Shape scaleShape(final Shape shape, final double scale) {
     final AffineTransform transform = AffineTransform.getScaleInstance(scale, scale);
     return transform.createTransformedShape(shape);
   }
 
-  /**
-   * Shape intersects. WARNING: USE THIS METHOD WITH CAUTION BECAUSE IT IS A VERY SLOW WAY OF CALCULATING INTERSECTIONS.
-   *
-   * @param shapeA
-   *          the shape a
-   * @param shapeB
-   *          the shape b
-   * @return true, if successful
-   */
+  /// Shape intersects. WARNING: USE THIS METHOD WITH CAUTION BECAUSE IT IS A VERY SLOW WAY OF CALCULATING INTERSECTIONS.
+  ///
+  /// @param shapeA
+  /// the shape a
+  /// @param shapeB
+  /// the shape b
+  /// @return true, if successful
   public static boolean shapeIntersects(final Shape shapeA, final Shape shapeB) {
     // compute rough estimate of boundary intersection to avoid more costly checks if not intersecting
     if (!shapeA.getBounds2D().intersects(shapeB.getBounds2D())) {
@@ -901,13 +817,11 @@ public class GeometricUtilities {
     return !areaA.isEmpty();
   }
 
-  /**
-   * Translates the given shape so that the top-left corner of its bounding box matches the supplied location.
-   *
-   * @param shape       the shape to translate
-   * @param newLocation the new top-left location of the shape's bounding box
-   * @return the translated shape
-   */
+  /// Translates the given shape so that the top-left corner of its bounding box matches the supplied location.
+  ///
+  /// @param shape       the shape to translate
+  /// @param newLocation the new top-left location of the shape's bounding box
+  /// @return the translated shape
   public static Shape translateShape(final Shape shape, final Point2D newLocation) {
     final AffineTransform t = new AffineTransform();
     t.translate(
@@ -916,13 +830,11 @@ public class GeometricUtilities {
     return t.createTransformedShape(shape);
   }
 
-  /**
-   * Normalizes the specified angle to the range between 0-360 degree.
-   *
-   * @param angle
-   *          The angle that will be normalized.
-   * @return The normalized angle.
-   */
+  /// Normalizes the specified angle to the range between 0-360 degree.
+  ///
+  /// @param angle
+  /// The angle that will be normalized.
+  /// @return The normalized angle.
   public static double normalizeAngle(final double angle) {
     double normalized = angle % 360;
 

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/PointDistanceComparator.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/PointDistanceComparator.java
@@ -3,7 +3,7 @@ package de.gurkenlabs.litiengine.util.geom;
 import java.awt.geom.Point2D;
 import java.util.Comparator;
 
-/** The Class PointDistanceComparator order points by their distance to the relative point. */
+/// The Class PointDistanceComparator order points by their distance to the relative point.
 public class PointDistanceComparator implements Comparator<Point2D> {
 
   private final Point2D relativePoint;

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/Trigonometry.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/Trigonometry.java
@@ -1,9 +1,7 @@
 package de.gurkenlabs.litiengine.util.geom;
 
-/**
- * Provides fast, approximate trigonometric functions backed by precomputed look-up tables. Useful when many calls are made per frame and the slight
- * approximation error introduced by table look-ups is acceptable.
- */
+/// Provides fast, approximate trigonometric functions backed by precomputed look-up tables. Useful when many calls are made per frame and the slight
+/// approximation error introduced by table look-ups is acceptable.
 public final class Trigonometry {
   private static final int ATAN2_BITS = 7;
   private static final int ATAN2_BITS2 = ATAN2_BITS << 1;
@@ -48,13 +46,11 @@ public final class Trigonometry {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Fast approximation of {@link Math#atan2(double, double)} in radians.
-   *
-   * @param y the y component
-   * @param x the x component
-   * @return the angle, in radians
-   */
+  /// Fast approximation of [double)][Math#atan2(double,] in radians.
+  ///
+  /// @param y the y component
+  /// @param x the x component
+  /// @return the angle, in radians
   public static float atan2(float y, float x) {
     float add;
     float mul;
@@ -90,64 +86,52 @@ public final class Trigonometry {
     return (atan2[yi * ATAN2_DIM + xi] + add) * mul;
   }
 
-  /**
-   * Fast approximation of {@link Math#atan2(double, double)} in degrees.
-   *
-   * @param y the y component
-   * @param x the x component
-   * @return the angle, in degrees
-   */
+  /// Fast approximation of [double)][Math#atan2(double,] in degrees.
+  ///
+  /// @param y the y component
+  /// @param x the x component
+  /// @return the angle, in degrees
   public static float atan2Deg(final float y, final float x) {
     return atan2(y, x) * DEG;
   }
 
-  /**
-   * Strict (non-approximated) {@link Math#atan2(double, double)} in degrees.
-   *
-   * @param y the y component
-   * @param x the x component
-   * @return the angle, in degrees
-   */
+  /// Strict (non-approximated) [double)][Math#atan2(double,] in degrees.
+  ///
+  /// @param y the y component
+  /// @param x the x component
+  /// @return the angle, in degrees
   public static float atan2DegStrict(final float y, final float x) {
     return (float) Math.atan2(y, x) * DEG;
   }
 
-  /**
-   * Fast approximation of {@link Math#cos(double)}.
-   *
-   * @param rad the angle, in radians
-   * @return the cosine
-   */
+  /// Fast approximation of [Math#cos(double)].
+  ///
+  /// @param rad the angle, in radians
+  /// @return the cosine
   public static final float cos(final float rad) {
     return cos[(int) (rad * RAD_TO_INDEX) & SIN_MASK];
   }
 
-  /**
-   * Fast approximation of {@link Math#cos(double)} accepting degrees.
-   *
-   * @param deg the angle, in degrees
-   * @return the cosine
-   */
+  /// Fast approximation of [Math#cos(double)] accepting degrees.
+  ///
+  /// @param deg the angle, in degrees
+  /// @return the cosine
   public static final float cosDeg(final float deg) {
     return cos[(int) (deg * DEG_TO_INDEX) & SIN_MASK];
   }
 
-  /**
-   * Fast approximation of {@link Math#sin(double)}.
-   *
-   * @param rad the angle, in radians
-   * @return the sine
-   */
+  /// Fast approximation of [Math#sin(double)].
+  ///
+  /// @param rad the angle, in radians
+  /// @return the sine
   public static final float sin(final float rad) {
     return sin[(int) (rad * RAD_TO_INDEX) & SIN_MASK];
   }
 
-  /**
-   * Fast approximation of {@link Math#sin(double)} accepting degrees.
-   *
-   * @param deg the angle, in degrees
-   * @return the sine
-   */
+  /// Fast approximation of [Math#sin(double)] accepting degrees.
+  ///
+  /// @param deg the angle, in degrees
+  /// @return the sine
   public static final float sinDeg(final float deg) {
     return sin[(int) (deg * DEG_TO_INDEX) & SIN_MASK];
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/Vector2D.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/geom/Vector2D.java
@@ -2,121 +2,93 @@ package de.gurkenlabs.litiengine.util.geom;
 
 import java.awt.geom.Point2D;
 
-/**
- * A simple mutable 2D vector with basic linear algebra operations (addition, subtraction, scaling, dot product, length and unit/normal vector).
- */
+/// A simple mutable 2D vector with basic linear algebra operations (addition, subtraction, scaling, dot product, length and unit/normal vector).
 public class Vector2D {
 
-  /**
-   * The x component of the vector.
-   */
+  /// The x component of the vector.
   protected double dX;
-  /**
-   * The y component of the vector.
-   */
+  /// The y component of the vector.
   protected double dY;
 
-  /**
-   * Creates a new zero vector.
-   */
+  /// Creates a new zero vector.
   public Vector2D() {
     this.dX = this.dY = 0.0;
   }
 
-  /**
-   * Creates a new vector with the supplied components.
-   *
-   * @param dX the x component
-   * @param dY the y component
-   */
+  /// Creates a new vector with the supplied components.
+  ///
+  /// @param dX the x component
+  /// @param dY the y component
   public Vector2D(final double dX, final double dY) {
     this.dX = dX;
     this.dY = dY;
   }
 
-  /**
-   * Creates a new vector pointing from {@code p1} to {@code p2}.
-   *
-   * @param p1 the start point
-   * @param p2 the end point
-   */
+  /// Creates a new vector pointing from `p1` to `p2`.
+  ///
+  /// @param p1 the start point
+  /// @param p2 the end point
   public Vector2D(final Point2D p1, final Point2D p2) {
     this.dX = p2.getX() - p1.getX();
     this.dY = p2.getY() - p1.getY();
   }
 
-  /**
-   * Adds another vector to this one and returns the resulting new vector.
-   *
-   * @param v1 the vector to add
-   * @return the sum vector
-   */
+  /// Adds another vector to this one and returns the resulting new vector.
+  ///
+  /// @param v1 the vector to add
+  /// @return the sum vector
   public Vector2D add(final Vector2D v1) {
     return new Vector2D(this.dX + v1.dX, this.dY + v1.dY);
   }
 
-  /**
-   * Computes the dot product of this vector with another.
-   *
-   * @param v1 the other vector
-   * @return the dot product
-   */
+  /// Computes the dot product of this vector with another.
+  ///
+  /// @param v1 the other vector
+  /// @return the dot product
   public double dotProduct(final Vector2D v1) {
     return this.dX * v1.dX + this.dY * v1.dY;
   }
 
-  /**
-   * Returns the x component of the vector.
-   *
-   * @return the x component
-   */
+  /// Returns the x component of the vector.
+  ///
+  /// @return the x component
   public double getX() {
     return this.dX;
   }
 
-  /**
-   * Returns the y component of the vector.
-   *
-   * @return the y component
-   */
+  /// Returns the y component of the vector.
+  ///
+  /// @return the y component
   public double getY() {
     return this.dY;
   }
 
-  /**
-   * Returns the Euclidean length of the vector.
-   *
-   * @return the length
-   */
+  /// Returns the Euclidean length of the vector.
+  ///
+  /// @return the length
   public double length() {
     return Math.sqrt(this.dX * this.dX + this.dY * this.dY);
   }
 
-  /**
-   * Returns a vector perpendicular to this one, obtained by rotating it 90 degrees clockwise.
-   *
-   * @return the perpendicular vector
-   */
+  /// Returns a vector perpendicular to this one, obtained by rotating it 90 degrees clockwise.
+  ///
+  /// @return the perpendicular vector
   public Vector2D normalVector() {
     return new Vector2D(this.getY(), -this.getX());
   }
 
-  /**
-   * Returns this vector scaled by the supplied factor.
-   *
-   * @param scaleFactor the scale factor
-   * @return the scaled vector
-   */
+  /// Returns this vector scaled by the supplied factor.
+  ///
+  /// @param scaleFactor the scale factor
+  /// @return the scaled vector
   public Vector2D scale(final double scaleFactor) {
     return new Vector2D(this.dX * scaleFactor, this.dY * scaleFactor);
   }
 
-  /**
-   * Subtracts another vector from this one and returns the resulting new vector.
-   *
-   * @param v1 the vector to subtract
-   * @return the difference vector
-   */
+  /// Subtracts another vector from this one and returns the resulting new vector.
+  ///
+  /// @param v1 the vector to subtract
+  /// @return the difference vector
   public Vector2D sub(final Vector2D v1) {
     return new Vector2D(this.dX - v1.dX, this.dY - v1.dY);
   }
@@ -126,11 +98,9 @@ public class Vector2D {
     return "Vector2D(" + this.dX + ", " + this.dY + ")";
   }
 
-  /**
-   * Returns the unit vector pointing in the same direction as this vector, or the zero vector if this vector has length zero.
-   *
-   * @return the unit vector
-   */
+  /// Returns the unit vector pointing in the same direction as this vector, or the zero vector if this vector has length zero.
+  ///
+  /// @return the unit vector
   public Vector2D unitVector() {
     final Vector2D unit = new Vector2D();
     final double length = this.length();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/Codec.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/Codec.java
@@ -18,13 +18,11 @@ public final class Codec {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Decodes a previously encoded angle.
-   *
-   * @param encodedAngle
-   *          The encoded angle.
-   * @return The decoded angle.
-   */
+  /// Decodes a previously encoded angle.
+  ///
+  /// @param encodedAngle
+  /// The encoded angle.
+  /// @return The decoded angle.
   public static float decodeAngle(final byte encodedAngle) {
     float angle = encodedAngle;
     angle += 127;
@@ -37,29 +35,24 @@ public final class Codec {
     return decodeSmallFloatingPointNumber(encodedAngle, 2);
   }
 
-  /**
-   * Decodes a small floating point number, previously encoded with {@link #encodeSmallFloatingPointNumber(float, int)
-   * encodeSmallFloatingPointNumber}.
-   *
-   * @param encodedNumber
-   *          The encoded number
-   * @param precision
-   *          The precision of the encoded number. The same precision, used for encoding.
-   * @return The decoded small floating point number.
-   */
+  /// Decodes a small floating point number, previously encoded with [int) encodeSmallFloatingPointNumber][#encodeSmallFloatingPointNumber(float,].
+  ///
+  /// @param encodedNumber
+  /// The encoded number
+  /// @param precision
+  /// The precision of the encoded number. The same precision, used for encoding.
+  /// @return The decoded small floating point number.
   public static float decodeSmallFloatingPointNumber(
       final short encodedNumber, final int precision) {
     return (float) ((encodedNumber + Short.MAX_VALUE) / Math.pow(10, precision));
   }
 
-  /**
-   * Encodes an angle, loosing some precision. The encoded / decoded values can differ at max. around 1.43 degrees from
-   * the original one.
-   *
-   * @param angle
-   *          The angle
-   * @return The encoded angle.
-   */
+  /// Encodes an angle, loosing some precision. The encoded / decoded values can differ at max. around 1.43 degrees from
+  /// the original one.
+  ///
+  /// @param angle
+  /// The angle
+  /// @return The encoded angle.
   public static byte encodeAngle(final float angle) {
     float encodedAngle = angle % 360;
     encodedAngle *= 256 / 360.0f;
@@ -79,15 +72,13 @@ public final class Codec {
     return encodeSmallFloatingPointNumber(encodedAngle, 2);
   }
 
-  /**
-   * Encodes positive numbers less than Short.MAX_VALUE * 2 / precision (6553.4 for precision = 1).
-   *
-   * @param smallNumber
-   *          The small number to encode
-   * @param precision
-   *          The comma precision for the encoding process.
-   * @return The encoded number.
-   */
+  /// Encodes positive numbers less than Short.MAX_VALUE * 2 / precision (6553.4 for precision = 1).
+  ///
+  /// @param smallNumber
+  /// The small number to encode
+  /// @param precision
+  /// The comma precision for the encoding process.
+  /// @return The encoded number.
   public static short encodeSmallFloatingPointNumber(final float smallNumber, final int precision) {
     if (smallNumber < 0 || (int) (smallNumber * Math.pow(10, precision)) > Short.MAX_VALUE * 2) {
       throw new IllegalArgumentException("The specified number is not within the range to encode.");
@@ -149,14 +140,12 @@ public final class Codec {
     return Base64.getEncoder().encodeToString(data);
   }
 
-  /**
-   * Decodes the specified {@code Base64} string to a byte array.
-   *
-   * @param base64
-   *          The Base64 string containing the encoded binary data.
-   * @return The decoded byte array.
-   * @see Base64
-   */
+  /// Decodes the specified `Base64` string to a byte array.
+  ///
+  /// @param base64
+  /// The Base64 string containing the encoded binary data.
+  /// @return The decoded byte array.
+  /// @see Base64
   public static byte[] decode(String base64) {
     return Base64.getDecoder().decode(base64);
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/FileUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/FileUtilities.java
@@ -13,10 +13,8 @@ import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Static utility methods for working with file system paths and URIs, including recursive file lookup, extension/name parsing, parent directory
- * resolution and human-readable byte size formatting.
- */
+/// Static utility methods for working with file system paths and URIs, including recursive file lookup, extension/name parsing, parent directory
+/// resolution and human-readable byte size formatting.
 public final class FileUtilities {
   private static final Logger log = Logger.getLogger(FileUtilities.class.getName());
   private static final String[] DIR_BLACKLIST = new String[] {"\\bin", "\\screenshots"};
@@ -27,14 +25,12 @@ public final class FileUtilities {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Recursively collects all files under {@code dir} whose absolute path ends with the supplied {@code extension}.
-   *
-   * @param fileNames the (mutable) list that receives the matching file paths
-   * @param dir       the directory to search
-   * @param extension the file extension to look for
-   * @return {@code fileNames} for chaining
-   */
+  /// Recursively collects all files under `dir` whose absolute path ends with the supplied `extension`.
+  ///
+  /// @param fileNames the (mutable) list that receives the matching file paths
+  /// @param dir       the directory to search
+  /// @param extension the file extension to look for
+  /// @return `fileNames` for chaining
   public static List<String> findFilesByExtension(
     final List<String> fileNames, final Path dir, final String extension) {
     try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
@@ -56,14 +52,12 @@ public final class FileUtilities {
     return fileNames;
   }
 
-  /**
-   * Recursively collects all files under {@code dir} whose absolute path ends with one of the supplied {@code files} names.
-   *
-   * @param fileNames the (mutable) list that receives the matching file paths
-   * @param dir       the directory to search
-   * @param files     the file name suffixes to look for
-   * @return {@code fileNames} for chaining
-   */
+  /// Recursively collects all files under `dir` whose absolute path ends with one of the supplied `files` names.
+  ///
+  /// @param fileNames the (mutable) list that receives the matching file paths
+  /// @param dir       the directory to search
+  /// @param files     the file name suffixes to look for
+  /// @return `fileNames` for chaining
   public static List<String> findFiles(
     final List<String> fileNames, final Path dir, final String... files) {
     try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
@@ -90,22 +84,18 @@ public final class FileUtilities {
     return fileNames;
   }
 
-  /**
-   * Returns the extension of the supplied file path (without the leading dot), or an empty string if the path has no extension.
-   *
-   * @param file the file path
-   * @return the extension, or {@code ""}
-   */
+  /// Returns the extension of the supplied file path (without the leading dot), or an empty string if the path has no extension.
+  ///
+  /// @param file the file path
+  /// @return the extension, or `""`
   public static String getExtension(final Path file) {
     return getExtension(file.toAbsolutePath().toString());
   }
 
-  /**
-   * Returns the extension of the supplied path string (without the leading dot), or an empty string if the path has no extension.
-   *
-   * @param path the path string
-   * @return the extension, or {@code ""}
-   */
+  /// Returns the extension of the supplied path string (without the leading dot), or an empty string if the path has no extension.
+  ///
+  /// @param path the path string
+  /// @return the extension, or `""`
   public static String getExtension(final String path) {
     final String fileName = getFileName(path, true);
     if (!fileName.contains(".")) {
@@ -118,33 +108,27 @@ public final class FileUtilities {
     }
   }
 
-  /**
-   * Returns the file name (without extension) of the supplied URL.
-   *
-   * @param path the URL
-   * @return the file name without extension
-   */
+  /// Returns the file name (without extension) of the supplied URL.
+  ///
+  /// @param path the URL
+  /// @return the file name without extension
   public static String getFileName(URL path) {
     return getFileName(path.getPath());
   }
 
-  /**
-   * Returns the file name (without extension) of the supplied path string.
-   *
-   * @param path the path string
-   * @return the file name without extension
-   */
+  /// Returns the file name (without extension) of the supplied path string.
+  ///
+  /// @param path the path string
+  /// @return the file name without extension
   public static String getFileName(final String path) {
     return getFileName(path, false);
   }
 
-  /**
-   * Returns the file name of the supplied path string, optionally including the extension.
-   *
-   * @param path      the path string
-   * @param extension {@code true} to keep the extension; {@code false} to strip it
-   * @return the file name
-   */
+  /// Returns the file name of the supplied path string, optionally including the extension.
+  ///
+  /// @param path      the path string
+  /// @param extension `true` to keep the extension; `false` to strip it
+  /// @return the file name
   public static String getFileName(final String path, boolean extension) {
     if (path == null
       || path.isEmpty()
@@ -194,13 +178,11 @@ public final class FileUtilities {
     return parent.toString();
   }
 
-  /**
-   * This method combines the specified basepath with the parts provided as arguments. The output will use the path separator of the current system;
-   *
-   * @param basePath The base path for the combined path.
-   * @param paths    The parts of the path to be constructed.
-   * @return The combined path.
-   */
+  /// This method combines the specified basepath with the parts provided as arguments. The output will use the path separator of the current system;
+  ///
+  /// @param basePath The base path for the combined path.
+  /// @param paths    The parts of the path to be constructed.
+  /// @return The combined path.
   public static String combine(String basePath, final String... paths) {
     basePath = basePath.replace(FILE_SEPARATOR_WIN, FILE_SEPARATOR);
     try {

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/JsonUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/JsonUtilities.java
@@ -27,28 +27,21 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Counterpart to {@link XmlUtilities} for working with JSON resources using the
- * <a href="https://jakarta.ee/specifications/jsonb/">Jakarta JSON Binding</a> (JSON-B) and
- * <a href="https://jakarta.ee/specifications/jsonp/">Jakarta JSON Processing</a> (JSON-P) APIs.
- *
- * <p>
- * The class provides two layers of access:
- * </p>
- * <ul>
- *   <li>A binding layer ({@link #read(Class, URL)}, {@link #read(Class, Path)}, {@link #save(Object, Path)})
- *       that maps JSON documents to plain Java objects via JSON-B, mirroring the API offered by
- *       {@link XmlUtilities} for JAXB.</li>
- *   <li>A tree-model layer ({@link #readTree(URL)}, {@link #readTree(Path)}, {@link #saveTree(JsonValue, Path)})
- *       that exposes the underlying {@link JsonStructure} for cases where direct DOM-style access is
- *       preferable to data binding.</li>
- * </ul>
- *
- * <p>
- * Both layers cache their factories and {@link Jsonb} instances per configuration so repeated use
- * does not pay the cost of recreating them.
- * </p>
- */
+/// Counterpart to [XmlUtilities] for working with JSON resources using the
+/// [Jakarta JSON Binding](https://jakarta.ee/specifications/jsonb/) (JSON-B) and
+/// [Jakarta JSON Processing](https://jakarta.ee/specifications/jsonp/) (JSON-P) APIs.
+///
+/// The class provides two layers of access:
+///
+/// - A binding layer ([URL)][#read(Class,], [Path)][#read(Class,], [Path)][#save(Object,])
+/// that maps JSON documents to plain Java objects via JSON-B, mirroring the API offered by
+/// [XmlUtilities] for JAXB.
+/// - A tree-model layer ([#readTree(URL)], [#readTree(Path)], [Path)][#saveTree(JsonValue,])
+/// that exposes the underlying [JsonStructure] for cases where direct DOM-style access is
+/// preferable to data binding.
+///
+/// Both layers cache their factories and [Jsonb] instances per configuration so repeated use
+/// does not pay the cost of recreating them.
 public final class JsonUtilities {
   private static final Logger log = Logger.getLogger(JsonUtilities.class.getName());
 
@@ -64,12 +57,10 @@ public final class JsonUtilities {
     throw new UnsupportedOperationException();
   }
 
-  /**
-   * Returns a cached {@link Jsonb} instance configured with the requested formatting.
-   *
-   * @param pretty Whether the returned instance produces pretty-printed output.
-   * @return A shared, thread-safe {@link Jsonb} instance.
-   */
+  /// Returns a cached [Jsonb] instance configured with the requested formatting.
+  ///
+  /// @param pretty Whether the returned instance produces pretty-printed output.
+  /// @return A shared, thread-safe [Jsonb] instance.
   public static Jsonb getJsonb(boolean pretty) {
     return jsonbInstances.computeIfAbsent(pretty, key -> {
       JsonbConfig config = new JsonbConfig().withFormatting(key);
@@ -77,14 +68,12 @@ public final class JsonUtilities {
     });
   }
 
-  /**
-   * Reads a JSON document from the given URL and binds it to an instance of the requested class.
-   *
-   * @param cls  The target class.
-   * @param path The URL of the JSON document.
-   * @param <T>  The bound type.
-   * @return The bound instance, or {@code null} if the document cannot be read.
-   */
+  /// Reads a JSON document from the given URL and binds it to an instance of the requested class.
+  ///
+  /// @param cls  The target class.
+  /// @param path The URL of the JSON document.
+  /// @param <T>  The bound type.
+  /// @return The bound instance, or `null` if the document cannot be read.
   public static <T> T read(Class<T> cls, URL path) {
     if (path == null) {
       return null;
@@ -97,14 +86,12 @@ public final class JsonUtilities {
     }
   }
 
-  /**
-   * Reads a JSON document from the given path and binds it to an instance of the requested class.
-   *
-   * @param cls      The target class.
-   * @param filePath The path to the JSON document.
-   * @param <T>      The bound type.
-   * @return The bound instance, or {@code null} if the document cannot be read.
-   */
+  /// Reads a JSON document from the given path and binds it to an instance of the requested class.
+  ///
+  /// @param cls      The target class.
+  /// @param filePath The path to the JSON document.
+  /// @param <T>      The bound type.
+  /// @return The bound instance, or `null` if the document cannot be read.
   public static <T> T read(Class<T> cls, Path filePath) {
     if (filePath == null) {
       return null;
@@ -117,25 +104,21 @@ public final class JsonUtilities {
     }
   }
 
-  /**
-   * Reads a JSON document from the given reader and binds it to an instance of the requested class.
-   *
-   * @param cls    The target class.
-   * @param reader The reader providing the JSON content.
-   * @param <T>    The bound type.
-   * @return The bound instance.
-   */
+  /// Reads a JSON document from the given reader and binds it to an instance of the requested class.
+  ///
+  /// @param cls    The target class.
+  /// @param reader The reader providing the JSON content.
+  /// @param <T>    The bound type.
+  /// @return The bound instance.
   public static <T> T read(Class<T> cls, Reader reader) {
     return getJsonb(false).fromJson(reader, cls);
   }
 
-  /**
-   * Reads the JSON document referenced by the given URL into a {@link JsonStructure} (object or
-   * array). Useful when the document does not follow a fixed schema.
-   *
-   * @param path The URL of the JSON document.
-   * @return The parsed structure, or {@code null} if the document cannot be read.
-   */
+  /// Reads the JSON document referenced by the given URL into a [JsonStructure] (object or
+  /// array). Useful when the document does not follow a fixed schema.
+  ///
+  /// @param path The URL of the JSON document.
+  /// @return The parsed structure, or `null` if the document cannot be read.
   public static JsonStructure readTree(URL path) {
     if (path == null) {
       return null;
@@ -148,12 +131,10 @@ public final class JsonUtilities {
     }
   }
 
-  /**
-   * Reads the JSON document at the given path into a {@link JsonStructure} (object or array).
-   *
-   * @param filePath The path to the JSON document.
-   * @return The parsed structure, or {@code null} if the document cannot be read.
-   */
+  /// Reads the JSON document at the given path into a [JsonStructure] (object or array).
+  ///
+  /// @param filePath The path to the JSON document.
+  /// @return The parsed structure, or `null` if the document cannot be read.
   public static JsonStructure readTree(Path filePath) {
     if (filePath == null) {
       return null;
@@ -166,25 +147,21 @@ public final class JsonUtilities {
     }
   }
 
-  /**
-   * Reads the JSON document from the given reader into a {@link JsonStructure}.
-   *
-   * @param reader The reader providing the JSON content.
-   * @return The parsed structure.
-   */
+  /// Reads the JSON document from the given reader into a [JsonStructure].
+  ///
+  /// @param reader The reader providing the JSON content.
+  /// @return The parsed structure.
   public static JsonStructure readTree(Reader reader) {
     try (JsonReader jsonReader = readerFactory.createReader(reader)) {
       return jsonReader.read();
     }
   }
 
-  /**
-   * Binds the given object to JSON and writes it to the specified path (pretty-printed).
-   *
-   * @param object   The object to serialize.
-   * @param filePath The destination path.
-   * @return The destination path, or {@code null} if the path is {@code null} or writing fails.
-   */
+  /// Binds the given object to JSON and writes it to the specified path (pretty-printed).
+  ///
+  /// @param object   The object to serialize.
+  /// @param filePath The destination path.
+  /// @return The destination path, or `null` if the path is `null` or writing fails.
   public static Path save(Object object, Path filePath) {
     if (filePath == null) {
       return null;
@@ -198,15 +175,13 @@ public final class JsonUtilities {
     return filePath;
   }
 
-  /**
-   * Binds the given object to JSON and writes it to the specified path, ensuring the path ends with
-   * the supplied extension (e.g. {@code "json"} or {@code ".json"}).
-   *
-   * @param object    The object to serialize.
-   * @param path      The destination path.
-   * @param extension The file extension (with or without a leading dot).
-   * @return The actual destination path used.
-   */
+  /// Binds the given object to JSON and writes it to the specified path, ensuring the path ends with
+  /// the supplied extension (e.g. `"json"` or `".json"`).
+  ///
+  /// @param object    The object to serialize.
+  /// @param path      The destination path.
+  /// @param extension The file extension (with or without a leading dot).
+  /// @return The actual destination path used.
   public static Path save(Object object, Path path, String extension) {
     String fullExtension = extension.startsWith(".") ? extension : "." + extension;
     Path fullPath = path;
@@ -216,25 +191,21 @@ public final class JsonUtilities {
     return save(object, fullPath);
   }
 
-  /**
-   * Binds the given object to JSON and writes it to the supplied writer.
-   *
-   * @param object The object to serialize.
-   * @param writer The writer to write the JSON to.
-   * @param pretty Whether to pretty-print the output.
-   */
+  /// Binds the given object to JSON and writes it to the supplied writer.
+  ///
+  /// @param object The object to serialize.
+  /// @param writer The writer to write the JSON to.
+  /// @param pretty Whether to pretty-print the output.
   public static void save(Object object, Writer writer, boolean pretty) {
     getJsonb(pretty).toJson(object, writer);
   }
 
-  /**
-   * Writes a {@link JsonValue} tree to the specified path.
-   *
-   * @param value    The JSON value to write.
-   * @param filePath The destination path.
-   * @param pretty   Whether to pretty-print the output.
-   * @return The destination path, or {@code null} if writing fails.
-   */
+  /// Writes a [JsonValue] tree to the specified path.
+  ///
+  /// @param value    The JSON value to write.
+  /// @param filePath The destination path.
+  /// @param pretty   Whether to pretty-print the output.
+  /// @return The destination path, or `null` if writing fails.
   public static Path saveTree(JsonValue value, Path filePath, boolean pretty) {
     if (filePath == null || value == null) {
       return null;
@@ -250,24 +221,20 @@ public final class JsonUtilities {
     return filePath;
   }
 
-  /**
-   * Convenience overload that pretty-prints by default.
-   *
-   * @param value    The JSON value to write.
-   * @param filePath The destination path.
-   * @return The destination path.
-   */
+  /// Convenience overload that pretty-prints by default.
+  ///
+  /// @param value    The JSON value to write.
+  /// @param filePath The destination path.
+  /// @return The destination path.
   public static Path saveTree(JsonValue value, Path filePath) {
     return saveTree(value, filePath, true);
   }
 
-  /**
-   * Serializes the given JSON value to a string.
-   *
-   * @param value  The JSON value to serialize.
-   * @param pretty Whether to pretty-print the output.
-   * @return The serialized JSON string.
-   */
+  /// Serializes the given JSON value to a string.
+  ///
+  /// @param value  The JSON value to serialize.
+  /// @param pretty Whether to pretty-print the output.
+  /// @return The serialized JSON string.
   public static String writeTreeToString(JsonValue value, boolean pretty) {
     JsonWriterFactory factory = pretty ? prettyWriterFactory : compactWriterFactory;
     java.io.StringWriter sw = new java.io.StringWriter();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/URLAdapter.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/URLAdapter.java
@@ -8,30 +8,24 @@ import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-/**
- * This class allows for absolute and relative URLs to be unmarshalled as Java URL objects.
- *
- * @see XmlJavaTypeAdapter
- */
+/// This class allows for absolute and relative URLs to be unmarshalled as Java URL objects.
+///
+/// @see XmlJavaTypeAdapter
 public class URLAdapter extends XmlAdapter<String, URL> {
   private URL base;
 
-  /**
-   * Constructs a new {@code URLAdapter}, with no additional properties. This constructor is called if no configured
-   * instance is available to an unmarshaller.
-   */
+  /// Constructs a new `URLAdapter`, with no additional properties. This constructor is called if no configured
+  /// instance is available to an unmarshaller.
   public URLAdapter() {
     this(null);
   }
 
-  /**
-   * Constructs a new {@code URLAdapter}, configured to use relative URLs using the supplied URL as a base.
-   *
-   * @param base
-   *          The base URL to use
-   * @see Unmarshaller#setAdapter(XmlAdapter)
-   * @see Marshaller#setAdapter(XmlAdapter)
-   */
+  /// Constructs a new `URLAdapter`, configured to use relative URLs using the supplied URL as a base.
+  ///
+  /// @param base
+  /// The base URL to use
+  /// @see Unmarshaller#setAdapter(XmlAdapter)
+  /// @see Marshaller#setAdapter(XmlAdapter)
   public URLAdapter(URL base) {
     this.base = base;
   }
@@ -88,11 +82,9 @@ public class URLAdapter extends XmlAdapter<String, URL> {
     return builder.substring(1);
   }
 
-  /**
-   * Gets the base URL used by this {@code URLAdapter} instance.
-   *
-   * @return The base URL used, or {@code null} if this instance has not been configured for relative URLs
-   */
+  /// Gets the base URL used by this `URLAdapter` instance.
+  ///
+  /// @return The base URL used, or `null` if this instance has not been configured for relative URLs
   public URL getBaseURL() {
     return this.base;
   }

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
@@ -36,14 +36,12 @@ public final class XmlUtilities {
     jaxbContexts = new ConcurrentHashMap<>();
   }
 
-  /**
-   * Saves the XML, contained by the specified input with the custom indentation. If the input is the result of jaxb marshalling, make sure to set
-   * Marshaller.JAXB_FORMATTED_OUTPUT to false in order for this method to work properly.
-   *
-   * @param input       The input stream that contains the original XML.
-   * @param fos         The output stream that is used to save the XML.
-   * @param indentation The indentation with which the XML should be saved.
-   */
+  /// Saves the XML, contained by the specified input with the custom indentation. If the input is the result of jaxb marshalling, make sure to set
+  /// Marshaller.JAXB_FORMATTED_OUTPUT to false in order for this method to work properly.
+  ///
+  /// @param input       The input stream that contains the original XML.
+  /// @param fos         The output stream that is used to save the XML.
+  /// @param indentation The indentation with which the XML should be saved.
   public static void saveWithCustomIndentation(ByteArrayInputStream input, OutputStream fos, int indentation) {
     try {
       TransformerFactory transformerFactory = TransformerFactory.newInstance();

--- a/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
+++ b/litiengine/src/main/java/de/gurkenlabs/litiengine/util/io/XmlUtilities.java
@@ -23,6 +23,12 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 
+/// JAXB helpers used to read and write engine XML resources.
+///
+/// JAXB contexts are cached by root type. Convenience save methods log marshalling failures and
+/// return the requested path; [#read(Class, URL)] exposes unmarshalling failures to its caller.
+///
+/// @see de.gurkenlabs.litiengine.resources.Resources
 public final class XmlUtilities {
   private static final Logger log = Logger.getLogger(XmlUtilities.class.getName());
 
@@ -36,8 +42,11 @@ public final class XmlUtilities {
     jaxbContexts = new ConcurrentHashMap<>();
   }
 
-  /// Saves the XML, contained by the specified input with the custom indentation. If the input is the result of jaxb marshalling, make sure to set
-  /// Marshaller.JAXB_FORMATTED_OUTPUT to false in order for this method to work properly.
+  /// Writes XML with custom indentation and closes the output stream after a successful transformation.
+  ///
+  /// If `input` is the result of JAXB marshalling, set [Marshaller#JAXB_FORMATTED_OUTPUT] to `false`
+  /// so existing indentation does not interfere. Transformation, flushing, and closing failures are
+  /// logged rather than propagated. The input stream is not closed.
   ///
   /// @param input       The input stream that contains the original XML.
   /// @param fos         The output stream that is used to save the XML.
@@ -61,6 +70,13 @@ public final class XmlUtilities {
     }
   }
 
+  /// Returns the cached JAXB context for a root type, creating it when necessary.
+  ///
+  /// Context-creation failures are logged.
+  ///
+  /// @param cls The JAXB root type.
+  /// @param <T> The root type.
+  /// @return The cached context, or `null` if it could not be created.
   public static <T> JAXBContext getContext(Class<T> cls) {
     try {
       final JAXBContext jaxbContext;
@@ -78,6 +94,13 @@ public final class XmlUtilities {
     return null;
   }
 
+  /// Unmarshals an XML resource and resolves relative URLs against that resource.
+  ///
+  /// @param cls The expected root type.
+  /// @param path The resource URL.
+  /// @param <T> The root type.
+  /// @return The unmarshalled object, or `null` if a JAXB context could not be created.
+  /// @throws JAXBException if unmarshalling fails.
   public static <T> T read(Class<T> cls, URL path) throws JAXBException {
     final JAXBContext jaxbContext = getContext(cls);
     if (jaxbContext == null) {
@@ -90,6 +113,13 @@ public final class XmlUtilities {
     return cls.cast(um.unmarshal(path));
   }
 
+  /// Marshals an object to a file using formatted XML output.
+  ///
+  /// Marshalling failures are logged rather than thrown.
+  ///
+  /// @param object The JAXB object to save.
+  /// @param filePath The destination path.
+  /// @return `filePath`, or `null` when the path or JAXB context is unavailable.
   public static Path save(Object object, Path filePath) {
     if (filePath == null) {
       return null;
@@ -108,6 +138,12 @@ public final class XmlUtilities {
     return filePath;
   }
 
+  /// Marshals an object after ensuring that the destination has an extension.
+  ///
+  /// @param object The JAXB object to save.
+  /// @param path The destination path without or with an extension.
+  /// @param extension The required extension, with or without a leading dot.
+  /// @return The actual destination path, or `null` if saving could not be initialized.
   public static Path save(Object object, Path path, String extension) {
     String fullExtension = extension.startsWith(".") ? extension : "." + extension;
     Path fullPath = path;

--- a/litiengine/src/test/java/de/gurkenlabs/litiengine/scripting/ScriptSequenceCinematicTests.java
+++ b/litiengine/src/test/java/de/gurkenlabs/litiengine/scripting/ScriptSequenceCinematicTests.java
@@ -47,4 +47,17 @@ class ScriptSequenceCinematicTests {
     context.close();
     assertFalse(sequence.isRunning());
   }
+
+  @Test
+  void testSinglePendingStepIsRunning() {
+    ScriptDefinition definition = new ScriptDefinition("seq-test", "java", null, "Dummy", ScriptHostType.GAME);
+    ScriptContext<Object> context = new ScriptContext<>(definition, new ScriptBinding("seq-test"), new Object());
+    ScriptSequence sequence = context.sequence().waitFor(1000).then(() -> {});
+
+    sequence.start();
+
+    assertTrue(sequence.isRunning());
+    context.close();
+    assertFalse(sequence.isRunning());
+  }
 }

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/MonacoResourceServer.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/MonacoResourceServer.java
@@ -8,12 +8,14 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 
 /** Serves only bundled editor assets on a tokenized loopback origin. */
 final class MonacoResourceServer implements AutoCloseable {
-  private static final String MONACO_ROOT = "META-INF/resources/webjars/monaco-editor/0.55.1/";
+  private static final String MONACO_METADATA = "META-INF/maven/org.webjars.npm/monaco-editor/pom.properties";
+  private static final String MONACO_ROOT_PREFIX = "META-INF/resources/webjars/monaco-editor/";
   private static final String EDITOR_ROOT = "de/gurkenlabs/utiliti/script-editor/";
   private static final Map<String, String> CONTENT_TYPES = Map.of(
     "html", "text/html; charset=utf-8",
@@ -24,9 +26,11 @@ final class MonacoResourceServer implements AutoCloseable {
     "svg", "image/svg+xml");
 
   private final HttpServer server;
+  private final String monacoRoot;
   private final String token = UUID.randomUUID().toString().replace("-", "");
 
   MonacoResourceServer() throws IOException {
+    this.monacoRoot = resolveMonacoRoot();
     this.server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
     this.server.createContext("/" + this.token + "/", this::serve);
     this.server.setExecutor(Executors.newVirtualThreadPerTaskExecutor());
@@ -52,7 +56,7 @@ final class MonacoResourceServer implements AutoCloseable {
       }
       String relative = path.substring(prefix.length());
       String resource = relative.startsWith("monaco/")
-        ? MONACO_ROOT + relative.substring("monaco/".length())
+        ? this.monacoRoot + relative.substring("monaco/".length())
         : relative.startsWith("editor/") ? EDITOR_ROOT + relative.substring("editor/".length()) : null;
       if (resource == null) {
         send(exchange, 404, new byte[0]);
@@ -81,6 +85,22 @@ final class MonacoResourceServer implements AutoCloseable {
             + "font-src 'self' data:; img-src 'self' data:; worker-src 'self' blob:; connect-src 'self'");
         send(exchange, 200, stream.readAllBytes());
       }
+    }
+  }
+
+  private static String resolveMonacoRoot() throws IOException {
+    ClassLoader classLoader = MonacoResourceServer.class.getClassLoader();
+    try (InputStream input = classLoader.getResourceAsStream(MONACO_METADATA)) {
+      if (input == null) {
+        throw new IOException("Monaco WebJar metadata is missing: " + MONACO_METADATA);
+      }
+      Properties metadata = new Properties();
+      metadata.load(input);
+      String version = metadata.getProperty("version");
+      if (version == null || version.isBlank()) {
+        throw new IOException("Monaco WebJar metadata does not declare a version: " + MONACO_METADATA);
+      }
+      return MONACO_ROOT_PREFIX + version + "/";
     }
   }
 

--- a/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/PropertyPanel.java
+++ b/utiliti/src/main/java/de/gurkenlabs/utiliti/view/components/PropertyPanel.java
@@ -643,14 +643,14 @@ public abstract class PropertyPanel extends JPanel {
     return groupLayout;
   }
 
+  private boolean applying;
+
   /**
    * Applies changes to the map object by invoking the provided update action. This method also manages the undo/redo functionality and updates the
    * environment.
    *
    * @param updateAction the action to apply to the map object
    */
-  private boolean applying;
-
   protected void applyChanges(Consumer<IMapObject> updateAction) {
     if (applying) {
       return;

--- a/utiliti/src/test/java/de/gurkenlabs/utiliti/view/components/ScriptLanguageServiceIntegrationTest.java
+++ b/utiliti/src/test/java/de/gurkenlabs/utiliti/view/components/ScriptLanguageServiceIntegrationTest.java
@@ -18,19 +18,13 @@ class ScriptLanguageServiceIntegrationTest {
   void servesMonacoEditorAssetsOverLoopbackServer() throws Exception {
     try (MonacoResourceServer server = new MonacoResourceServer()) {
       String baseUrl = server.editorUrl().replace("/editor/index.html", "");
-      for (String path : java.util.List.of("/editor/index.html", "/editor/bootstrap.js", "/editor/editor.js", "/editor/editor.css", "/monaco/min/vs/loader.js", "/monaco/min/vs/editor/editor.main.js")) {
-        java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
+      java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
+      for (String path : java.util.List.of("/editor/index.html", "/editor/bootstrap.js", "/editor/editor.js", "/editor/editor.css", "/monaco/min/vs/loader.js", "/monaco/min/vs/editor/editor.main.js", "/monaco/min/vs/loader")) {
         java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder(java.net.URI.create(baseUrl + path)).GET().build();
         java.net.http.HttpResponse<String> response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode(), "Failed to serve " + path);
         assertFalse(response.body().isEmpty(), "Empty response for " + path);
       }
-      // Test chunk request without extension
-      java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
-      java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder(java.net.URI.create(baseUrl + "/monaco/min/vs/monaco.contribution-EcChJV6a")).GET().build();
-      java.net.http.HttpResponse<String> response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
-      assertEquals(200, response.statusCode(), "Failed to serve extensionless chunk request /monaco/min/vs/monaco.contribution-EcChJV6a");
-      assertFalse(response.body().isEmpty(), "Empty response for chunk request");
     }
   }
 }


### PR DESCRIPTION
## Summary

Migrates the engine’s Javadocs to Java 23 native Markdown syntax (`///`) as introduced by JEP 467.

## Changes

- Convert engine Javadocs from `/** ... */` comments and embedded HTML to native Markdown.
- Replace HTML lists, paragraphs, links, and code blocks with readable Markdown equivalents.
- Improve public API documentation across core engine packages, especially:
  - abilities
  - entities and environments
  - graphics and GUI
  - resources
  - scripting
  - TMX and Wang terrain models
- Add package-level guides with links to important entry points and related implementations.
- Clarify units, nullability, mutability, ownership, lifecycle behavior, defaults, and error handling.
- Align scripted screen-shake parameter names with their documented millisecond semantics.
- Correct `ScriptSequence.isRunning()` so a single scheduled action remains reported as running until it executes or is cancelled.
- Add regression coverage for the corrected sequence lifecycle.

## Motivation

Native Markdown makes source documentation easier to read and maintain while still allowing the standard Javadoc tool to generate HTML documentation.

The additional documentation pass makes the public API easier to navigate by describing behavior and linking interfaces, builders, implementations, and related services.

## Compatibility

No public API signatures were removed or intentionally changed.

The `ScriptSequence.isRunning()` adjustment is a behavioral correction: it now matches its documented contract while an action is pending.

## Validation

- `./gradlew spotlessCheck`
- `./gradlew :litiengine:compileJava`
- `./gradlew :litiengine:javadoc`
- `./gradlew :litiengine:test --tests 'de.gurkenlabs.litiengine.scripting.*'`
- `./gradlew :litiengine:test --tests de.gurkenlabs.litiengine.scripting.ScriptSequenceCinematicTests`