### PR TITLE
Javadoc Theme Refinements & Zero-Flicker Performance Fixes

### DIFF
--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -98,8 +98,57 @@ void enhanceJavadocHtml(File file, File rootDir) {
   <meta name="twitter:description" content="Official Java API reference documentation for ${cleanHeading} in the LITIENGINE 2D Game Engine.">
 """
 
+  headAdditions += """  <script>(function(){try{var t=localStorage.getItem('liti-theme')||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>\n"""
+
   if (html.contains("</head>")) {
     html = html.replace("</head>", headAdditions + "\n</head>")
+  }
+
+  // 2. Generation-Time 2-Level Header (Eliminates DOM delay on large pages like index-all.html)
+  def navMatcher = (html =~ /(?s)(<ul id="navbar-top-firstrow"[^>]*>.*?<\/ul>)/)
+  if (navMatcher) {
+    def origNavList = navMatcher[0][1]
+    def backlink = '<li class="nav-item-backlink"><a href="https://docs.litiengine.com/" class="nav-link-docs" title="Back to LITIENGINE Documentation"><svg class="docs-back-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg><span>Docs</span></a></li>'
+    def enhancedNavList = origNavList.replaceFirst(/(<ul[^>]*>)/, "\$1\n${backlink}")
+
+    def level1Html = """
+  <div class="liti-header-level1">
+    <div class="liti-header-container">
+      <a class="liti-brand-link" href="https://docs.litiengine.com/">
+        <img class="liti-brand-logo" src="${r}assets/logo.png" alt="LITIENGINE Logo" width="28.79" height="28.79">
+        <span class="liti-brand-text"><strong>LITIENGINE Docs</strong> <span class="api-tag">API</span></span>
+      </a>
+      <div class="liti-header-level1-right">
+        <button type="button" class="liti-theme-toggle" title="Toggle dark / light mode" aria-label="Toggle theme">
+          <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+        <div class="nav-list-search">
+          <span class="search-icon-wrapper"><svg class="search-icon-svg" viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg></span>
+          <input type="text" id="search-input" placeholder="Search" autocomplete="off">
+          <kbd class="search-kbd">Ctrl+K</kbd>
+        </div>
+        <a href="https://github.com/gurkenlabs/litiengine" target="_blank" rel="noopener noreferrer" class="liti-github-link">
+          <svg class="github-icon" viewBox="0 0 24 24" width="19" height="19" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg> <span>gurkenlabs/litiengine</span>
+        </a>
+      </div>
+    </div>
+  </div>"""
+
+    def level2Html = """
+  <div class="liti-header-level2">
+    <div class="liti-header-container">
+      ${enhancedNavList}
+      <a href="https://opencollective.com/litiengine" target="_blank" rel="noopener noreferrer" class="md-tabs__link--sponsor">
+        <svg class="sponsor-heart-icon" viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg> <span>Sponsor</span>
+      </a>
+    </div>
+  </div>"""
+
+    def newTopNav = """<div class="top-nav" id="navbar-top">${level1Html}${level2Html}\n</div>"""
+    // Remove the old nav-list-search from sub-nav first
+    html = html.replaceFirst(/(?s)<div class="nav-list-search">.*?<\/div>/, '')
+    // Replace the entire top-nav block cleanly up to sub-nav
+    html = html.replaceFirst(/(?s)<div class="top-nav" id="navbar-top">.*?<\/div>(?=\s*<div class="sub-nav">)/, newTopNav)
   }
 
   // 2. Build Contextual Tags at generation time

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -52,6 +52,14 @@ tasks.withType(Javadoc).configureEach {
 
     // Generation-time HTML adjustments (Favicons, Fonts, SEO/GEO metadata, Bottom Tags, and Footer)
     if (destinationDir && destinationDir.exists()) {
+      // Optimize stylesheet.css by stripping unused @import url('fonts/dejavu.css');
+      def stylesheetFile = new File(destinationDir, 'resource-files/stylesheet.css')
+      if (stylesheetFile.exists()) {
+        def css = stylesheetFile.getText('UTF-8')
+        css = css.replace("@import url('fonts/dejavu.css');", "/* dejavu.css omitted */")
+        stylesheetFile.setText(css, 'UTF-8')
+      }
+
       destinationDir.eachFileRecurse(groovy.io.FileType.FILES) { file ->
         if (file.name.endsWith(".html")) {
           enhanceJavadocHtml(file, destinationDir)

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -149,7 +149,8 @@ void enhanceJavadocHtml(File file, File rootDir) {
     </div>
   </div>"""
 
-    def newTopNav = """<div class="top-nav" id="navbar-top">${level1Html}${level2Html}\n</div>"""
+    def hiddenToggleBtn = '<button id="navbar-toggle-button" aria-controls="navbar-top" aria-expanded="false" aria-label="Toggle navigation links" style="display:none;"></button>'
+    def newTopNav = """<div class="top-nav" id="navbar-top">${hiddenToggleBtn}${level1Html}${level2Html}\n</div>"""
     // Remove the old nav-list-search from sub-nav first
     html = html.replaceFirst(/(?s)<div class="nav-list-search">.*?<\/div>/, '')
     // Replace the entire top-nav block cleanly up to sub-nav

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -154,6 +154,39 @@ void enhanceJavadocHtml(File file, File rootDir) {
     html = html.replaceFirst(/(?s)<div class="nav-list-search">.*?<\/div>/, '')
     // Replace the entire top-nav block cleanly up to sub-nav
     html = html.replaceFirst(/(?s)<div class="top-nav" id="navbar-top">.*?<\/div>(?=\s*<div class="sub-nav">)/, newTopNav)
+
+    // Remove empty sub-nav on pages without breadcrumbs (overview, tree, index, search, etc.)
+    html = html.replaceAll(/(?s)<div class="sub-nav">\s*<div class="nav-content">\s*<ol class="sub-nav-list">\s*<\/ol>\s*<\/div>\s*<\/div>/, '')
+
+    // Statically pre-render sticky alphabet bar on index-all.html
+    if (file.name == 'index-all.html') {
+      def jumpMatcher = (html =~ /(?s)<div class="header">\s*<h1>Index<\/h1>\s*<\/div>\s*(.*?)(?=<h2 class="title" id="I:A">)/)
+      if (jumpMatcher) {
+        def rawJump = jumpMatcher[0][1]
+        def letterLinks = []
+        def letM = (rawJump =~ /<a href="#I:[A-Z]">([A-Z])<\/a>/)
+        while (letM.find()) {
+          letterLinks.add(letM.group(0))
+        }
+        def secondaryLinks = []
+        def secM = (rawJump =~ /<a href="[^"]*?(allclasses-index|allpackages-index|constant-values|serialized-form)\.html">(.*?)<\/a>/)
+        while (secM.find()) {
+          secondaryLinks.add(secM.group(0))
+        }
+
+        def stickyBarHtml = """<div class="index-sticky-bar">
+  <div class="index-letters-container">
+    ${letterLinks.join('\n    ')}
+  </div>
+  <div class="index-secondary-container">
+    ${secondaryLinks.join('\n    ')}
+  </div>
+</div>\n"""
+
+        html = html.replace(jumpMatcher[0][0], """<div class="header"><h1>Index</h1></div>\n${stickyBarHtml}""")
+        html = html.replaceAll(/(?s)<\/dl>\s*<a href="#I:A">A<\/a>.*?<\/main>/, '</dl>\n</main>')
+      }
+    }
   }
 
   // 2. Build Contextual Tags at generation time

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -134,10 +134,12 @@ void enhanceJavadocHtml(File file, File rootDir) {
   if (cleanHeading.endsWith("Listener")) tags.add("listener")
   if (cleanHeading.endsWith("Event")) tags.add("event")
   if (cleanHeading.endsWith("Controller")) tags.add("controller")
-  if (html.contains("deprecation-block") || html.contains("deprecated-label")) tags.add("deprecated")
-
-  if (tags.size() < 4) tags.add("api")
-  if (tags.size() < 5) tags.add("java")
+  if (file.name == 'search.html' || file.name == 'help-doc.html') {
+    tags.clear()
+  } else {
+    if (tags.size() < 4) tags.add("api")
+    if (tags.size() < 5) tags.add("java")
+  }
 
   // 2. Insert Bottom Tags inside <main>
   if (tags && html.contains("</main>")) {

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -68,7 +68,7 @@ void enhanceJavadocHtml(File file, File rootDir) {
   def html = file.getText("UTF-8")
   if (html.contains("<!-- liti-enhanced -->")) return
 
-  // 1. Early Head Injections (Theme script, Critical font variables & Fonts at the very top of <head> before any CSS/scripts)
+  // 1. Early Head Injections (Theme script & Critical font variables at the very top of <head> before any CSS/scripts)
   def earlyHead = """<head>
   <!-- liti-enhanced -->
   <script>(function(){try{var t=localStorage.getItem('liti-theme')||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
@@ -88,10 +88,7 @@ void enhanceJavadocHtml(File file, File rootDir) {
       font-size: var(--body-font-size);
       line-height: var(--block-line-height);
     }
-  </style>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=optional" rel="stylesheet">"""
+  </style>"""
   html = html.replaceFirst("<head>", earlyHead)
 
   // 2. Metadata & Favicons in <head>

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -120,7 +120,7 @@ void enhanceJavadocHtml(File file, File rootDir) {
   <div class="liti-header-level1">
     <div class="liti-header-container">
       <a class="liti-brand-link" href="https://docs.litiengine.com/">
-        <img class="liti-brand-logo" src="${r}assets/logo.png" alt="LITIENGINE Logo" width="28.79" height="28.79">
+        <img class="liti-brand-logo" src="${r}assets/icon.png" alt="LITIENGINE Logo" width="28.79" height="28.79">
         <span class="liti-brand-text"><strong>LITIENGINE Docs</strong> <span class="api-tag">API</span></span>
       </a>
       <div class="liti-header-level1-right">

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -208,6 +208,15 @@ void enhanceJavadocHtml(File file, File rootDir) {
         """<div class="page-search-wrapper">${searchIconSvg}${inp}${resetStr}</div>"""
       }
     }
+
+    // Statically enhance TOC filter input on pages with a table of contents
+    def tocFilterPattern = /(?s)<div class="toc-header">\s*(?:Contents&nbsp;)?(<input type="text" class="filter-input"[^>]*>)\s*(<input type="reset" class="reset-filter"[^>]*>)?\s*<\/div>/
+    def tocSearchSvg = '<span class="search-icon-wrapper"><svg class="search-icon-svg" viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg></span>'
+    html = html.replaceAll(tocFilterPattern) { full, inp, rst ->
+      def cleanInp = inp.replace('placeholder="Filter contents (type .)"', 'placeholder="Filter"')
+      def resetStr = rst ?: ''
+      """<div class="toc-header"><div class="toc-filter-wrapper">${tocSearchSvg}${cleanInp}${resetStr}</div></div>"""
+    }
   }
 
   // 2. Build Contextual Tags at generation time

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -158,6 +158,17 @@ void enhanceJavadocHtml(File file, File rootDir) {
     // Remove empty sub-nav on pages without breadcrumbs (overview, tree, index, search, etc.)
     html = html.replaceAll(/(?s)<div class="sub-nav">\s*<div class="nav-content">\s*<ol class="sub-nav-list">\s*<\/ol>\s*<\/div>\s*<\/div>/, '')
 
+    // Remove redundant single-level "java.lang.Object" inheritance tree on class declaration pages
+    html = html.replaceAll(/(?s)<div class="inheritance" title="Inheritance Tree">\s*<a href="[^"]*?Object\.html"[^>]*?>java\.lang\.Object<\/a>\s*<div class="inheritance">([^<]+)<\/div>\s*<\/div>/, '')
+
+    // Remove redundant "extends Object" from type-signature if class only extends Object
+    html = html.replaceAll(/(?s)<span class="extends-implements">\s*extends\s*<a href="[^"]*?Object\.html"[^>]*?>Object<\/a>\s*<\/span>/, '')
+
+    // Unwrap java.lang.Object root node in hierarchy trees
+    if (file.name.endsWith('-tree.html')) {
+      html = html.replaceAll(/(?s)<li class="circle">java\.lang\.<a href="[^"]*?Object\.html"[^>]*?>Object<\/a>\s*<ul>(.*?)<\/ul>\s*<\/li>/, '$1')
+    }
+
     // Statically pre-render sticky alphabet bar on index-all.html
     if (file.name == 'index-all.html') {
       def jumpMatcher = (html =~ /(?s)<div class="header">\s*<h1>Index<\/h1>\s*<\/div>\s*(.*?)(?=<h2 class="title" id="I:A">)/)

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -187,6 +187,16 @@ void enhanceJavadocHtml(File file, File rootDir) {
         html = html.replaceAll(/(?s)<\/dl>\s*<a href="#I:A">A<\/a>.*?<\/main>/, '</dl>\n</main>')
       }
     }
+
+    // Statically pre-render search box wrapper on search.html
+    if (file.name == 'search.html') {
+      def searchInputPattern = /(?s)(<input type="text" id="page-search-input"[^>]*>)\s*(<input type="reset" id="page-search-reset"[^>]*>)?/
+      def searchIconSvg = '<span class="page-search-icon"><svg class="search-icon-svg" viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg></span>'
+      html = html.replaceFirst(searchInputPattern) { full, inp, rst ->
+        def resetStr = rst ?: ''
+        """<div class="page-search-wrapper">${searchIconSvg}${inp}${resetStr}</div>"""
+      }
+    }
   }
 
   // 2. Build Contextual Tags at generation time

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -68,12 +68,17 @@ void enhanceJavadocHtml(File file, File rootDir) {
   def html = file.getText("UTF-8")
   if (html.contains("<!-- liti-enhanced -->")) return
 
-  // 1. Favicons & Fonts in <head>
-  def headAdditions = """
+  // 1. Early Head Injections (Theme script & Fonts at the very top of <head> before any CSS/scripts)
+  def earlyHead = """<head>
   <!-- liti-enhanced -->
+  <script>(function(){try{var t=localStorage.getItem('liti-theme')||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Montserrat:wght@400;500;600;700&family=Roboto:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">"""
+  html = html.replaceFirst("<head>", earlyHead)
+
+  // 2. Metadata & Favicons in <head>
+  def headAdditions = """
   <link rel="icon" type="image/png" sizes="32x32" href="${r}assets/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="${r}assets/favicon-16x16.png">
   <link rel="shortcut icon" href="${r}assets/favicon.ico">
@@ -100,8 +105,6 @@ void enhanceJavadocHtml(File file, File rootDir) {
   <meta name="twitter:title" content="${cleanHeading} | LITIENGINE API">
   <meta name="twitter:description" content="Official Java API reference documentation for ${cleanHeading} in the LITIENGINE 2D Game Engine.">
 """
-
-  headAdditions += """  <script>(function(){try{var t=localStorage.getItem('liti-theme')||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>\n"""
 
   if (html.contains("</head>")) {
     html = html.replace("</head>", headAdditions + "\n</head>")

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -167,7 +167,7 @@ void enhanceJavadocHtml(File file, File rootDir) {
     </a>
   </div>
   <div class="md-copyright">
-    <span>Copyright &copy; 2026 GURKENLABS &middot; Released under the <a href="https://mit-license.org/" target="_blank" rel="noopener noreferrer">MIT License</a></span>
+    <span><a href="https://docs.litiengine.com/" target="_blank" rel="noopener noreferrer">Documentation</a> &middot; Copyright &copy; 2026 GURKENLABS &middot; Released under the <a href="https://mit-license.org/" target="_blank" rel="noopener noreferrer">MIT License</a></span>
   </div>
 </footer>
 """

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -28,6 +28,9 @@ tasks.withType(Javadoc).configureEach {
   options.header = """<a href="${engineUrl}" target="_blank" class="nav-brand-link"><b>${engineName} 🎮</b> API</a>"""
   options.bottom = """<p class="legal-copy"><small>Copyright &#169; ${copyrightText}. Released under the <a href="${mitUrl}" target="_blank">${mitName} License</a>.</small></p>"""
 
+  options.noDeprecatedList = true
+  options.noHelp = true
+
   if (themeCss.exists()) {
     options.addStringOption("-add-stylesheet", themeCss.absolutePath)
   }
@@ -108,6 +111,8 @@ void enhanceJavadocHtml(File file, File rootDir) {
   def navMatcher = (html =~ /(?s)(<ul id="navbar-top-firstrow"[^>]*>.*?<\/ul>)/)
   if (navMatcher) {
     def origNavList = navMatcher[0][1]
+    origNavList = origNavList.replaceAll(/(?s)<li>\s*<a[^>]*href="[^"]*(deprecated-list|help-doc)\.html[^"]*"[^>]*>.*?<\/li>/, '')
+    origNavList = origNavList.replaceAll(/(?s)<li class="nav-bar-cell1-rev">\s*(Deprecated|Help)\s*<\/li>/, '')
     def backlink = '<li class="nav-item-backlink"><a href="https://docs.litiengine.com/" class="nav-link-docs" title="Back to LITIENGINE Documentation"><svg class="docs-back-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg><span>Docs</span></a></li>'
     def enhancedNavList = origNavList.replaceFirst(/(<ul[^>]*>)/, "\$1\n${backlink}")
 

--- a/buildSrc/src/main/groovy/javadoc-defaults.gradle
+++ b/buildSrc/src/main/groovy/javadoc-defaults.gradle
@@ -68,13 +68,30 @@ void enhanceJavadocHtml(File file, File rootDir) {
   def html = file.getText("UTF-8")
   if (html.contains("<!-- liti-enhanced -->")) return
 
-  // 1. Early Head Injections (Theme script & Fonts at the very top of <head> before any CSS/scripts)
+  // 1. Early Head Injections (Theme script, Critical font variables & Fonts at the very top of <head> before any CSS/scripts)
   def earlyHead = """<head>
   <!-- liti-enhanced -->
   <script>(function(){try{var t=localStorage.getItem('liti-theme')||(window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <style>
+    :root {
+      --body-font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+      --code-font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+      --body-font-size: 16px;
+      --block-font-size: 16px;
+      --code-font-size: 14px;
+      --nav-font-size: 16.8px;
+      --block-line-height: 1.6;
+      --code-line-height: 1.55;
+    }
+    html, body {
+      font-family: var(--body-font-family);
+      font-size: var(--body-font-size);
+      line-height: var(--block-line-height);
+    }
+  </style>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">"""
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=optional" rel="stylesheet">"""
   html = html.replaceFirst("<head>", earlyHead)
 
   // 2. Metadata & Favicons in <head>

--- a/config/javadoc/generate_js.py
+++ b/config/javadoc/generate_js.py
@@ -112,14 +112,49 @@ js_code = """/**
   function setupTwoLevelNavigation() {
     try {
       const header = document.querySelector('header[role="banner"]');
-      if (!header || document.querySelector('.liti-header-level1')) return;
+      if (!header) return;
+
+      const themeBtn = header.querySelector('.liti-theme-toggle');
+      if (themeBtn) {
+        function updateToggleIcon() {
+          themeBtn.innerHTML = isDarkMode() ? MOON_SVG : SUN_SVG;
+        }
+
+        themeBtn.addEventListener('click', function () {
+          const nextTheme = isDarkMode() ? 'light' : 'dark';
+          document.documentElement.setAttribute('data-theme', nextTheme);
+          setStoredTheme(nextTheme);
+          updateToggleIcon();
+        });
+
+        updateToggleIcon();
+      }
+
+      const searchInput = header.querySelector('#search-input');
+      if (searchInput && document.body.classList.contains('search-page')) {
+        searchInput.addEventListener('focus', function () {
+          const pageInput = document.getElementById('page-search-input');
+          if (pageInput) {
+            pageInput.focus();
+            pageInput.select();
+          }
+        });
+      }
+
+      const isMac = navigator.platform && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      if (isMac) {
+        header.querySelectorAll('.search-kbd').forEach(k => { k.textContent = '⌘K'; });
+      }
+
+      // If header is already baked statically into HTML, our work here is done!
+      if (header.querySelector('.liti-header-level1')) return;
 
       const navList = document.querySelector('ul.nav-list');
       if (!navList) return;
 
       const navListSearch = document.querySelector('.nav-list-search');
 
-      // Create 2-Level Header Structure
+      // Create 2-Level Header Structure Fallback
       const level1 = document.createElement('div');
       level1.className = 'liti-header-level1';
 

--- a/config/javadoc/generate_js.py
+++ b/config/javadoc/generate_js.py
@@ -181,25 +181,25 @@ js_code = """/**
       level1Right.className = 'liti-header-level1-right';
 
       // 1. Theme toggle button (Dark -> Moon icon, Light -> Sun icon)
-      const themeBtn = document.createElement('button');
-      themeBtn.type = 'button';
-      themeBtn.className = 'liti-theme-toggle';
-      themeBtn.title = 'Toggle dark / light mode';
-      themeBtn.setAttribute('aria-label', 'Toggle theme');
+      const dynamicThemeBtn = document.createElement('button');
+      dynamicThemeBtn.type = 'button';
+      dynamicThemeBtn.className = 'liti-theme-toggle';
+      dynamicThemeBtn.title = 'Toggle dark / light mode';
+      dynamicThemeBtn.setAttribute('aria-label', 'Toggle theme');
 
-      function updateToggleIcon() {
-        themeBtn.innerHTML = isDarkMode() ? MOON_SVG : SUN_SVG;
+      function updateDynamicToggleIcon() {
+        dynamicThemeBtn.innerHTML = isDarkMode() ? MOON_SVG : SUN_SVG;
       }
 
-      themeBtn.addEventListener('click', function () {
+      dynamicThemeBtn.addEventListener('click', function () {
         const nextTheme = isDarkMode() ? 'light' : 'dark';
         document.documentElement.setAttribute('data-theme', nextTheme);
         setStoredTheme(nextTheme);
-        updateToggleIcon();
+        updateDynamicToggleIcon();
       });
 
-      updateToggleIcon();
-      level1Right.appendChild(themeBtn);
+      updateDynamicToggleIcon();
+      level1Right.appendChild(dynamicThemeBtn);
 
       // 2. Search capsule
       if (navListSearch) {
@@ -402,9 +402,10 @@ js_code = """/**
     // 1. Unwrap java.lang.Object root nodes so all direct classes start directly at the top level
     const rootNodes = Array.from(document.querySelectorAll('section.hierarchy > ul > li.circle'));
     rootNodes.forEach(li => {
-      const link = li.querySelector('a[href*="java.lang/Object.html"], a[title*="java.lang.Object"]');
-      const directText = li.childNodes.length ? li.childNodes[0].textContent : '';
-      if ((link && link.textContent.trim() === 'Object') || directText.includes('java.lang.Object') || directText.trim() === 'java.lang.') {
+      const link = li.querySelector('a[href*="Object.html"]');
+      const isObjLink = link && (link.textContent.trim() === 'Object' || link.href.includes('/Object.html'));
+      const isObjText = li.textContent.includes('java.lang.Object') || (li.childNodes.length && li.childNodes[0].textContent.includes('java.lang.'));
+      if (isObjLink || isObjText) {
         const childUl = li.querySelector('ul');
         if (childUl && li.parentNode) {
           const parentUl = li.parentNode;
@@ -649,6 +650,18 @@ js_code = """/**
       }
 
       current = Array.from(current.children).find(el => el.classList.contains('inheritance'));
+    }
+
+    // Also clean up redundant "extends Object" from type-signature
+    const extImplements = document.querySelector('.type-signature .extends-implements');
+    if (extImplements) {
+      const extObjLink = extImplements.querySelector('a[href*="Object.html"]');
+      if (extObjLink && extObjLink.textContent.trim() === 'Object') {
+        const text = extImplements.textContent.trim();
+        if (text === 'extends Object') {
+          extImplements.remove();
+        }
+      }
     }
 
     // Filter out Object nodes

--- a/config/javadoc/generate_js.py
+++ b/config/javadoc/generate_js.py
@@ -129,7 +129,7 @@ js_code = """/**
       // Brand Link (Exact 28.79px logo from DevTools)
       const brand = document.createElement('a');
       brand.className = 'liti-brand-link';
-      brand.href = 'https://gurkenlabs.github.io/litiengine-docs/';
+      brand.href = 'https://docs.litiengine.com/';
       brand.innerHTML = `<img class="liti-brand-logo" src="${OFFICIAL_LOGO_SRC}" alt="LITIENGINE Logo" width="28.79" height="28.79"> <span class="liti-brand-text"><strong>LITIENGINE Docs</strong> <span class="api-tag">API</span></span>`;
       level1Inner.appendChild(brand);
 
@@ -218,8 +218,14 @@ js_code = """/**
     const level2Inner = document.createElement('div');
     level2Inner.className = 'liti-header-container';
 
-    // Move navList into level 2
+    // Move navList into level 2 with a prominent backlink to documentation
     if (navList) {
+      if (!navList.querySelector('.nav-item-backlink')) {
+        const backLi = document.createElement('li');
+        backLi.className = 'nav-item-backlink';
+        backLi.innerHTML = `<a href="https://docs.litiengine.com/" class="nav-link-docs" title="Back to LITIENGINE Documentation"><svg class="docs-back-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg><span>Docs</span></a>`;
+        navList.insertBefore(backLi, navList.firstChild);
+      }
       level2Inner.appendChild(navList);
     }
 

--- a/config/javadoc/generate_js.py
+++ b/config/javadoc/generate_js.py
@@ -146,6 +146,14 @@ js_code = """/**
         header.querySelectorAll('.search-kbd').forEach(k => { k.textContent = '⌘K'; });
       }
 
+      // Remove Deprecated and Help navigation items
+      header.querySelectorAll('ul.nav-list li').forEach(li => {
+        const text = li.textContent.trim().toLowerCase();
+        if (text === 'deprecated' || text === 'help') {
+          li.remove();
+        }
+      });
+
       // If header is already baked statically into HTML, our work here is done!
       if (header.querySelector('.liti-header-level1')) return;
 

--- a/config/javadoc/generate_js.py
+++ b/config/javadoc/generate_js.py
@@ -115,8 +115,9 @@ js_code = """/**
       if (!header || document.querySelector('.liti-header-level1')) return;
 
       const navList = document.querySelector('ul.nav-list');
+      if (!navList) return;
+
       const navListSearch = document.querySelector('.nav-list-search');
-      if (!navList || !navListSearch) return;
 
       // Create 2-Level Header Structure
       const level1 = document.createElement('div');
@@ -157,30 +158,46 @@ js_code = """/**
       updateToggleIcon();
       level1Right.appendChild(themeBtn);
 
-    // 2. Search capsule
-    if (navListSearch) {
-      const searchInput = navListSearch.querySelector('#search-input');
-      if (searchInput) {
-        searchInput.setAttribute('placeholder', 'Search');
-      }
+      // 2. Search capsule
+      if (navListSearch) {
+        const searchInput = navListSearch.querySelector('#search-input');
+        if (searchInput) {
+          searchInput.setAttribute('placeholder', 'Search');
+        }
 
-      if (!navListSearch.querySelector('.search-icon-svg')) {
-        const iconWrapper = document.createElement('span');
-        iconWrapper.className = 'search-icon-wrapper';
-        iconWrapper.innerHTML = SEARCH_SVG;
-        navListSearch.insertBefore(iconWrapper, navListSearch.firstChild);
-      }
+        if (!navListSearch.querySelector('.search-icon-svg')) {
+          const iconWrapper = document.createElement('span');
+          iconWrapper.className = 'search-icon-wrapper';
+          iconWrapper.innerHTML = SEARCH_SVG;
+          navListSearch.insertBefore(iconWrapper, navListSearch.firstChild);
+        }
 
-      if (!navListSearch.querySelector('.search-kbd')) {
-        const kbd = document.createElement('kbd');
-        kbd.className = 'search-kbd';
-        const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-        kbd.textContent = isMac ? '⌘K' : 'Ctrl+K';
-        navListSearch.appendChild(kbd);
-      }
+        if (!navListSearch.querySelector('.search-kbd')) {
+          const kbd = document.createElement('kbd');
+          kbd.className = 'search-kbd';
+          const isMac = navigator.platform && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+          kbd.textContent = isMac ? '⌘K' : 'Ctrl+K';
+          navListSearch.appendChild(kbd);
+        }
 
-      level1Right.appendChild(navListSearch);
-    }
+        level1Right.appendChild(navListSearch);
+      } else {
+        const searchCapsule = document.createElement('div');
+        searchCapsule.className = 'nav-list-search';
+        const isMac = navigator.platform && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+        searchCapsule.innerHTML = `<span class="search-icon-wrapper">${SEARCH_SVG}</span><input type="text" id="search-input" placeholder="Search"><kbd class="search-kbd">${isMac ? '⌘K' : 'Ctrl+K'}</kbd>`;
+        const headerInput = searchCapsule.querySelector('#search-input');
+        if (headerInput) {
+          headerInput.addEventListener('focus', function () {
+            const pageInput = document.getElementById('page-search-input');
+            if (pageInput) {
+              pageInput.focus();
+              pageInput.select();
+            }
+          });
+        }
+        level1Right.appendChild(searchCapsule);
+      }
 
     // 3. GitHub Repo Link (clean & simplified)
     const githubLink = document.createElement('a');
@@ -463,7 +480,7 @@ js_code = """/**
     document.addEventListener('keydown', (e) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
-        const searchInput = document.getElementById('search-input') || document.getElementById('page-search-input');
+        const searchInput = document.getElementById('page-search-input') || document.getElementById('search-input');
         if (searchInput) {
           searchInput.focus();
           searchInput.select();

--- a/config/javadoc/generate_js.py
+++ b/config/javadoc/generate_js.py
@@ -63,30 +63,6 @@ js_code = """/**
     return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   }
 
-  function loadGoogleFonts() {
-    if (document.querySelector('link[href*="fonts.googleapis.com"]')) return;
-    const head = document.head || document.getElementsByTagName('head')[0];
-    if (!head) return;
-    const preconnect1 = document.createElement('link');
-    preconnect1.rel = 'preconnect';
-    preconnect1.href = 'https://fonts.googleapis.com';
-    head.appendChild(preconnect1);
-
-    const preconnect2 = document.createElement('link');
-    preconnect2.rel = 'preconnect';
-    preconnect2.href = 'https://fonts.gstatic.com';
-    preconnect2.crossOrigin = 'anonymous';
-    head.appendChild(preconnect2);
-
-    const fontLink = document.createElement('link');
-    fontLink.rel = 'stylesheet';
-    fontLink.href = 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap';
-    fontLink.media = 'all';
-    head.appendChild(fontLink);
-  }
-
-  loadGoogleFonts();
-
   function setupFavicons() {
     const r = getRoot();
     const head = document.head || document.getElementsByTagName('head')[0];

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -1524,9 +1524,17 @@ div.table-tabs > .active-table-tab {
   line-height: 1.55 !important;
   overflow: visible !important;
   border-bottom: 1px solid var(--border-subtle) !important;
-  display: flex !important;
+  display: flex;
   align-items: center !important;
   word-break: break-word !important;
+}
+
+/* Ensure inline display: none applied by script.js table filtering is always respected */
+.summary-table > div[style*="display: none"],
+.summary-table > div[style*="display:none"],
+.details-table > div[style*="display: none"],
+.details-table > div[style*="display:none"] {
+  display: none !important;
 }
 
 .col-first, .col-second, .col-last, .col-constructor-name {

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -709,6 +709,48 @@ ul.nav-list li.nav-bar-cell1-rev a,
   background-color: transparent !important;
 }
 
+/* Backlink to main documentation in Level 2 */
+ul.nav-list li.nav-item-backlink {
+  margin-right: 0.5rem !important;
+}
+
+ul.nav-list li.nav-item-backlink a.nav-link-docs {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 0.4rem !important;
+  height: 32px !important;
+  line-height: 32px !important;
+  padding: 0 0.85rem !important;
+  color: var(--color-primary) !important;
+  background-color: var(--color-primary-light) !important;
+  border: 1px solid var(--border-subtle) !important;
+  border-radius: 6px !important;
+  font-size: 0.86rem !important;
+  font-weight: 600 !important;
+  text-decoration: none !important;
+  transition: all 0.15s ease !important;
+  white-space: nowrap !important;
+}
+
+ul.nav-list li.nav-item-backlink a.nav-link-docs:hover {
+  background-color: var(--color-primary) !important;
+  color: #ffffff !important;
+  border-color: var(--color-primary) !important;
+  transform: translateX(-2px) !important;
+  text-decoration: none !important;
+}
+
+ul.nav-list li.nav-item-backlink a.nav-link-docs svg.docs-back-icon {
+  width: 14px !important;
+  height: 14px !important;
+  stroke: currentColor !important;
+  transition: transform 0.15s ease !important;
+}
+
+ul.nav-list li.nav-item-backlink a.nav-link-docs:hover svg.docs-back-icon {
+  transform: translateX(-2px) !important;
+}
+
 /* Sponsor button in Level 2 */
 .md-tabs__link--sponsor {
   display: inline-flex !important;

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -2152,20 +2152,32 @@ body.search-page h1.title {
 }
 
 input#page-search-input {
+  background-color: var(--search-box-bg) !important;
+  border: 1px solid var(--search-box-border) !important;
+  border-radius: 8px !important;
+  height: 44px !important;
+  padding: 0 1rem !important;
+  width: min(100%, 480px) !important;
+  color: var(--search-input-text-color) !important;
+  font-size: 0.95rem !important;
+  font-family: var(--body-font-family) !important;
+  box-sizing: border-box !important;
+  transition: all 0.2s ease !important;
+}
+
+.page-search-wrapper input#page-search-input {
   background: transparent !important;
   background-image: none !important;
   background-color: transparent !important;
   border: none !important;
-  color: var(--search-input-text-color) !important;
-  font-size: 0.95rem !important;
-  font-family: var(--body-font-family) !important;
-  outline: none !important;
-  box-shadow: none !important;
+  border-radius: 0 !important;
   padding: 0 !important;
   margin: 0 !important;
   width: 100% !important;
   height: 100% !important;
   flex: 1 1 auto !important;
+  box-shadow: none !important;
+  outline: none !important;
 }
 
 input#page-search-reset {

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -709,6 +709,12 @@ ul.nav-list li.nav-bar-cell1-rev a,
   background-color: transparent !important;
 }
 
+/* Hide Deprecated and Help navigation items */
+ul.nav-list li:has(a[href*="deprecated-list"]),
+ul.nav-list li:has(a[href*="help-doc"]) {
+  display: none !important;
+}
+
 /* Backlink to main documentation in Level 2 */
 ul.nav-list li.nav-item-backlink {
   margin-right: 0.5rem !important;

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -495,13 +495,20 @@ header[role="banner"] {
 }
 
 .liti-brand-text .api-tag {
-  color: var(--color-primary);
-  font-size: 0.8rem;
-  font-weight: 700;
-  background-color: var(--color-primary-light);
-  padding: 0.15rem 0.5rem;
-  border-radius: 4px;
-  margin-left: 0.4rem;
+  display: inline-flex !important;
+  align-items: center !important;
+  font-size: 0.68rem !important;
+  font-weight: 800 !important;
+  letter-spacing: 0.07em !important;
+  text-transform: uppercase !important;
+  line-height: 1 !important;
+  padding: 0.22rem 0.5rem !important;
+  border-radius: 4px !important;
+  margin-left: 0.5rem !important;
+  vertical-align: middle !important;
+  color: #ffffff !important;
+  background: linear-gradient(135deg, #ff6b5b 0%, #e64a3b 100%) !important;
+  box-shadow: 0 2px 8px rgba(230, 74, 59, 0.3) !important;
 }
 
 .liti-header-level1-right {

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -1048,10 +1048,34 @@ ol.sub-nav-list .current-selection {
   flex-shrink: 0 !important;
 }
 
+input.filter-input {
+  background-color: var(--search-box-bg) !important;
+  background-image: none !important;
+  border: 1px solid var(--search-box-border) !important;
+  border-radius: 6px !important;
+  color: var(--body-text-color) !important;
+  font-size: 0.82rem !important;
+  font-family: var(--body-font-family) !important;
+  padding: 0.35rem 0.6rem !important;
+  height: 34px !important;
+  width: 100% !important;
+  box-sizing: border-box !important;
+  outline: none !important;
+  transition: all 0.2s ease !important;
+}
+
+input.filter-input:focus {
+  border-color: var(--color-primary) !important;
+  box-shadow: 0 0 0 2px rgba(0, 189, 165, 0.25) !important;
+  background-color: var(--code-background-color) !important;
+}
+
 .toc-filter-wrapper input.filter-input {
   background: transparent !important;
   background-color: transparent !important;
+  background-image: none !important;
   border: none !important;
+  border-radius: 0 !important;
   color: var(--body-text-color) !important;
   font-size: 0.82rem !important;
   font-family: var(--body-font-family) !important;

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -807,6 +807,7 @@ div.sub-nav {
   width: 100%;
 }
 
+.sub-nav:not(:has(li)),
 .sub-nav:has(.sub-nav-list:empty) {
   display: none !important;
 }
@@ -1818,10 +1819,19 @@ footer {
    Alphabetical Index Page (index-all.html)
    ========================================================================== */
 
-body.index-page main {
+body.index-page .main-grid {
+  display: block !important;
+  width: 100% !important;
   max-width: var(--max-content-width) !important;
   margin: 0 auto !important;
-  padding: 2rem 1.5rem !important;
+  padding: 1.25rem 1.5rem 4rem 1.5rem !important;
+}
+
+body.index-page main {
+  width: 100% !important;
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
 }
 
 body.index-page main h1 {
@@ -1829,7 +1839,8 @@ body.index-page main h1 {
   font-weight: 700 !important;
   letter-spacing: -0.02em !important;
   color: var(--title-color) !important;
-  margin-bottom: 1.5rem !important;
+  margin-top: 0 !important;
+  margin-bottom: 1rem !important;
 }
 
 /* Raw Alphabet Jump Links (Pure CSS Fallback before JS wrapping) */
@@ -1873,14 +1884,14 @@ body.index-page main > span.vertical-separator {
 /* Sticky Alphabet Quick-Jump Bar */
 .index-sticky-bar {
   position: sticky !important;
-  top: 130px !important;
-  z-index: 90 !important;
+  top: 116px !important;
+  z-index: 100 !important;
   background-color: var(--header-glass-bg) !important;
   backdrop-filter: blur(14px) !important;
   -webkit-backdrop-filter: blur(14px) !important;
   padding: 0.85rem 1.25rem !important;
-  margin: 1rem 1rem 2.5rem 1rem !important;
-  width: calc(100% - 2rem) !important;
+  margin: 0.75rem 0 2rem 0 !important;
+  width: 100% !important;
   box-sizing: border-box !important;
   border: 1px solid var(--border-color) !important;
   border-radius: 12px !important;
@@ -2323,11 +2334,28 @@ span.search-result-desc a:hover {
    Hierarchy & Tree Pages (overview-tree.html & package-tree.html)
    ========================================================================== */
 
-body.tree-page main,
-body.package-tree-page main {
+body.tree-page .main-grid,
+body.package-tree-page .main-grid {
+  display: block !important;
+  width: 100% !important;
   max-width: var(--max-content-width) !important;
   margin: 0 auto !important;
-  padding: 2rem 1.5rem !important;
+  padding: 1.25rem 1.5rem 4rem 1.5rem !important;
+}
+
+body.tree-page main,
+body.package-tree-page main {
+  width: 100% !important;
+  max-width: 100% !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+body.tree-page h1.title,
+body.package-tree-page h1.title {
+  margin-top: 0 !important;
+  margin-bottom: 0.75rem !important;
+  padding-top: 0 !important;
 }
 
 .package-hierarchy-label {

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -2259,6 +2259,97 @@ div.table-tabs > button[id^="result-tab-"].active-table-tab {
   font-weight: 600 !important;
 }
 
+/* ==========================================================================
+   Search Autocomplete Results Dropdown (Header Search Bar)
+   ========================================================================== */
+
+ul.ui-autocomplete {
+  position: fixed !important;
+  z-index: 999999 !important;
+  background-color: var(--card-bg) !important;
+  border: 1px solid var(--border-color) !important;
+  border-radius: 12px !important;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5), 0 4px 12px rgba(0, 0, 0, 0.25) !important;
+  backdrop-filter: blur(16px) !important;
+  -webkit-backdrop-filter: blur(16px) !important;
+  padding: 0.35rem 0 !important;
+  margin-top: 4px !important;
+  max-height: calc(90vh - 120px) !important;
+  overflow-y: auto !important;
+}
+
+.ui-autocomplete-category {
+  background-color: var(--even-row-color) !important;
+  color: var(--text-muted) !important;
+  font-size: 0.72rem !important;
+  font-weight: 700 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.08em !important;
+  padding: 0.55rem 1rem 0.35rem 1rem !important;
+  border-bottom: 1px solid var(--border-subtle) !important;
+}
+
+.ui-autocomplete > li.result-item {
+  font-family: var(--body-font-family) !important;
+  padding: 0.45rem 1rem !important;
+  border-bottom: 1px solid var(--border-subtle) !important;
+  cursor: pointer !important;
+  transition: background-color 0.12s ease !important;
+}
+
+.ui-autocomplete > li.result-item:last-of-type {
+  border-bottom: none !important;
+}
+
+.ui-autocomplete > li.result-item:hover,
+.ui-autocomplete > li.result-item.ui-state-active,
+.ui-autocomplete > li.result-item .ui-state-active,
+.ui-menu .ui-state-active {
+  background-color: var(--color-primary-light) !important;
+  border-color: transparent !important;
+  margin: 0 !important;
+}
+
+.ui-autocomplete .search-result-label {
+  color: var(--color-primary) !important;
+  font-weight: 600 !important;
+  font-size: 0.92rem !important;
+}
+
+.ui-autocomplete .search-result-desc {
+  color: var(--text-muted) !important;
+  font-size: 0.8rem !important;
+}
+
+.ui-autocomplete .result-highlight {
+  color: var(--navbar-link-hover) !important;
+  font-weight: 700 !important;
+  text-decoration: underline !important;
+}
+
+ul.ui-autocomplete li.ui-static-link {
+  position: sticky !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  background: var(--card-bg) !important;
+  border-top: 1px solid var(--border-color) !important;
+  padding: 0.65rem 1rem !important;
+  z-index: 1000000 !important;
+  border-bottom-left-radius: 12px !important;
+  border-bottom-right-radius: 12px !important;
+}
+
+ul.ui-autocomplete li.ui-static-link a {
+  color: var(--color-primary) !important;
+  font-weight: 600 !important;
+  font-size: 0.88rem !important;
+  text-decoration: none !important;
+}
+
+ul.ui-autocomplete li.ui-static-link a:hover {
+  text-decoration: underline !important;
+}
+
 /* Modern Results Table Grid */
 div.result-table,
 .two-column-search-results {

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -1884,21 +1884,21 @@ body.index-page main > span.vertical-separator {
 /* Sticky Alphabet Quick-Jump Bar */
 .index-sticky-bar {
   position: sticky !important;
-  top: 116px !important;
+  top: 128px !important;
   z-index: 100 !important;
   background-color: var(--header-glass-bg) !important;
-  backdrop-filter: blur(14px) !important;
-  -webkit-backdrop-filter: blur(14px) !important;
-  padding: 0.85rem 1.25rem !important;
-  margin: 0.75rem 0 2rem 0 !important;
+  backdrop-filter: blur(16px) !important;
+  -webkit-backdrop-filter: blur(16px) !important;
+  padding: 1rem 1.25rem !important;
+  margin: 1.25rem 0 2.5rem 0 !important;
   width: 100% !important;
   box-sizing: border-box !important;
   border: 1px solid var(--border-color) !important;
   border-radius: 12px !important;
-  box-shadow: var(--elevated-shadow) !important;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4), var(--elevated-shadow) !important;
   display: flex !important;
   flex-direction: column !important;
-  gap: 0.65rem !important;
+  gap: 0.75rem !important;
 }
 
 .index-letters-container {

--- a/config/javadoc/litiengine.css
+++ b/config/javadoc/litiengine.css
@@ -2036,6 +2036,26 @@ dl.index dd .block {
    Search Page (search.html)
    ========================================================================== */
 
+body.search-page .main-grid {
+  max-width: var(--max-content-width) !important;
+  margin: 0 auto !important;
+  padding: 2.5rem 1.5rem 4rem 1.5rem !important;
+  display: block !important;
+}
+
+body.search-page main {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+body.search-page h1.title {
+  font-size: 2.2rem !important;
+  font-weight: 700 !important;
+  letter-spacing: -0.02em !important;
+  color: var(--title-color) !important;
+  margin-bottom: 1.25rem !important;
+}
+
 .page-search-wrapper {
   display: inline-flex !important;
   align-items: center !important;

--- a/config/javadoc/litiengine.js
+++ b/config/javadoc/litiengine.js
@@ -108,14 +108,49 @@
   function setupTwoLevelNavigation() {
     try {
       const header = document.querySelector('header[role="banner"]');
-      if (!header || document.querySelector('.liti-header-level1')) return;
+      if (!header) return;
+
+      const themeBtn = header.querySelector('.liti-theme-toggle');
+      if (themeBtn) {
+        function updateToggleIcon() {
+          themeBtn.innerHTML = isDarkMode() ? MOON_SVG : SUN_SVG;
+        }
+
+        themeBtn.addEventListener('click', function () {
+          const nextTheme = isDarkMode() ? 'light' : 'dark';
+          document.documentElement.setAttribute('data-theme', nextTheme);
+          setStoredTheme(nextTheme);
+          updateToggleIcon();
+        });
+
+        updateToggleIcon();
+      }
+
+      const searchInput = header.querySelector('#search-input');
+      if (searchInput && document.body.classList.contains('search-page')) {
+        searchInput.addEventListener('focus', function () {
+          const pageInput = document.getElementById('page-search-input');
+          if (pageInput) {
+            pageInput.focus();
+            pageInput.select();
+          }
+        });
+      }
+
+      const isMac = navigator.platform && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+      if (isMac) {
+        header.querySelectorAll('.search-kbd').forEach(k => { k.textContent = '⌘K'; });
+      }
+
+      // If header is already baked statically into HTML, our work here is done!
+      if (header.querySelector('.liti-header-level1')) return;
 
       const navList = document.querySelector('ul.nav-list');
       if (!navList) return;
 
       const navListSearch = document.querySelector('.nav-list-search');
 
-      // Create 2-Level Header Structure
+      // Create 2-Level Header Structure Fallback
       const level1 = document.createElement('div');
       level1.className = 'liti-header-level1';
 

--- a/config/javadoc/litiengine.js
+++ b/config/javadoc/litiengine.js
@@ -142,6 +142,14 @@
         header.querySelectorAll('.search-kbd').forEach(k => { k.textContent = '⌘K'; });
       }
 
+      // Remove Deprecated and Help navigation items
+      header.querySelectorAll('ul.nav-list li').forEach(li => {
+        const text = li.textContent.trim().toLowerCase();
+        if (text === 'deprecated' || text === 'help') {
+          li.remove();
+        }
+      });
+
       // If header is already baked statically into HTML, our work here is done!
       if (header.querySelector('.liti-header-level1')) return;
 

--- a/config/javadoc/litiengine.js
+++ b/config/javadoc/litiengine.js
@@ -125,7 +125,7 @@
       // Brand Link (Exact 28.79px logo from DevTools)
       const brand = document.createElement('a');
       brand.className = 'liti-brand-link';
-      brand.href = 'https://gurkenlabs.github.io/litiengine-docs/';
+      brand.href = 'https://docs.litiengine.com/';
       brand.innerHTML = `<img class="liti-brand-logo" src="${OFFICIAL_LOGO_SRC}" alt="LITIENGINE Logo" width="28.79" height="28.79"> <span class="liti-brand-text"><strong>LITIENGINE Docs</strong> <span class="api-tag">API</span></span>`;
       level1Inner.appendChild(brand);
 
@@ -214,8 +214,14 @@
     const level2Inner = document.createElement('div');
     level2Inner.className = 'liti-header-container';
 
-    // Move navList into level 2
+    // Move navList into level 2 with a prominent backlink to documentation
     if (navList) {
+      if (!navList.querySelector('.nav-item-backlink')) {
+        const backLi = document.createElement('li');
+        backLi.className = 'nav-item-backlink';
+        backLi.innerHTML = `<a href="https://docs.litiengine.com/" class="nav-link-docs" title="Back to LITIENGINE Documentation"><svg class="docs-back-icon" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg><span>Docs</span></a>`;
+        navList.insertBefore(backLi, navList.firstChild);
+      }
       level2Inner.appendChild(navList);
     }
 

--- a/config/javadoc/litiengine.js
+++ b/config/javadoc/litiengine.js
@@ -59,30 +59,6 @@
     return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   }
 
-  function loadGoogleFonts() {
-    if (document.querySelector('link[href*="fonts.googleapis.com"]')) return;
-    const head = document.head || document.getElementsByTagName('head')[0];
-    if (!head) return;
-    const preconnect1 = document.createElement('link');
-    preconnect1.rel = 'preconnect';
-    preconnect1.href = 'https://fonts.googleapis.com';
-    head.appendChild(preconnect1);
-
-    const preconnect2 = document.createElement('link');
-    preconnect2.rel = 'preconnect';
-    preconnect2.href = 'https://fonts.gstatic.com';
-    preconnect2.crossOrigin = 'anonymous';
-    head.appendChild(preconnect2);
-
-    const fontLink = document.createElement('link');
-    fontLink.rel = 'stylesheet';
-    fontLink.href = 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap';
-    fontLink.media = 'all';
-    head.appendChild(fontLink);
-  }
-
-  loadGoogleFonts();
-
   function setupFavicons() {
     const r = getRoot();
     const head = document.head || document.getElementsByTagName('head')[0];

--- a/config/javadoc/litiengine.js
+++ b/config/javadoc/litiengine.js
@@ -177,25 +177,25 @@
       level1Right.className = 'liti-header-level1-right';
 
       // 1. Theme toggle button (Dark -> Moon icon, Light -> Sun icon)
-      const themeBtn = document.createElement('button');
-      themeBtn.type = 'button';
-      themeBtn.className = 'liti-theme-toggle';
-      themeBtn.title = 'Toggle dark / light mode';
-      themeBtn.setAttribute('aria-label', 'Toggle theme');
+      const dynamicThemeBtn = document.createElement('button');
+      dynamicThemeBtn.type = 'button';
+      dynamicThemeBtn.className = 'liti-theme-toggle';
+      dynamicThemeBtn.title = 'Toggle dark / light mode';
+      dynamicThemeBtn.setAttribute('aria-label', 'Toggle theme');
 
-      function updateToggleIcon() {
-        themeBtn.innerHTML = isDarkMode() ? MOON_SVG : SUN_SVG;
+      function updateDynamicToggleIcon() {
+        dynamicThemeBtn.innerHTML = isDarkMode() ? MOON_SVG : SUN_SVG;
       }
 
-      themeBtn.addEventListener('click', function () {
+      dynamicThemeBtn.addEventListener('click', function () {
         const nextTheme = isDarkMode() ? 'light' : 'dark';
         document.documentElement.setAttribute('data-theme', nextTheme);
         setStoredTheme(nextTheme);
-        updateToggleIcon();
+        updateDynamicToggleIcon();
       });
 
-      updateToggleIcon();
-      level1Right.appendChild(themeBtn);
+      updateDynamicToggleIcon();
+      level1Right.appendChild(dynamicThemeBtn);
 
       // 2. Search capsule
       if (navListSearch) {
@@ -398,9 +398,10 @@
     // 1. Unwrap java.lang.Object root nodes so all direct classes start directly at the top level
     const rootNodes = Array.from(document.querySelectorAll('section.hierarchy > ul > li.circle'));
     rootNodes.forEach(li => {
-      const link = li.querySelector('a[href*="java.lang/Object.html"], a[title*="java.lang.Object"]');
-      const directText = li.childNodes.length ? li.childNodes[0].textContent : '';
-      if ((link && link.textContent.trim() === 'Object') || directText.includes('java.lang.Object') || directText.trim() === 'java.lang.') {
+      const link = li.querySelector('a[href*="Object.html"]');
+      const isObjLink = link && (link.textContent.trim() === 'Object' || link.href.includes('/Object.html'));
+      const isObjText = li.textContent.includes('java.lang.Object') || (li.childNodes.length && li.childNodes[0].textContent.includes('java.lang.'));
+      if (isObjLink || isObjText) {
         const childUl = li.querySelector('ul');
         if (childUl && li.parentNode) {
           const parentUl = li.parentNode;
@@ -645,6 +646,18 @@
       }
 
       current = Array.from(current.children).find(el => el.classList.contains('inheritance'));
+    }
+
+    // Also clean up redundant "extends Object" from type-signature
+    const extImplements = document.querySelector('.type-signature .extends-implements');
+    if (extImplements) {
+      const extObjLink = extImplements.querySelector('a[href*="Object.html"]');
+      if (extObjLink && extObjLink.textContent.trim() === 'Object') {
+        const text = extImplements.textContent.trim();
+        if (text === 'extends Object') {
+          extImplements.remove();
+        }
+      }
     }
 
     // Filter out Object nodes

--- a/config/javadoc/litiengine.js
+++ b/config/javadoc/litiengine.js
@@ -111,8 +111,9 @@
       if (!header || document.querySelector('.liti-header-level1')) return;
 
       const navList = document.querySelector('ul.nav-list');
+      if (!navList) return;
+
       const navListSearch = document.querySelector('.nav-list-search');
-      if (!navList || !navListSearch) return;
 
       // Create 2-Level Header Structure
       const level1 = document.createElement('div');
@@ -153,30 +154,46 @@
       updateToggleIcon();
       level1Right.appendChild(themeBtn);
 
-    // 2. Search capsule
-    if (navListSearch) {
-      const searchInput = navListSearch.querySelector('#search-input');
-      if (searchInput) {
-        searchInput.setAttribute('placeholder', 'Search');
-      }
+      // 2. Search capsule
+      if (navListSearch) {
+        const searchInput = navListSearch.querySelector('#search-input');
+        if (searchInput) {
+          searchInput.setAttribute('placeholder', 'Search');
+        }
 
-      if (!navListSearch.querySelector('.search-icon-svg')) {
-        const iconWrapper = document.createElement('span');
-        iconWrapper.className = 'search-icon-wrapper';
-        iconWrapper.innerHTML = SEARCH_SVG;
-        navListSearch.insertBefore(iconWrapper, navListSearch.firstChild);
-      }
+        if (!navListSearch.querySelector('.search-icon-svg')) {
+          const iconWrapper = document.createElement('span');
+          iconWrapper.className = 'search-icon-wrapper';
+          iconWrapper.innerHTML = SEARCH_SVG;
+          navListSearch.insertBefore(iconWrapper, navListSearch.firstChild);
+        }
 
-      if (!navListSearch.querySelector('.search-kbd')) {
-        const kbd = document.createElement('kbd');
-        kbd.className = 'search-kbd';
-        const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-        kbd.textContent = isMac ? '⌘K' : 'Ctrl+K';
-        navListSearch.appendChild(kbd);
-      }
+        if (!navListSearch.querySelector('.search-kbd')) {
+          const kbd = document.createElement('kbd');
+          kbd.className = 'search-kbd';
+          const isMac = navigator.platform && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+          kbd.textContent = isMac ? '⌘K' : 'Ctrl+K';
+          navListSearch.appendChild(kbd);
+        }
 
-      level1Right.appendChild(navListSearch);
-    }
+        level1Right.appendChild(navListSearch);
+      } else {
+        const searchCapsule = document.createElement('div');
+        searchCapsule.className = 'nav-list-search';
+        const isMac = navigator.platform && navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+        searchCapsule.innerHTML = `<span class="search-icon-wrapper">${SEARCH_SVG}</span><input type="text" id="search-input" placeholder="Search"><kbd class="search-kbd">${isMac ? '⌘K' : 'Ctrl+K'}</kbd>`;
+        const headerInput = searchCapsule.querySelector('#search-input');
+        if (headerInput) {
+          headerInput.addEventListener('focus', function () {
+            const pageInput = document.getElementById('page-search-input');
+            if (pageInput) {
+              pageInput.focus();
+              pageInput.select();
+            }
+          });
+        }
+        level1Right.appendChild(searchCapsule);
+      }
 
     // 3. GitHub Repo Link (clean & simplified)
     const githubLink = document.createElement('a');
@@ -459,7 +476,7 @@
     document.addEventListener('keydown', (e) => {
       if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
-        const searchInput = document.getElementById('search-input') || document.getElementById('page-search-input');
+        const searchInput = document.getElementById('page-search-input') || document.getElementById('search-input');
         if (searchInput) {
           searchInput.focus();
           searchInput.select();


### PR DESCRIPTION
### Summary

This update refines the custom Javadoc theme with bugfixes, type hierarchy simplifications, and a comprehensive performance overhaul that eliminates DOM reflows, font flickering (FOUT), and layout shifts during page navigation.

---

### Key Improvements

#### 1. Zero-Flicker Performance & Font Optimization
- **Eliminated Runtime Stylesheet Injection**: Removed runtime `loadGoogleFonts()` from `litiengine.js` that was dynamically injecting external stylesheet links into `<head>` after initial paint, which caused CSSOM invalidation and full-document DOM re-renders.
- **Native Offline Typography**: Switched to the high-performance native system UI font stack (`-apple-system`, `BlinkMacSystemFont`, `Segoe UI`, `Roboto...`) matching `docs.litiengine.com`, removing all external `fonts.googleapis.com` network requests.
- **Early `<head>` Theme & Typography Initialization**: Moved the theme setter script (`data-theme`) and critical root font sizing (`16px`) to the very top of `<head>` so dark/light themes and typography render correctly on frame zero before stylesheets parse.
- **Stripped Redundant Font Imports**: Automatically stripped Oracle's unused `@import url('fonts/dejavu.css');` from `stylesheet.css` during the build, saving an unnecessary synchronous network request.

#### 2. Navigation, Search & Table Filters
- **Fixed Table Tab Filters**: Resolved table tab filtering (`All Classes and Interfaces | Interfaces | Classes...`) by ensuring summary table styles properly respect standard Javadoc inline `display: none` toggles.
- **Pre-rendered TOC Search Capsule**: Pre-rendered the table of contents filter input with an integrated SVG search icon at build time and added resilient standalone styles.
- **Sticky A-Z Jump Bar Margin**: Added proper spacing and positioning around `.index-sticky-bar` on `index-all.html`.
- **Search Autocomplete Z-Index**: Elevated autocomplete dropdown results above sticky headers.
- **Prevented `script.js` TypeError**: Preserved standard Javadoc `#navbar-toggle-button` in the DOM so Oracle's navigation script does not throw null reference errors.

#### 3. Type Hierarchy & Brand Polish
- **Clean Object Inheritance**: Stripped redundant `extends java.lang.Object` from class declaration signatures and unwrapped `Object` from hierarchy trees (`-tree.html`).
- **Package Hierarchy Badges**: Restored `.tree-pkg-badge` (collapsing lengthy `de.gurkenlabs.litiengine.*` prefixes into compact chips) and tree connectors.
- **Brand Assets & Header Cleanup**: Switched the brand logo icon to `icon.png`, removed deprecated/help nav tabs, and styled the header `API` badge with a vibrant coral gradient.

---

### Commits Included (19)
- `12fe48c8` `perf(javadoc): strip unused dejavu.css import from stylesheet.css`
- `19390477` `perf(javadoc): remove runtime loadGoogleFonts to prevent stylesheet injection and DOM reflow`
- `e2fa5edc` `perf(javadoc): eliminate external font network requests to ensure consistent local font rendering`
- `990b7a71` `perf(javadoc): inline critical font sizing and use display=optional to stop index reflow`
- `78507e40` `perf(javadoc): inject theme script and font preloads at top of head to eliminate FOUT`
- `28da9238` `style(javadoc): apply vibrant gradient highlight badge to API brand tag`
- `865722a1` `fix(javadoc): preserve navbar-toggle-button to prevent script.js TypeError`
- `5b108d0a` `fix(javadoc): enable table tab filtering by respecting inline display: none`
- `1754092f` `fix(javadoc): pre-render TOC filter capsule and add resilient filter-input styles`
- `5b39a9fc` `fix(javadoc): skip redundant Object inheritance and restore hierarchy tree badges`
- `b9193ff1` `style(javadoc): add margin around sticky index navigation bar`
- `340b82fa` `fix(javadoc): use icon.png instead of logo.png for header brand icon`
- `6221b731` `fix(javadoc): raise search autocomplete dropdown z-index above header`
- `ae66260e` `fix(javadoc): ensure page search input is styled and pre-rendered`
- `9e9d780d` `fix(javadoc): eliminate excessive header vertical space and restore sticky index navigation`
- `f7965029` `style(javadoc): remove deprecated and help items from navigation`
- `b8b0f6c0` `perf(javadoc): pre-render 2-level header at build time to eliminate DOM load delay on large pages`
- `385fd816` `feat(javadoc): add backlink to main documentation in header and footer`
- `a864862f` `fix(javadoc): resolve broken header and tags on search.html`